### PR TITLE
Add treecode plugin and remove serena plugin permissions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "iu3qez-tools": {
+      "source": {
+        "source": "github",
+        "repo": "iu3qez/treecode"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "treecode@iu3qez-tools": true
+  },
   "permissions": {
     "allow": [
       "Bash(python3 -c \"import sys, json; text=json.loads\\(''{\"\"t\"\":'' + sys.stdin.read\\(\\).split\\(''\"\"text\"\":'',1\\)[1].rstrip\\(''}''\\) + ''}''\\)[''t'']; print\\(text\\)\")",
@@ -13,15 +24,6 @@
       "mcp__plugin_context7_context7__resolve-library-id",
       "mcp__plugin_context7_context7__query-docs",
       "Bash(git *)",
-      "mcp__plugin_serena_serena__check_onboarding_performed",
-      "mcp__plugin_serena_serena__activate_project",
-      "mcp__plugin_serena_serena__onboarding",
-      "mcp__plugin_serena_serena__list_dir",
-      "mcp__plugin_serena_serena__read_file",
-      "mcp__plugin_serena_serena__write_memory",
-      "mcp__plugin_serena_serena__list_memories",
-      "mcp__plugin_serena_serena__read_memory",
-      "mcp__plugin_serena_serena__get_current_config",
       "WebSearch",
       "Bash(gh issue:*)",
       "Bash(grep:*)",


### PR DESCRIPTION
## Summary

Update local Claude settings to enable the treecode plugin from the iu3qez/treecode repository while removing all permissions for the deprecated serena plugin.

## Changes

- **Added treecode plugin support:**
  - Registered `iu3qez-tools` marketplace pointing to the `iu3qez/treecode` GitHub repository
  - Enabled `treecode@iu3qez-tools` plugin

- **Removed serena plugin permissions:**
  - Deleted all 10 serena plugin capability grants:
    - `check_onboarding_performed`
    - `activate_project`
    - `onboarding`
    - `list_dir`
    - `read_file`
    - `write_memory`
    - `list_memories`
    - `read_memory`
    - `get_current_config`

## Notes

This is a local development settings change (`.claude/settings.local.json`) that updates the Claude Code plugin configuration. The treecode plugin replaces the functionality previously provided by serena.

https://claude.ai/code/session_012LwEUhLjvadMNpVS9dU41V