### PR TITLE
docs: add distributed CLAUDE.md tree (root map + per-module briefs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,3 +149,40 @@ Update these files as features are completed or new issues are found. Keep MEMOR
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — Immutable design principles, stream semantics, fault model
 - **[CODING_STYLE.md](CODING_STYLE.md)** — Compiler flags, PVS-Studio, C patterns, error handling
 - **[parameters.yaml](parameters.yaml)** — Configuration source of truth
+
+<!-- BEGIN treecode:map (auto) -->
+## Module map
+
+Distributed CLAUDE.md tree — open a module's own CLAUDE.md for its detailed brief.
+Keying events flow only through `keying_stream_t`; Core 0 = hard-RT, Core 1 = background.
+
+**Real-time path (Core 0)**
+- `components/keyer_core/`  — Keying stream, samples, consumers, fault primitives  → components/keyer_core/CLAUDE.md
+- `components/keyer_iambic/`  — Iambic keyer finite-state machine  → components/keyer_iambic/CLAUDE.md
+- `components/keyer_audio/`  — Sidetone synthesis, audio ring buffer, PTT  → components/keyer_audio/CLAUDE.md
+- `components/keyer_hal/`  — GPIO / I2S / ES8311 hardware abstraction  → components/keyer_hal/CLAUDE.md
+- `components/keyer_logging/`  — RT-safe logging (RT_* macros, drop-not-block)  → components/keyer_logging/CLAUDE.md
+
+**Background consumers (Core 1)**
+- `components/keyer_text/`  — Text→CW and memory-keyer playback  → components/keyer_text/CLAUDE.md
+- `components/keyer_decoder/`  — CW decoder / morse timing classifier  → components/keyer_decoder/CLAUDE.md
+- `components/keyer_led/`  — Status LED (WS2812B via RMT)  → components/keyer_led/CLAUDE.md
+
+**User-facing interfaces (Core 1)**
+- `components/keyer_console/`  — Serial console line-editor + commands  → components/keyer_console/CLAUDE.md
+- `components/keyer_usb/`  — TinyUSB multi-CDC transport + UF2  → components/keyer_usb/CLAUDE.md
+- `components/keyer_webui/`  — HTTP server + REST/WebSocket API (backend)  → components/keyer_webui/CLAUDE.md
+- `components/keyer_webui/frontend/`  — Svelte 5 + Vite SPA, embedded into flash  → components/keyer_webui/frontend/CLAUDE.md
+
+**Networking / remote**
+- `components/keyer_cwnet/`  — Remote CW-over-network transport  → components/keyer_cwnet/CLAUDE.md
+- `components/keyer_wifi/`  — WiFi bring-up  → components/keyer_wifi/CLAUDE.md
+- `components/keyer_vpn/`  — WireGuard VPN glue  → components/keyer_vpn/CLAUDE.md
+- `components/esp_wireguard/`  — Vendored WireGuard fork (v6/mbedtls4 patched)  → components/esp_wireguard/CLAUDE.md
+- `components/provisioning/`  — Device provisioning  → components/provisioning/CLAUDE.md
+
+**App, config, tests**
+- `components/keyer_config/`  — GENERATED config (DO NOT EDIT; from parameters.yaml)  → components/keyer_config/CLAUDE.md
+- `main/`  — Entry point; rt_task (Core 0) + bg_task (Core 1)  → main/CLAUDE.md
+- `test_host/`  — Unity host tests (stream-based, no hardware)  → test_host/CLAUDE.md
+<!-- END treecode:map (auto) -->

--- a/components/esp_wireguard/CLAUDE.md
+++ b/components/esp_wireguard/CLAUDE.md
@@ -1,0 +1,38 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# esp_wireguard — vendored WireGuard implementation (in-tree fork)
+
+Responsibility: Provides the WireGuard protocol (Noise handshake, ChaCha20-
+Poly1305, Curve25519/BLAKE2s crypto) and an lwIP netif that tunnels IP traffic.
+Owns the low-level tunnel; keyer_vpn is the only in-tree consumer and drives it
+through the public API. This is third-party code — keep changes minimal and
+patch-documented.
+
+Key abstractions:
+- wireguard_config_t: private/public keys, endpoint, port, allowed IP + mask,
+  keepalive (see ESP_WIREGUARD_CONFIG_DEFAULT).
+- wireguard_ctx_t: config + lwIP netif + saved default netif.
+- esp_wireguard_init / esp_wireguard_connect / esp_wireguard_set_default /
+  esp_wireguardif_peer_is_up / esp_wireguard_disconnect.
+
+Depends on: esp_netif, lwip, mbedtls (REQUIRES).
+Used by: keyer_vpn (only). Not called directly from main or any other component.
+External deps of note: bundles its own reference crypto (crypto/refc, nacl
+curve25519) rather than relying on mbedtls for the primitives.
+
+Conventions: Treat as vendored/frozen. Warning suppressions are applied
+per-file in CMakeLists.txt, not globally: src/crypto/refc/x25519.c gets
+-Wno-error=stringop-overread, and src/wireguard.c gets
+-Wno-error=unterminated-string-initialization (GCC 15 flags the protocol's
+fixed byte-string constants CONSTRUCTION/IDENTIFIER/LABEL_MAC1/LABEL_COOKIE).
+
+Gotchas:
+- DO NOT REPLACE with the component-registry version of trombik/esp_wireguard.
+  This is an in-tree fork of 0.9.0; upstream is ESP-IDF v5-only and will not
+  build on v6.
+- RNG patch: mbedtls 4 / TF-PSA-Crypto split removed mbedtls_entropy_* and
+  mbedtls_ctr_drbg_* linkage, so the fork was patched to call esp_fill_random()
+  directly (ESP32 HW RNG — cryptographically strong once WiFi/RF is up). Do not
+  "restore" the mbedtls entropy path.
+- Bring the tunnel up only after WiFi is connected and time is synced (keyer_vpn
+  enforces this); the handshake depends on a correct clock.
+<!-- END treecode (auto) -->

--- a/components/keyer_audio/CLAUDE.md
+++ b/components/keyer_audio/CLAUDE.md
@@ -1,0 +1,25 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_audio — Sidetone synthesis, audio ring buffer, and PTT control (RT/TX path, Core 0)
+
+Responsibility: Owns turning a key-down boolean into audio samples and PTT state on the hard RT path. Generates sidetone via phase accumulator, buffers samples SPSC, tracks PTT with a tail timeout, and selects between local sidetone and remote audio. It must NOT touch the keying stream directly, allocate, log, or block — the RT task feeds it the already-resolved key state each sample tick.
+
+Key abstractions:
+- `sidetone_gen_t` + `sidetone_next_sample(gen, key_down)` — 256-entry sine LUT, 32-bit phase accumulator, fade envelope (FADE_SILENT/IN/SUSTAIN/OUT) to kill key clicks.
+- `audio_ring_buffer_t` — lock-free SPSC ring over caller-supplied power-of-2 storage; `push` overwrites oldest when full, `pop` non-blocking.
+- `ptt_controller_t` — PTT_ON on audio activity, PTT_OFF after `tail_ms`; optional `ptt_pa_callback_t` for PA keying; `ptt_force_off()` for fault recovery.
+- `audio_source_selector_t` — priority sidetone > remote > none.
+
+Depends on: keyer_core (REQUIRES). Consumes no stream type itself — pure sample/state logic.
+
+Used by: main/rt_task.c drives `sidetone_next_sample` and `ptt_tick` every sample/tick on Core 0. Host tests exercise sidetone, buffer, and PTT directly (test_host).
+
+External deps of note: none — no ESP-IDF driver deps; I2S/codec output lives in keyer_hal, which the RT task feeds from this buffer.
+
+Conventions: Built with -Wconversion -Wshadow. Caller owns all storage (ring buffer storage array, generator struct). Fixed-point phase: upper 8 bits index the LUT (PHASE_SHIFT 24).
+
+Gotchas:
+- Everything here runs on the 100µs RT path — keep it allocation-free, lock-free, log-free. `sidetone_next_sample` is the per-sample hot loop.
+- Ring buffer is strictly one producer / one consumer; a full buffer silently drops the oldest sample rather than blocking.
+- The fade state machine, not `key_down`, decides when output is truly silent — check `sidetone_is_active()` (not the raw key) before deciding PTT/idle.
+- PTT holds ON for the whole tail window after the last audio; `ptt_tick` must be called even when idle for the timeout to expire.
+<!-- END treecode (auto) -->

--- a/components/keyer_config/CLAUDE.md
+++ b/components/keyer_config/CLAUDE.md
@@ -1,0 +1,42 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_config — GENERATED configuration component (DO NOT EDIT)
+
+>>> DO NOT EDIT ANY FILE IN THIS COMPONENT BY HAND. <<<
+Every .c and .h here is machine-generated at build time from
+`/parameters.yaml` by `/scripts/gen_config_c.py`. Hand edits are silently
+overwritten on the next build. Only `CMakeLists.txt` is checked into git;
+the `src/` and `include/` trees do not exist until the first build generates them.
+
+Responsibility: Provides the process-wide configuration model: the atomic `g_config`
+struct, its default initializer, NVS load/save persistence, and the console command
+surface for reading/writing parameters. It owns the single source of runtime settings
+(WPM, iambic/memory/squeeze modes, sidetone freq/volume, GPIO pins, WiFi/VPN/LED
+params, etc.) and the `generation` counter used for lock-free hot-reload.
+
+Key abstractions (all generated):
+- `config.h` / `config.c` — `keyer_config_t g_config`, `config_init_defaults()`,
+  and the `CONFIG_GET_*()` accessor macros used everywhere else.
+- `config_nvs.h` / `config_nvs.c` — `config_load_from_nvs()` / save to NVS.
+- `config_console.h` / `config_console.c` — console get/set command handlers.
+- `config_meta.h`, `config_schema.h` — parameter metadata / schema tables.
+
+Depends on: `nvs_flash` (only REQUIRES entry).
+
+Used by: nearly everything — main, rt_task, bg_task, and most `keyer_*` components read
+`g_config` through the generated macros.
+
+External deps of note: ESP-IDF NVS for persistence; Python3 + PyYAML run at configure
+time by the CMake `add_custom_command` (build fails hard via `COMMAND_ERROR_IS_FATAL`
+if generation fails, rather than using stale files).
+
+Conventions: To change a parameter, edit `/parameters.yaml` and rebuild — or regenerate
+manually with `python scripts/gen_config_c.py parameters.yaml components/keyer_config`.
+Config values are accessed atomically; cross-core reads use the `generation` counter to
+detect torn reads.
+
+Gotchas:
+- The component looks empty in git (just CMakeLists.txt) — that is expected, not a bug.
+- Because sources are generated, grepping this dir before a build finds nothing; read
+  `parameters.yaml` and the generator to understand what fields exist.
+- Adding/renaming a field means updating `parameters.yaml` only; never patch the .c/.h.
+<!-- END treecode (auto) -->

--- a/components/keyer_console/CLAUDE.md
+++ b/components/keyer_console/CLAUDE.md
@@ -1,0 +1,39 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_console — Interactive serial command interface (Core 1)
+
+Responsibility: Owns the line-editing state machine and command registry for the
+interactive text console. Parses input a character at a time, maintains history and
+tab completion, dispatches parsed commands to handlers, and prints results. It is a
+user-facing interface: it runs only on Core 1 (background) and must NEVER touch the
+hard RT path or block it. It does not own the USB transport — bytes are fed in by
+keyer_usb; on-host builds it can echo directly.
+
+Key abstractions:
+- `console_push_char()` / `console_process_char()` — feed one input byte; return true
+  when a full command line was executed (caller should reprint the prompt).
+- `console_parse_line()` → `console_parsed_cmd_t` (command + up to 3 args).
+- Command registry: `console_cmd_t`, `console_get_commands()`, `console_find_command()`,
+  `console_execute()`; handlers return `console_error_t` (E01..E06 codes).
+- History ring (`console_history_*`) and tab completion (`console_complete`).
+- `console_task()` — Core 1 loop (getchar) for non-USB/host use.
+
+Depends on: keyer_config, keyer_logging, keyer_hal, keyer_decoder, keyer_text,
+esp_driver_usb_serial_jtag, esp_timer (REQUIRES); keyer_usb, keyer_wifi, keyer_vpn
+(PRIV_REQUIRES, for command handlers that touch USB/WiFi/VPN state).
+
+Used by: main/bg_task.c and keyer_usb (usb_console.c pushes RX bytes into the state
+machine). Prompt shows the configured callsign from g_config.
+
+External deps of note: On ESP builds `printf` is redefined to `usb_console_printf`
+(see top of console.c / commands.c) so output goes to CDC0, not stdout.
+
+Conventions: Fixed-size static buffers only (CONSOLE_LINE_MAX=64, no heap). Errors are
+returned as `console_error_t`, never printed by handlers directly. CMakeLists runs
+gen_log_tags.py at configure time to produce log_tags.h. Built with -Wconversion
+-Wshadow.
+
+Gotchas: Circular-looking dep with keyer_usb is intentional and one-way at link time
+(console PRIV_REQUIRES keyer_usb; usb only includes console.h). Arrow keys / Ctrl-C /
+Ctrl-U are handled via an ANSI escape state machine inside push_char — feeding raw
+bytes out of order will desync it. `console_complete_reset()` is a retained no-op.
+<!-- END treecode (auto) -->

--- a/components/keyer_core/CLAUDE.md
+++ b/components/keyer_core/CLAUDE.md
@@ -1,0 +1,27 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_core — Lock-free stream, sample, consumer, and fault primitives (the heart of the keyer)
+
+Responsibility: Owns the ONE interface every keying event flows through — the lock-free SPMC `keying_stream_t`. Defines the 6-byte `stream_sample_t` event unit, the consumer handles that read it, and the atomic fault state. It must NOT touch hardware, allocate, log via ESP_LOGx, or depend on any other keyer component — it is pure C + stdatomic.h with zero ESP-IDF REQUIRES.
+
+Key abstractions:
+- `keying_stream_t`: single-producer/multi-consumer ring buffer. Producer owns `write_idx` (atomic, monotonic); consumers each hold their own thread-local `read_idx`. `stream_push` does silence/RLE compression via `idle_ticks`; `stream_push_raw` records unconditionally. Returns false when buffer full (a FAULT condition).
+- `stream_sample_t` (packed 6B): gpio paddle state, local_key (iambic output), audio_level, flags (edge/silence/tx/rx markers), config_gen (also reused as silence tick count).
+- Consumers: `stream_consumer_t` (basic), `hard_rt_consumer_t` (MUST keep up — FAULTs on lag > max_lag), `best_effort_consumer_t` (skips + counts drops, never FAULTs).
+- `fault_state_t`: all-atomic active/code/data/count; `fault_set/clear`, inline `fault_is_active`. Codes: OVERRUN, LATENCY_EXCEEDED, PRODUCER_OVERRUN, HARDWARE.
+
+Depends on: nothing (REQUIRES ""). Pure standard C.
+Used by: keyer_iambic, keyer_hal, keyer_logging, and main/rt_task + bg_task — essentially every component depends on keyer_core.
+External deps of note: none. Intentionally free of ESP-IDF so it builds and runs under the host Unity tests in test_host/.
+
+Conventions:
+- Built with -Wconversion -Wshadow -Wstrict-prototypes; keep it warning-clean.
+- Buffer capacity MUST be power of 2 (asserted in stream_init); `mask` gives fast modulo.
+- Producer uses memory_order_acq_rel on write_idx; consumers use acquire on load. Preserve these orderings.
+- Backing buffer is caller-provided (PSRAM on target); this module never allocates it.
+
+Gotchas:
+- This is the hard-RT data path (Core 0, 100µs ceiling). No malloc, no locks, no logging here — atomics only.
+- `config_gen` is overloaded: normal samples carry a config generation, silence markers carry tick count (see sample_silence*). Don't conflate them.
+- Hard-RT consumer overrun is not recoverable in place — it sets FAULT and stops; recovery is via explicit resync. "Corrupted CW timing is worse than silence."
+- Silence compression means unchanged samples are NOT written — consumers must expand silence markers, and call stream_flush before shutdown to emit pending idle ticks.
+<!-- END treecode (auto) -->

--- a/components/keyer_cwnet/CLAUDE.md
+++ b/components/keyer_cwnet/CLAUDE.md
@@ -1,0 +1,43 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_cwnet — remote CW-over-network transport (CWNet protocol)
+
+Responsibility: Implements the CWNet TCP protocol for streaming key-down/key-up
+events to/from a remote server, plus server time synchronization. Owns the wire
+format, the client state machine, and the ESP-IDF socket glue. It must NOT touch
+the hard RT path, allocate on the RT path, or read/write the keying stream
+directly — bg_task (Core 1) pulls samples from a best-effort consumer and hands
+key events to this module.
+
+Key abstractions:
+- cwnet_client_t / cwnet_client_config_t: transport-agnostic state machine
+  (DISCONNECTED -> CONNECTING -> READY). Socket I/O is injected via send_cb /
+  get_time_ms_cb callbacks so it is testable without a network.
+- cwnet_frame_parser_t: streaming, fragmentation-tolerant frame parser
+  (command byte encodes category in bits 7-6, command in bits 5-0).
+- cwnet_ping_t / cwnet_timer_t: PING-based clock sync and RTT/latency.
+- cwstream_encode/decode_timestamp: 7-bit non-linear ms timestamp codec.
+- cwnet_socket_*: the concrete ESP-IDF layer (BSD sockets + lwIP DNS) that owns
+  the real TCP socket, reconnection, and NVS config; driven by
+  cwnet_socket_process() at ~100Hz.
+
+Depends on: keyer_config, keyer_logging, esp_timer, lwip.
+Used by: main/bg_task.c (init + process + send_key_event), keyer_webui
+  (api_system.c, for state/latency reporting).
+External deps of note: lwIP BSD sockets + getaddrinfo (blocking DNS, non-blocking
+  connect via select()); esp_timer for local time; RT_*() logging into
+  g_bg_log_stream, not ESP_LOGx.
+
+Conventions: The pure protocol layer (client/frame/ping/timestamp) never calls
+socket APIs — only cwnet_socket.c does. Config comes from g_config.remote.
+-Wconversion/-Wshadow/-Wstrict-prototypes are enforced.
+
+Gotchas:
+- Timer MUST resync on every PING REQUEST or timestamps drift and the server
+  rejects packets.
+- cwnet_socket runs entirely on Core 1; it is best-effort and never blocks the
+  keyer. cwnet_socket_init() is a no-op unless remote.cwnet_enabled in NVS.
+- The client does not own its socket; the socket layer must forward
+  on_connected / on_data / on_disconnected events into it.
+- Frame parser copies only small fragmented payloads into its 256-byte buffer;
+  large payloads are returned as pointers into the input buffer (do not retain).
+<!-- END treecode (auto) -->

--- a/components/keyer_decoder/CLAUDE.md
+++ b/components/keyer_decoder/CLAUDE.md
@@ -1,0 +1,26 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_decoder — CW-to-text decoder, adaptive timing, morse table (Core 1 consumer)
+
+Responsibility: Owns best-effort decoding of transmitted CW back into text. Registers as a best-effort consumer on the keying stream, measures mark/space durations, adaptively learns the operator's speed, matches accumulated dit/dah patterns to characters, and buffers decoded text for display. It must NOT be on the RT path and must never stall the stream — dropped samples are acceptable (counted in stats), corrupted timing is not.
+
+Key abstractions:
+- `decoder_init()` / `decoder_process()` — init registers the consumer; process drains all pending samples, call ~10ms from bg_task.
+- `decoder_pop_char()` / `decoder_get_text()` — FIFO read of decoded characters.
+- `timing_classifier_t` — EMA-based (alpha ~0.3) dit/dah averages, 25% tolerance, warmup period; classifies KEY_EVENT_DIT/DAH/INTRA_GAP/CHAR_GAP/WORD_GAP; exposes detected WPM (1200000/dit_avg).
+- `morse_table_lookup` / `_reverse` / `morse_match_prosign` / `morse_get_prosign_tag` — static ITU table, linear search (~50 entries), also used by keyer_text.
+- `decoder_stats_t`, `decoder_handle_event()` (test injection).
+
+Depends on: keyer_core (the stream + sample/consumer types), esp_timer (timestamps).
+
+Used by: main/bg_task.c calls `decoder_process`; keyer_console, keyer_text (morse table), and keyer_webui consume decoded output / lookups.
+
+External deps of note: esp_timer for `esp_timer_get_time()` on target; on host it is stubbed with `decoder_set_mock_time()` and `decoder_set_test_stream()` so the whole module runs without hardware.
+
+Conventions: Built with -Wconversion -Wshadow -Wstrict-prototypes. Pure logic, host-testable. `ESP_PLATFORM` guards the timer/stream source vs. host stubs.
+
+Gotchas:
+- Best-effort by design: if process falls behind, samples are dropped (samples_dropped) — never add blocking or backpressure to protect the RT producer.
+- Timing classifier reports WPM 0 until warmup completes; check `timing_classifier_is_calibrated()` before trusting it.
+- Inactivity timeout (7 dit units of silence) force-finalizes the in-progress character.
+- All decoder state is single-threaded on Core 1; readers (console/webui) call the getters from the same task context.
+<!-- END treecode (auto) -->

--- a/components/keyer_hal/CLAUDE.md
+++ b/components/keyer_hal/CLAUDE.md
@@ -1,0 +1,25 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_hal — Hardware abstraction: paddle/TX GPIO, I2S audio, ES8311 codec, TCA9555 PA
+
+Responsibility: Owns all direct hardware access so the rest of the keyer stays hardware-free. Reads paddle GPIO, drives the TX line, and provides audio output (I2S DMA + ES8311 codec over I2C, plus PA enable via TCA9555 IO expander). It must NOT contain keying logic — it only reads inputs and pushes bytes/levels out.
+
+Key abstractions:
+- GPIO (`hal_gpio.h`): `hal_gpio_init`, `hal_gpio_read_paddles` → `gpio_state_t`, `hal_gpio_set_tx/get_tx`. ISR-based press detection with `hal_gpio_consume_dit_press`/`consume_dah_press` (atomic-exchange, RT-safe) and `hal_gpio_isr_tick(now_us)` which the RT task must call every tick.
+- Audio (`hal_audio.h`): `hal_audio_init` (ES8311 + I2S + TCA9555), `hal_audio_write(int16 mono samples)`, `hal_audio_start/stop`, `hal_audio_set_volume/set_pa` (I2C, NOT RT-safe), `hal_audio_is_available`.
+- Config structs `hal_gpio_config_t` / `hal_audio_config_t` with *_DEFAULT macros matching the reference board.
+
+Depends on: keyer_core, driver, esp_driver_gpio, esp_driver_i2s, esp_driver_i2c, esp_timer. PRIV_REQUIRES esp_codec_dev, esp_io_expander, esp_io_expander_tca95xx_16bit (declared in idf_component.yml).
+Used by: main/rt_task (paddle read + TX + audio write on Core 0) and audio setup during boot.
+External deps of note: esp_codec_dev drives the ES8311; the TCA9555 16-bit expander gates the power amp; uses esp_private/gpio.h `gpio_iomux_output/input` (v6 rename) in force_gpio_reset.
+
+Conventions:
+- Built with -Wconversion -Wshadow.
+- ISR handlers are IRAM_ATTR and use ONLY ISR-safe ops (atomic_store, disable interrupt) — see the header comment block in hal_gpio.c.
+- Every driver include must have a matching REQUIRES entry (ESP-IDF v6 strict transitive-deps).
+
+Gotchas:
+- `esp_timer_start_once()` is NOT ISR-safe. Pattern: ISR sets an atomic "needs blanking" flag; `hal_gpio_isr_tick` (task context) actually starts the blanking timer and runs a stuck-interrupt watchdog. This adds ~1ms to blanking start — do not move timer starts into the ISR.
+- `isr_blanking_us = 0` disables the ISR and falls back to pure polling.
+- Audio init failing must NOT block boot — the system degrades gracefully (check `hal_audio_is_available`).
+- set_volume/set_pa do I2C transactions — never call them from the Core 0 RT path.
+<!-- END treecode (auto) -->

--- a/components/keyer_iambic/CLAUDE.md
+++ b/components/keyer_iambic/CLAUDE.md
@@ -1,0 +1,27 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_iambic — Iambic keyer finite state machine (paddle GPIO → keying output)
+
+Responsibility: Owns the pure keying logic that converts paddle state into dit/dah element timing. Takes a timestamp + `gpio_state_t` per tick and emits a `stream_sample_t` with `local_key` set. It must NOT do any I/O, allocation, or hardware access, and must NOT read the clock itself — the caller passes `now_us`. Fully testable on host.
+
+Key abstractions:
+- `iambic_processor_t`: the FSM. States IDLE / SEND_DIT / SEND_DAH / GAP, plus element start/end/duration timestamps, per-paddle press/release timestamps, dit/dah memory flags, squeeze tracking, and key_down output.
+- `iambic_tick(proc, now_us, gpio)`: the single entrypoint — advances the FSM and returns the output sample. `iambic_init/set_config/reset`.
+- `iambic_config_t`: wpm, mode (A/B), memory_mode, squeeze_mode, memory-window start/end percentages. Inline PARIS-timing helpers (`iambic_dit_duration_us` = 1200000/wpm, dah = 3×, gap = 1×).
+- `iambic_preset.h`: 10-slot atomic preset store (`g_iambic_presets`) with RT-safe (<200ns) accessors. NOTE: preset store is deprecated in favor of unified g_config, but its enum types (iambic_mode_t, memory_mode_t, squeeze_mode_t) remain the canonical definitions.
+
+Depends on: keyer_core (for sample.h / gpio_state_t / stream_sample_t).
+Used by: main/rt_task (Core 0 RT loop) which feeds it paddle reads from keyer_hal and pushes its output samples into the stream.
+External deps of note: none — no ESP-IDF, builds under host tests.
+
+Conventions:
+- Built with -Wconversion -Wshadow -Wstrict-prototypes.
+- All timing is int64 microseconds; caller supplies `now_us` (esp_timer on target, synthetic in tests). Never call a clock in here.
+- Preset fields are atomic and edited off the RT path; the RT path only reads them.
+
+Gotchas:
+- Runs on the hard-RT path — keep `iambic_tick` allocation-free, lock-free, and bounded.
+- Mode A stops immediately on paddle release; Mode B completes the current element plus one bonus element — do not "simplify" this asymmetry away.
+- Memory window: paddle presses are only latched between start%/end% of the element; presses before start% (debounce) or after end% are dropped by design.
+- Release debounce: `IAMBIC_DEBOUNCE_RELEASE_US` (5ms) blanks re-presses of the same paddle after release to kill contact bounce.
+- squeeze_mode LATCH_OFF = live paddle sampling, LATCH_ON = snapshot at element start — different feel, both intentional.
+<!-- END treecode (auto) -->

--- a/components/keyer_led/CLAUDE.md
+++ b/components/keyer_led/CLAUDE.md
@@ -1,0 +1,24 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_led — WS2812B RGB status LED driver (Core 1)
+
+Responsibility: Owns the WS2812B status LED strip: a state machine of connectivity/keyer states (boot, wifi-connecting, failed, degraded, AP mode, provisioning, connected, idle) rendered as breathing/flashing animations, plus a real-time keying overlay (DIT/DAH/squeeze) driven by the paddle inputs. Purely a display sink — it must NOT influence keying, TX, or the stream.
+
+Key abstractions:
+- `led_init(led_config_t)` / `led_deinit()` — sets up the RMT TX channel and a custom byte+copy strip encoder; init is non-fatal (keyer runs on if it fails).
+- `led_set_state(led_state_t)` / `led_get_state()` — pick the base animation.
+- `led_tick(now_us, dit, dah)` — call periodically from bg_task; advances animations and overlays live paddle state.
+- `led_config_t` (gpio, count, brightness, brightness_dim) with `LED_CONFIG_DEFAULT` (GPIO38, 7 LEDs); `led_set_brightness()`.
+
+Depends on: driver, esp_driver_rmt (WS2812B bit-banging via RMT), esp_timer (animation clock).
+
+Used by: main/bg_task.c calls `led_tick` with current paddle state; main sets states on lifecycle events; provisioning drives AP/provisioning states.
+
+External deps of note: esp_driver_rmt — timing constants encode the WS2812B protocol (T0H/T0L/T1H/T1L ticks at 10MHz/100ns resolution, plus a reset symbol). Changing them breaks the LED protocol, not just brightness.
+
+Conventions: Built with -Wall -Wextra -Werror -Wconversion -Wshadow (strictest in the tree). Colors are 0xRRGGBB; MAX_LEDS 16.
+
+Gotchas:
+- Runs on Core 1 only — never call from the RT task. It is a status sink; the DIT/DAH args are for display, not a keying source.
+- Init failure is deliberately non-fatal: always guard with `led_is_initialized()` and let the keyer continue if the strip is absent.
+- WS2812B is GRB on the wire; the encoder handles ordering — pass logical 0xRRGGBB, don't pre-swap.
+<!-- END treecode (auto) -->

--- a/components/keyer_logging/CLAUDE.md
+++ b/components/keyer_logging/CLAUDE.md
@@ -1,0 +1,26 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_logging — RT-safe non-blocking logging (lock-free push, Core-1 UART drain)
+
+Responsibility: Owns logging that is safe to call from the hard-RT path. The producer side (RT_*() macros) pushes formatted entries into a lock-free ring in ~100-200ns and never blocks; a Core-1 task drains them to UART. It exists precisely so the RT path never calls ESP_LOGx/printf. It must NOT block, allocate, or do I/O on the producer side — draining and UART writes happen off Core 0.
+
+Key abstractions:
+- `log_stream_t`: fixed 256-entry (`LOG_BUFFER_SIZE`) ring of `log_entry_t` (timestamp, level, ≤120-char msg), with atomic write/read/dropped indices. Globals `g_rt_log_stream` (Core 0) and `g_bg_log_stream` (Core 1).
+- Producer: `log_stream_push` / the `RT_ERROR/WARN/INFO/DEBUG/TRACE(stream, ts, fmt, ...)` macros. Diagnostic variants `RT_DIAG_*` gate on the atomic `g_rt_diag_enabled` flag (single relaxed load when off).
+- Consumer: `log_stream_drain`, `log_stream_count/has_entries/dropped`, and `uart_logger_init` + `uart_logger_task` (drains both streams to UART1 @115200 on Core 1).
+
+Depends on: keyer_core, driver, esp_driver_uart, esp_driver_gpio, esp_timer.
+Used by: every component/task that logs from or near the RT path — main/rt_task, bg_task, and anything on Core 0. The uart_log task (Core 1) is the sole drainer.
+External deps of note: esp_driver_uart (UART1 output), esp_timer (timestamps). snprintf is used inside RT_LOG on a stack buffer.
+
+Conventions:
+- Built with -Wconversion -Wshadow.
+- On the RT/producer side use ONLY the RT_*/RT_DIAG_* macros — never ESP_LOGx or printf.
+- Caller passes the timestamp (`ts`, µs) into the macros; keep it consistent with esp_timer_get_time().
+- Two separate streams keep Core-0 and Core-1 producers from contending.
+
+Gotchas:
+- The ring is bounded: on overflow entries are DROPPED (dropped counter increments), never blocked — silence beats stalling the RT path. Check the dropped count if logs go missing.
+- Messages over LOG_MAX_MSG_LEN (120) are truncated.
+- RT_LOG still runs snprintf on the producer — cheap but not free; keep hot-loop TRACE behind RT_DIAG_* so it compiles to a single atomic check when diagnostics are off.
+- The drain task must actually be scheduled on Core 1, or the ring fills and everything after is dropped.
+<!-- END treecode (auto) -->

--- a/components/keyer_text/CLAUDE.md
+++ b/components/keyer_text/CLAUDE.md
@@ -1,0 +1,26 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_text — Text-to-CW playback and NVS message memories (Core 1 producer)
+
+Responsibility: Owns converting ASCII text (letters, digits, punctuation, `<..>` prosigns, spaces) into CW element timing and exposing the resulting key-down state to the RT task. Also owns 8 persistent message slots in NVS. It must NOT write the keying stream or touch GPIO/audio itself — it only publishes a key-down boolean that Core 0 samples.
+
+Key abstractions:
+- `text_keyer_send(text)` / `_abort` / `_pause` / `_resume` — single active transmission; state machine IDLE/SENDING/PAUSED.
+- `text_keyer_tick(now_us)` — advances element timing; call from bg_task (~10ms) on Core 1.
+- `text_keyer_is_key_down()` — atomic load, called from Core 0 RT task (~1ms) to fold text keying into the sidetone/TX path.
+- `text_keyer_config_t.paddle_abort` — non-owning `atomic_bool*`; a paddle press aborts playback.
+- `text_memory_*` — 8 slots (`TEXT_MEMORY_SLOTS`), text + label, load/get/set/save via NVS.
+
+Depends on: keyer_core, keyer_decoder (for morse_table reverse lookup + prosigns), keyer_config (global WPM), nvs_flash.
+
+Used by: main/bg_task.c ticks it; main/rt_task.c polls `is_key_down`; keyer_console and keyer_webui drive send/memory commands.
+
+External deps of note: nvs_flash for message persistence; reuses keyer_decoder's `morse_table_reverse`/`morse_match_prosign` rather than carrying its own table.
+
+Conventions: Built with -Wconversion -Wshadow -Wstrict-prototypes. WPM comes from `CONFIG_GET_WPM()`, clamped 5–60; dit = 1200000/WPM µs (PARIS).
+
+Gotchas:
+- Timing state (`s_send`, `s_state`) is mutated only on Core 1; only `s_key_down` crosses cores — it is atomic (release on write, acquire on read). Do not read other fields from the RT task.
+- `element_end_us == 0` is the "start next element / just resumed" sentinel, not a real timestamp.
+- Every abort/pause/done path must force key-down false, or a stuck key leaves the TX keyed — the code releases the key on all exits deliberately.
+- Single transmission only: `send` returns -1 if not IDLE.
+<!-- END treecode (auto) -->

--- a/components/keyer_usb/CLAUDE.md
+++ b/components/keyer_usb/CLAUDE.md
@@ -1,0 +1,34 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_usb — TinyUSB multi-CDC transport (Core 1)
+
+Responsibility: Owns the USB device stack (TinyUSB) and exposes three composite CDC-ACM
+interfaces plus UF2 firmware update. It is the physical transport for the user-facing
+console and logs; it runs entirely on Core 1 and must never block the RT path. It moves
+bytes only — command parsing lives in keyer_console, log formatting in keyer_logging.
+
+Key abstractions:
+- `usb_cdc_init()` / `usb_cdc_write()` / `usb_cdc_flush()` / `usb_cdc_connected()` — raw
+  per-interface I/O. CDC0=console, CDC1=log, CDC2=Winkeyer (reserved).
+- `usb_console_*` — CDC0 RX callback echoes and pushes chars into console_push_char;
+  `usb_console_printf()` is the console output sink.
+- `usb_log_*` — CDC1 drain task pulls the RT-safe log ring buffer and applies
+  global/per-tag level filters (`usb_log_set_level`, `usb_log_set_tag_level`).
+- `usb_uf2_init()` / `usb_uf2_enter()` — reboot into UF2 mass-storage bootloader.
+- `usb_winkeyer_*` — stub for future K1EL Winkeyer3 emulation (not implemented).
+
+Depends on: esp_tinyusb (registry, ^1.0.0), keyer_logging, esp_system (REQUIRES);
+freertos, esp_timer, keyer_console (PRIV_REQUIRES).
+
+Used by: main.c (usb_cdc_init early in app_main) and bg_task.c (usb_log_task). Console
+commands in keyer_console call into usb_uf2 / usb_log / usb_console.
+
+External deps of note: espressif/esp_tinyusb declared in idf_component.yml; USB VID/PID
+0x303A/0x8002, serial "KEYER-IU3QEZ-001". UF2 path uses esp_tinyuf2.
+
+Conventions: init order matters — usb_cdc_init() must run before console_task starts.
+Built with -Wno-unused-parameter (TinyUSB callback signatures).
+
+Gotchas: CDC2/Winkeyer is a stub — `usb_winkeyer_is_enabled()` always returns false.
+The log drain is a Core 1 task, not called from RT code; RT producers only enqueue into
+the ring buffer. Entering UF2 (`usb_uf2_enter`) restarts the device and does not return.
+<!-- END treecode (auto) -->

--- a/components/keyer_vpn/CLAUDE.md
+++ b/components/keyer_vpn/CLAUDE.md
@@ -1,0 +1,38 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_vpn — VPN glue (WireGuard tunnel manager)
+
+Responsibility: Thin orchestration layer that brings up a WireGuard tunnel using
+the vendored esp_wireguard component. Owns the connect sequence — wait for WiFi,
+sync wall-clock time via SNTP (required for the WireGuard handshake), build the
+wireguard_config_t, init/connect, then monitor. Publishes an atomic vpn_state_t
+and tunnel stats. It must NOT run on the RT path; the whole thing lives on Core 1
+and is best-effort with zero impact on keying.
+
+Key abstractions:
+- vpn_config_app_t / VPN_CONFIG_DEFAULT: endpoint, port (51820), server public
+  key, client private key, tunnel address/CIDR, allowed_ips, keepalive.
+- vpn_state_t: DISABLED / WAITING_WIFI / WAITING_TIME / CONNECTING / CONNECTED /
+  FAILED.
+- vpn_stats_t: tx/rx bytes, handshake count, last handshake time.
+- vpn_app_init / vpn_app_start (spawns a pinned Core 1 task) / vpn_app_stop,
+  plus vpn_get_state / vpn_is_connected / vpn_get_stats / vpn_state_str.
+
+Depends on: esp_netif, esp_event, nvs_flash, esp_timer, keyer_logging,
+keyer_config, keyer_wifi (REQUIRES); esp_wireguard (PRIV_REQUIRES).
+Used by: main/main.c and main/bg_task.c (startup + LED status), keyer_webui
+  (api_vpn.c), keyer_console (commands.c).
+
+External deps of note: esp_sntp (pool.ntp.org / time.google.com) — the tunnel
+cannot come up until time is synced, because WireGuard timestamps the handshake.
+Wraps esp_wireguard_init/connect/set_default and esp_wireguardif_peer_is_up.
+
+Conventions: State transitions use explicit atomic stores with acquire/release
+ordering; the worker task cooperatively exits when state is set to DISABLED.
+Strict warning set (-Werror, -Wconversion, -Wsign-conversion, stack protector).
+
+Gotchas:
+- Requires a working clock; a device with no SNTP reachability stalls in
+  WAITING_TIME and never connects.
+- esp_wireguard_init must not be called twice — disconnect before reconfiguring.
+- Keepalive 25 is the NAT-friendly default; 0 disables it.
+<!-- END treecode (auto) -->

--- a/components/keyer_webui/CLAUDE.md
+++ b/components/keyer_webui/CLAUDE.md
@@ -1,0 +1,37 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_webui — HTTP + WebSocket backend for the web UI (Core 1)
+
+Responsibility: Owns the on-device HTTP server that serves the embedded single-page app
+and the JSON REST API, plus a WebSocket endpoint for real-time streaming. It is a
+user-facing interface running on Core 1 — it reads/writes config and queries subsystems,
+but must never sit on or block the hard RT path. Rendering/state lives in frontend/.
+
+Key abstractions:
+- `webui_init()` / `webui_start()` / `webui_stop()` — lifecycle (esp_http_server).
+- REST handlers in api_*.c: `/api/config`, `/api/config/schema`, `/api/parameter`,
+  `/api/config/save`, `/api/status`, `/api/system/{stats,reboot}`, `/api/decoder/*`,
+  `/api/timeline/config`, `/api/text/*` (send/status/abort/pause/resume/memory/play),
+  `/api/vpn/status`.
+- Static/SPA serving (http_server.c): exact-asset match else SPA_ROUTES → index.html.
+- ws_server.c: single `/ws` endpoint (max 8 clients); `ws_broadcast*` push decoder,
+  pattern, and timeline events. `webui_*_push` / `webui_timeline_push` are the producer
+  entry points called from other subsystems.
+
+Depends on: esp_http_server, esp_timer, keyer_config, keyer_core, keyer_cwnet,
+keyer_decoder, keyer_wifi, keyer_vpn, keyer_text (REQUIRES).
+
+Used by: main.c / bg_task.c (start server); decoder and timeline subsystems call the
+webui_*_push broadcast entry points.
+
+External deps of note: cJSON comes from espressif/cjson (declared in idf_component.yml),
+NOT the old ESP-IDF `json` component — it was removed in v6, so do NOT add `json` to
+REQUIRES. Handlers `#include "cJSON.h"` and build JSON with cJSON_Create*/AddItem*.
+
+Conventions: Built strict — -Wall -Wextra -Werror -Wconversion -Wsign-conversion. The
+config schema is served as a precompiled CONFIG_SCHEMA_JSON string (no runtime build).
+
+Gotchas: The frontend is built at CMake time (npm install && vite build) and embedded
+into the generated src/assets.c via scripts/embed_assets.py — assets are gzipped and
+served from flash, there is no filesystem. New client routes must be added to both the
+Svelte router and the SPA_ROUTES list in http_server.c or a deep-link 404s.
+<!-- END treecode (auto) -->

--- a/components/keyer_webui/frontend/CLAUDE.md
+++ b/components/keyer_webui/frontend/CLAUDE.md
@@ -1,0 +1,36 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_webui/frontend — Svelte single-page web UI (npm/Vite)
+
+Responsibility: Owns the browser-side user interface — the SPA served by keyer_webui. A
+separate module with its own npm toolchain; it produces static assets (JS/CSS/HTML) that
+get embedded into firmware. It holds no device state of its own beyond view state and
+talks to the board only over the REST + WebSocket API.
+
+Key abstractions:
+- App.svelte — shell + client-side router (history.pushState / popstate) over pages/:
+  Home, Config, System, Keyer, Decoder, Timeline. main.ts mounts the app.
+- lib/api.ts — `ApiClient` (exported singleton `api`): typed REST wrappers over /api/*
+  and a self-reconnecting WebSocket client for /ws (decoded, word, pattern, paddle,
+  keying, gap events) with device→browser timestamp synchronization.
+- lib/types.ts — shared API DTOs; lib/themes.ts + lib/stores/theme.ts — theming, theme
+  is loaded from device config on mount.
+
+Depends on: svelte ^5, vite ^5, @sveltejs/vite-plugin-svelte ^4, typescript ^5 (all
+devDependencies — no runtime npm deps; output is self-contained static assets).
+
+Used by: keyer_webui (its CMakeLists runs `npm install` + `npm run build`, then
+embed_assets.py bundles frontend/dist into src/assets.c).
+
+External deps of note: none at runtime — plain fetch/WebSocket, no UI framework CDN.
+
+Conventions: Scripts — `dev` (vite dev server, proxies /api to http://192.168.4.1),
+`build` (vite build → dist/), `preview`. vite.config.ts pins output to assets/app.js and
+inlines nothing (assetsInlineLimit 0) so embed_assets can gzip each file. __GIT_HASH__
+and __BUILD_TIME__ are injected as build-time defines.
+
+Gotchas: Do NOT read or touch node_modules — it is gitignored and regenerated on build.
+The built bundle is embedded into flash, so any UI change requires an idf.py build to
+take effect on-device; running the vite dev server alone only updates the browser, not
+the board. New pages must be wired into BOTH App.svelte's router/navItems and the
+backend SPA_ROUTES list, or deep links 404.
+<!-- END treecode (auto) -->

--- a/components/keyer_wifi/CLAUDE.md
+++ b/components/keyer_wifi/CLAUDE.md
@@ -1,0 +1,37 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# keyer_wifi — WiFi bring-up (STA with AP fallback)
+
+Responsibility: Owns the device's WiFi lifecycle: init the esp_wifi/esp_netif
+stack, attempt an STA connection to the configured SSID, and fall back to an
+open AP if that fails. Publishes a single atomic state value for other Core 1
+consumers (LED, web UI, console, VPN). It must NOT do any provisioning UI
+(that is the isolated `provisioning` component) and must never run on the RT
+path.
+
+Key abstractions:
+- wifi_config_app_t / WIFI_CONFIG_DEFAULT: SSID, password, timeout, and optional
+  static-IP settings.
+- wifi_state_t: DISABLED / CONNECTING / CONNECTED / FAILED / AP_MODE.
+- wifi_app_init / wifi_app_start / wifi_app_stop: non-blocking lifecycle.
+- wifi_get_state / wifi_get_ip / wifi_is_connected: thread-safe status reads.
+
+Depends on: esp_wifi, esp_netif, esp_event, nvs_flash.
+Used by: main/main.c and main/bg_task.c (startup + LED mapping), keyer_webui
+  (api_system.c), keyer_console (commands.c). keyer_vpn waits on
+  wifi_is_connected() before starting its tunnel.
+
+External deps of note: esp_event default loop and IP/WIFI event handlers drive
+the STA reconnect logic; STA and AP netifs must be created before
+esp_wifi_init() (ESP-IDF ordering requirement).
+
+Conventions: State is exposed only through the atomic accessor functions — no
+shared structs. Compiled with -Werror plus -Wconversion/-Wshadow.
+
+Gotchas:
+- esp_event_loop_create_default() may already exist; ESP_ERR_INVALID_STATE is
+  treated as benign.
+- On STA failure the module switches to open AP mode rather than staying down,
+  so "connected" from a client's view can mean AP_MODE — check wifi_get_state()
+  not just is_connected().
+- Non-blocking start: callers must poll wifi_get_state(), not assume readiness.
+<!-- END treecode (auto) -->

--- a/components/provisioning/CLAUDE.md
+++ b/components/provisioning/CLAUDE.md
@@ -1,0 +1,36 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# provisioning — first-time device provisioning via AP + web form
+
+Responsibility: Handles first-boot setup of an unconfigured device. Brings up an
+open AP ("CWKeyer-Setup"), serves an HTTP form for WiFi credentials, callsign,
+and theme, writes them to NVS, and reboots. Also detects a paddle-hold factory
+reset at boot. This runs INSTEAD OF normal keyer boot — never alongside it — and
+owns nothing on the RT path.
+
+Key abstractions:
+- provisioning_is_needed(): true when NVS has no WiFi SSID.
+- provisioning_check_factory_reset(dit_gpio, dah_gpio, hold_ms): clears the
+  stored SSID if both paddles are held at boot.
+- provisioning_start(): creates AP, runs the web server, saves config, reboots.
+  Does NOT return.
+- Internal split: provisioning_wifi.c (AP/netif), provisioning_http.c (server +
+  handlers), provisioning_html.c (embedded form page).
+
+Depends on: nvs_flash, esp_wifi, esp_netif, esp_http_server, driver,
+esp_driver_gpio, esp_timer, keyer_led.
+Used by: main/main.c only (gate at startup before normal boot).
+External deps of note: esp_http_server for the setup UI; raw GPIO reads for the
+paddle factory-reset check; keyer_led for status feedback.
+
+Conventions: Deliberately self-contained and duplicates small bits of WiFi/NVS
+logic for fault isolation — do NOT refactor it to share code with keyer_wifi.
+The whole flow is one-shot and terminates in esp_restart(). Strict warnings
+(-Werror, -Wconversion, -Wsign-conversion).
+
+Gotchas:
+- provisioning_start() never returns; the device reboots via a deferred
+  reboot_task after the form is submitted and committed to NVS.
+- NVS keys here (PROV_NVS_WIFI_SSID/PASS/EN, CALLSIGN, THEME) are the contract
+  with the normal-boot config loader — keep them in sync.
+- It reads paddle GPIOs directly, so pin wiring must match the keyer config.
+<!-- END treecode (auto) -->

--- a/main/CLAUDE.md
+++ b/main/CLAUDE.md
@@ -1,0 +1,42 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# main — firmware entry point and the two per-core RT/BG tasks
+
+Responsibility: Owns `app_main()` boot sequence and the two pinned FreeRTOS tasks that
+drive the whole keyer. It wires components together (NVS, config, HAL, WiFi/VPN, WebUI,
+decoder, console, streams) and defines the process-global singletons
+(`g_keying_stream`, `g_fault_state`, `g_paddle_active`). It must NOT contain keying,
+audio, or protocol logic — that lives in the `keyer_*` components; main only
+orchestrates init and hosts the task loops.
+
+Key abstractions:
+- `app_main()` (main.c): ordered boot — logs → NVS → factory-reset/provisioning check
+  → config load → netif → HAL GPIO → USB CDC → LED → WiFi → VPN → stream/fault init →
+  audio → console → WebUI → decoder → text keyer, then spawns tasks and waits for USB CDC.
+- `rt_task()` (rt_task.c): the 1ms hard-RT loop — GPIO poll → iambic tick → stream_push →
+  hard_rt_consumer → TX GPIO + I2S sidetone → PTT. Also does IDLE-only config hot-reload.
+- `bg_task()` (bg_task.c): 10ms best-effort loop — LED/WiFi/VPN state, CWNet socket,
+  decoder, WebUI timeline push, text keyer tick, periodic stats.
+- `audio_test.c`: standalone 600Hz tone task for bringing up the ES8311 codec (not in boot path).
+
+Depends on: essentially every component — keyer_core, keyer_iambic, keyer_audio,
+keyer_logging, keyer_console, keyer_usb, keyer_config, keyer_hal, keyer_decoder,
+keyer_text, keyer_led, keyer_wifi, keyer_vpn, keyer_webui, keyer_cwnet, provisioning,
+plus freertos and esp_timer.
+
+Used by: nobody — this is the top of the tree; it becomes the firmware image.
+
+External deps of note: ESP-IDF FreeRTOS (`xTaskCreatePinnedToCore`), NVS, esp_netif/esp_event,
+esp_timer for the monotonic `now_us` clock threaded through both loops.
+
+Conventions: Do ALL component init in `app_main` (bg_task explicitly assumes this — it
+re-initializes nothing but the timeline consumer and CWNet). Config is read via the
+generated `CONFIG_GET_*()` macros. Globals cross cores only through atomics or the stream.
+
+Gotchas:
+- rt_task is pinned to Core 0 at `configMAX_PRIORITIES-1` and is the hard RT path:
+  NO malloc/log/mutex/printf on it — use `RT_*` macros and `stdatomic.h` only (ARCHITECTURE.md).
+- Iambic/sidetone/PTT config hot-reload happens ONLY when the FSM is IDLE, guarded by a
+  config `generation` counter with a torn-read retry; never reload mid-element.
+- bg_task, usb_log, uart_log are all pinned to Core 1; uart_log is deleted once USB CDC connects.
+- On stream_push failure rt_task raises `FAULT_PRODUCER_OVERRUN` — corrupted timing must FAULT, not limp.
+<!-- END treecode (auto) -->

--- a/test_host/CLAUDE.md
+++ b/test_host/CLAUDE.md
@@ -1,0 +1,42 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# test_host — Unity host test harness (runs on the dev machine, no hardware)
+
+Responsibility: Compiles the platform-independent parts of the `keyer_*` components on
+the host and exercises them with Unity, so keying/decoding/protocol logic can be tested
+without an ESP32. It owns the CMake build that selects which component `src/*.c` files
+are host-safe, the ESP-platform stubs, and the test suites. It must NOT test HAL/driver
+code or anything needing real GPIO/I2S/NVS — those files are deliberately excluded.
+
+Key abstractions:
+- `CMakeLists.txt` — the whole harness: strict flags (`-Wall -Wextra -Werror
+  -Wconversion` …), `HOST_TEST=1` / target defines, FetchContent-pulled Unity v2.5.2,
+  explicit lists of component sources (core, iambic, audio, logging, decoder, cwnet,
+  console parser only) plus the `test_*.c` suites, linked into one `test_runner`.
+- `test_main.c` — Unity entry / `RUN_TEST_GROUP` driver.
+- `test_*.c` — one suite per unit (stream, iambic, sidetone, fault, decoder,
+  timing_classifier, morse_table, cwnet_*, console_parser, …).
+- `stubs/` — thin ESP shims (`esp_err.h`, `esp_timer.h`, `esp_stubs.c/.h`) supplying just
+  enough of the platform (error codes, `esp_timer_get_time`) to link on the host.
+
+Depends on (build-time, via include_directories/source lists): keyer_core, keyer_iambic,
+keyer_audio, keyer_logging, keyer_console (parser only), keyer_config headers,
+keyer_decoder, keyer_cwnet. Plus Unity, fetched over the network at configure time.
+
+Used by: developers and CI — run `cmake -B build && cmake --build build && ./build/test_runner`
+(add `-DCMAKE_C_FLAGS="-fsanitize=address,undefined"` for sanitizers).
+
+External deps of note: Unity (ThrowTheSwitch, pinned v2.5.2 via FetchContent — needs git +
+network on first configure).
+
+Conventions: Components are driven ONLY through the lock-free stream by feeding fake,
+recorded, or synthesized `stream_sample_t` sequences. There are NO mocks — per the
+project rule, "if you need a mock, the design is wrong; the stream is the only interface."
+The `stubs/` are platform shims for linking, not behavioral mocks of modules under test.
+
+Gotchas:
+- Adding a new host test or a newly-host-safe component source means editing the source
+  lists in `CMakeLists.txt` by hand — there is no glob; commented-out entries mark files
+  intentionally excluded because they pull in HAL/console/NVS dependencies.
+- keyer_config sources are excluded (need NVS stubs); only its generated headers are on the
+  include path, so a build must have generated them first.
+<!-- END treecode (auto) -->

--- a/treemap.config.json
+++ b/treemap.config.json
@@ -1,0 +1,7 @@
+{
+  "caps": {
+    "root": 240,
+    "nested": 60,
+    "hard_max": 260
+  }
+}


### PR DESCRIPTION
## Summary

Adds a lazy-loaded, distributed `CLAUDE.md` tree generated with the [treecode](https://github.com/iu3qez/treecode) tree-mapper (engine v0.2.0):

- A **lean root map** appended inside a `treecode:map` marker block on the existing top-level `CLAUDE.md` — the hand-written project instructions are untouched; only the auto block is generated.
- **20 nested `CLAUDE.md`** briefs, one per detected module: every `components/*` component, `components/keyer_webui/frontend`, `main/`, and `test_host/`.

Each nested brief follows the fixed template (responsibility · key abstractions · depends-on / used-by · external deps · conventions · gotchas), 24–43 lines each, within the 60-line cap. `treemap.py check` reports **no drift**.

## Details

- **Dependencies** are drawn from each `CMakeLists.txt` `REQUIRES`/`PRIV_REQUIRES`, since the engine does not parse C `#include`s (the auto dependency graph is empty for C).
- Real-time constraints are emphasized on the Core-0 hard-RT modules (`keyer_core`, `keyer_iambic`, `keyer_audio`, `keyer_hal`, `keyer_logging`); background/Core-1 consumers and user-facing interfaces are marked as such.
- Module-specific footguns captured: the vendored `esp_wireguard` fork (do-not-replace, `esp_fill_random()` RNG patch, per-file GCC15 warning suppressions), the cJSON-from-`espressif/cjson` note for `keyer_webui`, and a prominent **GENERATED — DO NOT EDIT** warning on `keyer_config` (pointing to `parameters.yaml` + `scripts/gen_config_c.py`).
- `treemap.config.json` is added to raise the root-map cap for this repo's long top-level `CLAUDE.md`.

## Notes for reviewers

- All generated content lives strictly inside `<!-- BEGIN … -->` / `<!-- END … -->` marker blocks; text outside them is human-owned and safe to edit.
- Regenerate / re-verify with:
  ```
  treemap.py --root . scan     # discover modules
  treemap.py --root . check    # drift + cap check (currently: no drift)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q29kWAVNEp6h6MQJzt4Eyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q29kWAVNEp6h6MQJzt4Eyc)_