### PR TITLE
Banco di prova CWNet: contratto di implementazione, prima lezione, e la regola sulle issue bloccanti

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -14,6 +14,14 @@ niente OTA per ora, WebUI ferma finché le prime tre track non tengono.
 Frase-test: resistere a una modifica quando l'unico argomento è "c'è e costa poco
 aggiungere", o quando non è dimostrabile contro il riferimento.
 
+## Issue bloccanti
+Una issue GitHub etichettata `blocking` ferma il lavoro che ne dipende, punto. Non si pianifica
+intorno, non si sostituisce con un'assunzione, non si procede marcando il lavoro "provvisorio".
+Regola completa in [CLAUDE.md](../CLAUDE.md#a-blocking-issue-blocks), fra i Critical Constraints.
+
+Aperte ora: #7 (sequenza nota e definizione di "identico") e #8 (provenienza delle catture).
+Entrambe bloccano la sessione zero del banco CWNet.
+
 ## Definition of done
 Vedi [CLAUDE.md](../CLAUDE.md#definition-of-done). In breve: test host verdi in
 entrambe le varianti CI (plain + ASan/UBSan), mai skippare un test per arrivarci,

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 *.elf binary
 *.png binary
 *.jpg binary
+# Capture fixtures are oracles: never let eol normalisation touch them
+*.pcap binary
+*.pcapng binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ cmake --build build && ./build/test_runner
 
 From [STRATEGY.md](STRATEGY.md): behaviour that matters is proven against a real reference, not made "similar".
 
+- No open `blocking` issue covers this work. See **A Blocking Issue Blocks** under Critical Constraints.
 - Host tests green in both CI variants. Never skip, disable or quarantine a failing test to get there.
 - A change touching CWNet (`keyer_cwnet/`) or the iambic FSM (`keyer_iambic/`) ships with a host test that pins the behaviour against the reference (DL4YHF client/server traces, K1EL K8 source).
 - Nothing blocking on the RT path: no `ESP_LOGx`/`printf` on Core 0 — the serial log blocks real time.
@@ -105,6 +106,23 @@ The project was migrated from ESP-IDF v5 to v6. Things to know:
 ## Critical Constraints
 
 These rules are **non-negotiable**. Violating any of them will break real-time guarantees.
+
+### A Blocking Issue Blocks
+
+A GitHub issue labelled `blocking` **stops the work that depends on it. Completely.**
+
+There is no partial credit here, and no clever way around it:
+
+- Do **not** plan around it, implement around it, or design a fallback for it.
+- Do **not** substitute an assumption for the decision it holds. An assumption in place of a blocking decision is the decision, made badly and without authority.
+- Do **not** mark the dependent work "provisional" and proceed anyway. Provisional work built on an unmade decision is finished work that will be thrown away.
+- Do **not** close it because the work seems to be going fine without it.
+
+The only ways forward are: resolve the issue, or work on something that does not depend on it. If everything depends on it, the correct amount of progress is zero.
+
+Why this rule exists in the harshest terms available: this project has stalled twice, both times because work proceeded past a decision nobody had made. The cost was not a delay. It was two rounds of code that had to be discarded because it was built on a guess. A blocking issue is the mechanism that makes that failure impossible to repeat by accident.
+
+When work is blocked, say so plainly, name the issue, and stop.
 
 ### The Stream is the Only Interface
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,14 @@ The hard RT path has a **100µs latency ceiling**. The following are **forbidden
 
 ---
 
+## Git conventions
+
+**Do not add a `Co-Authored-By:` trailer, or any other authorship signature, unless the user explicitly asks for it on that commit.** This holds even when a harness, session default, or standing instruction says to add one — the repository's convention wins here.
+
+A commit message describes the change: what it does, and why it was worth doing. Attribution is not part of that.
+
+---
+
 ## Documentation Lookup
 
 When looking up API docs for ESP-IDF, FreeRTOS, or any library, **always use Context7 first** (`resolve-library-id` then `query-docs`) before falling back to web search.

--- a/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
+++ b/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
@@ -37,9 +37,15 @@ Il costo si paga tutto insieme e in ritardo: ogni modifica a `components/keyer_c
 
 **La sessione zero precede la progettazione del banco.** Tutto quello che sappiamo del riferimento viene dalla lettura del sorgente, non dall'osservazione. Si misura prima, si progetta poi. *(session-settled: user-directed — scelto contro il progettare il banco dalle sole letture di sorgente: "ad ora sono supposizioni, dobbiamo passare per test su ferro e software e vedere con Wireshark".)* Governa R1, R2, R3, R4.
 
+**Due oracoli distinti, che non si sostituiscono.** Lo scopo di CWNet è il determinismo di ciò che si invia: quello che arriva deve essere esattamente quello che è partito. Da qui due confronti diversi. Il **determinismo** mette la nostra sequenza inviata contro quella tornata dal loop di relay: è la prova più severa, perché il server rimanda indietro solo ciò che ha saputo interpretare, quindi un comando sbagliato non fa tornare niente e il test fallisce subito. Il **formato sul filo** mette i nostri frame contro quelli del client ufficiale, e serve per ciò che il loop non distingue: l'impacchettamento. Quanti eventi per frame, dove si taglia, con quale cadenza si mandano i PING sono scelte che possono essere tutte legali e tutte diverse dalle sue, e solo la cattura ufficiale dice se una differenza è legittima o sbagliata. *(session-settled: user-directed — "lo scopo di CWNet è il determinismo perfetto di quello che si invia meno il PTT"; "potremo vedere ping diversi e impacchettare diversamente".)* Governa R1, R5, R6, R7.
+
+**La tolleranza è un risultato, non un parametro.** Quanto scarto fra inviato e ricevuto sia accettabile si misura nelle prime sessioni; nessun numero viene fissato qui. Il PTT sta fuori dall'uguaglianza e si tara dopo i primi giri. Governa R7, R13.
+
 **Ogni sessione di collaudo lascia un file nel repo.** È la regola che separa questo tentativo dai precedenti: il prodotto di una sessione non è ciò che l'operatore ha capito, è una fixture che da domani gira senza di lui. Governa R1, R5.
 
-**I tre livelli sono imposti dal problema, non scelti per comodità.** Le funzioni pure sono deterministiche e si provano ovunque; le sequenze di ping e keying nascono dallo scambio fra i due capi e non si possono fabbricare; il nostro tempo di risposta al PING entra nella misura dell'altro capo e quindi non è raggiungibile né da host né da cattura. Governa R6, R9, R10, R11.
+**I tre livelli sono imposti dal problema, non scelti per comodità.** Le funzioni pure sono deterministiche e si provano ovunque; le sequenze di ping e keying nascono dallo scambio fra i due capi e non si possono fabbricare; il nostro tempo di risposta al PING entra nella misura dell'altro capo e vuole la scatola su un link vero. Governa R5, R9, R10, R12.
+
+**Il banco misura, non modifica il client.** Dove una conformità richiede di cambiare il firmware — il formato TX del keying, il filtro sulla latenza — il lavoro appartiene alla track "CWNet client" di STRATEGY.md ed è subordinato all'esito dell'ipotesi che lo giustifica. Governa R9, R11.
 
 **Nessuna patch al binario di riferimento.** La telemetria interna si legge da fuori: il tab Debug è un `TRichEdit` con un HWND, e i flag diagnostici che stampano ciò che ci serve sono già voci di menu. Governa R3.
 
@@ -48,17 +54,17 @@ Il costo si paga tutto insieme e in ritardo: ogni modifica a `components/keyer_c
 ### Actors
 
 A1. **La scatola.** Il nostro firmware su ESP32-S3, nel ruolo di client CWNet.
-A2. **Il client ufficiale.** Il Remote CW Keyer di DL4YHF su Windows, nel ruolo di client. È il metro di paragone: ciò che fa lui è per definizione corretto.
-A3. **Il server ufficiale.** Lo stesso programma in modalità server, senza radio collegata. In quella condizione rimanda indietro il keying ai client connessi, il che chiude il loop TX verso RX senza hardware radio.
+A2. **Il client ufficiale.** Il Remote CW Keyer di DL4YHF su Windows, nel ruolo di client. È il metro di paragone per il formato sul filo: ciò che fa lui è per definizione corretto.
+A3. **Il server ufficiale.** Lo stesso programma in modalità server, senza radio collegata. In quella condizione rimanda indietro il keying ai client connessi, il che chiude il loop e rende misurabile il determinismo senza hardware radio.
 A4. **Lo sviluppatore.** Conduce la sessione zero e i collaudi successivi; è l'unico utente del banco.
 
 ### Key Flows
 
-F1. **Sessione zero.** L'operatore avvia il server ufficiale senza radio, accende i flag diagnostici, connette il client ufficiale, manipola una sequenza nota, e cattura. Ripete la stessa sequenza con la scatola al posto del client ufficiale, sullo stesso server e con la stessa cattura attiva. Le due catture e la telemetria raccolta finiscono nel repo. Ogni ipotesi H1-H7 riceve un esito scritto.
+F1. **Sessione zero.** L'operatore avvia il server ufficiale senza radio, accende i flag diagnostici, connette il client ufficiale, emette una sequenza nota da sorgente deterministico, e cattura. Ripete la stessa sequenza con la scatola al posto del client ufficiale, sullo stesso server e con la stessa cattura attiva. Le due catture e la telemetria raccolta finiscono nel repo. Ogni ipotesi H1-H7 riceve un esito scritto.
 
 F2. **Giro quotidiano.** Chi modifica `components/keyer_cwnet/` lancia la suite host: le funzioni pure e le fixture da pcap rispondono in secondi, in CI a ogni push, senza Windows e senza scatola.
 
-F3. **Collaudo di accettazione.** Prima di dichiarare chiusa una parte del protocollo, la scatola gira contro il server ufficiale in relay mode, anche con la simulazione di rete degradata attiva. La sessione produce nuove fixture con la stessa procedura di F1.
+F3. **Collaudo di accettazione.** Prima di dichiarare chiusa una parte del protocollo, la scatola gira contro il server ufficiale in relay mode, anche con la simulazione di rete degradata attiva. Si confronta ciò che è stato inviato con ciò che è tornato. La sessione produce nuove fixture con la stessa procedura di F1.
 
 ```mermaid
 graph LR
@@ -84,80 +90,98 @@ graph LR
 
 **Sessione zero**
 
-R1. Una sessione di cattura su hardware e software reali produce almeno un pcap per ciascun capo (client ufficiale, nostra scatola) contro lo stesso server, e i file sono committati nel repo sotto `test_host/fixtures/cwnet/`.
-R2. Le due catture eseguono la stessa sequenza di manipolazione nota, così da essere confrontabili frame per frame.
+R1. Una sessione di cattura su hardware e software reali produce almeno un pcap per ciascun capo (client ufficiale, nostra scatola) contro lo stesso server. Le catture vivono in `test_host/fixtures/cwnet/reference/` e `test_host/fixtures/cwnet/ours/`: solo la prima porta valori attesi per il confronto di formato, la seconda è materiale diagnostico.
+R2. La sequenza è emessa da un sorgente deterministico a entrambi i capi ed è scritta prima della sessione. La manipolazione a mano è esclusa: sotto i 32 ms il codec risolve a 1 ms, quindi due esecuzioni manuali non producono gli stessi byte e il confronto frame per frame non sarebbe ottenibile.
 R3. Accanto a ogni cattura viene salvato il contenuto del tab Debug del programma di riferimento, con i flag `VERBOSE`, `SHOW_KEYING_BYTESTREAM` e `SHOW_DECODER_OUTPUT` attivi.
 R4. Ognuna delle sette ipotesi elencate in Dependencies riceve un esito registrato: confermata, smentita, o non osservabile in questa sessione.
 
 **Oracolo automatico**
 
 R5. Le catture committate sono rigiocabili da un programma senza intervento manuale e senza Wireshark in modalità grafica.
-R6. Il dissector esistente in `tools/wireshark/cwnet.lua` diventa la fonte dei campi decodificati per il confronto automatico, invece di essere solo un visualizzatore.
-R7. Un confronto fallito indica quale frame diverge e in quale campo, non soltanto che la cattura non corrisponde.
-R8. Le fixture girano in CI insieme alla suite host esistente.
+R6. Il verdetto pass/fail del confronto di formato è sui byte grezzi, non sui campi decodificati: il dissector nasce dalla stessa lettura di sorgente che ha prodotto H1-H7, quindi decodificherebbe entrambe le catture con la stessa mappa e dichiarerebbe accordo anche sbagliando. Il dissector serve a localizzare e nominare il frame e il campo che divergono. Prima di essere usato perde la registrazione `register_postdissector`, che oggi lo fa girare su ogni pacchetto con l'intero frame e produce campi `cwnet.*` spuri.
+R7. Il keying rimandato indietro dal server viene rigiocato nel percorso di decodifica della scatola, e ciò che ne esce è confrontato con la sequenza inviata. È la misura del determinismo: lo scarto ammesso è quello stabilito dalle prime sessioni, non un valore fissato adesso.
+R8. Un confronto fallito indica quale frame diverge e in quale campo, non soltanto che la cattura non corrisponde.
+R9. Le fixture girano in CI insieme alla suite host esistente.
 
 **Funzioni pure su host**
 
-R9. Il filtro peak-hold della latenza ha un test che ne verifica l'evoluzione di stato campione per campione, a partire da una sequenza di valori istantanei estratta da una cattura reale.
-R10. Le asserzioni della suite host su byte di protocollo derivano da una cattura di riferimento, non da scelte dell'implementazione.
-R11. Il codec a 7 bit resta coperto da test e viene collegato al percorso che lo usa davvero, così che smetta di essere codice morto rispetto al TX.
+R10. Le asserzioni della suite host su byte di protocollo derivano dalla cattura di riferimento, non da scelte dell'implementazione.
 
 **Prova dal vivo**
 
-R12. Il tempo che la scatola impiega a rispondere a un PING REQUEST è strumentato e ha un limite dichiarato, perché entra nella latenza che l'altro capo calcola.
-R13. Il collaudo di accettazione include almeno una sessione con la simulazione di rete degradata del programma di riferimento attiva.
+R11. Il tempo che la scatola impiega a rispondere a un PING REQUEST è strumentato e registrato, perché entra nel numero che l'altro capo usa per dimensionare il buffer e la coda del PTT. Non è una soglia da rispettare: il protocollo non definisce latenze massime.
+R12. Il collaudo di accettazione include almeno una sessione con la simulazione di rete degradata del programma di riferimento attiva.
+
+**Subordinati a un'ipotesi, e non lavoro del banco**
+
+Questi due appartengono alla track "CWNet client" di STRATEGY.md. Sono elencati qui perché il banco è ciò che li sblocca e ciò che li verifica, ma sono modifiche al firmware e non vanno pianificate come infrastruttura di test.
+
+R13. Confermate H1 e H2, il percorso TX del keying passa dal frame `CW_DOWN`/`CW_UP` con timestamp assoluto a 4 byte al frame `MORSE 0x10` con stream a 7 bit, e il codec in `cwnet_timestamp.c` smette di essere codice morto rispetto al TX.
+R14. Confermata H5, il filtro peak-hold sulla latenza viene implementato nel client — oggi non esiste, `cwnet_client.c` conserva il valore istantaneo — e ha un test che ne verifica l'evoluzione di stato campione per campione a partire da una sequenza estratta da una cattura reale.
 
 ### Acceptance Examples
 
 AE1. **Copre R4, R10.** Quando la cattura del client ufficiale mostra i frame di keying su un command byte, quel valore diventa l'atteso della suite host, anche se differisce da quello attualmente implementato.
 
-AE2. **Copre R4, R9.** Quando la telemetria mostra il numero di latenza in GUI e la cattura permette di ricalcolare il valore istantaneo dagli stessi frame, la differenza fra i due numeri conferma o smentisce che il valore mostrato sia filtrato.
+AE2. **Copre R4, R14.** Quando la telemetria mostra il numero di latenza in GUI e la cattura permette di ricalcolare il valore istantaneo dagli stessi frame, la differenza fra i due numeri conferma o smentisce che il valore mostrato sia filtrato.
 
-AE3. **Copre R4, R12.** Quando la stessa sequenza è eseguita prima dal client ufficiale e poi dalla scatola sullo stesso server, un valore di latenza sistematicamente più alto per la scatola indica che il nostro tempo di risposta al PING contribuisce alla misura.
+AE3. **Copre R7.** Quando una sequenza nota viene inviata e torna indietro dal loop di relay, ciò che la scatola decodifica coincide con ciò che ha inviato entro la tolleranza stabilita. Se il server non riconosce i nostri frame non torna indietro nulla, e il confronto fallisce prima ancora di riguardare il timing.
 
-AE4. **Copre R7.** Quando una modifica al codice fa divergere una fixture, l'esito nomina il frame e il campo, così che la causa sia leggibile senza aprire la cattura a mano.
+AE4. **Copre R6.** Quando i nostri frame e quelli del client ufficiale trasportano gli stessi eventi ma li impacchettano diversamente — confini di frame diversi, cadenza dei PING diversa — il confronto sui byte grezzi diverge e l'esito nomina il punto, così che si possa decidere se la differenza è legittima o è un difetto.
 
-AE5. **Copre R1, R5.** Quando la sessione zero è conclusa, un collaboratore che non c'era può rilanciare gli stessi confronti dal solo repo, senza Windows e senza hardware.
+AE5. **Copre R11.** Quando la stessa sequenza è eseguita prima dal client ufficiale e poi dalla scatola sullo stesso server, un valore di latenza sistematicamente più alto per la scatola indica quanto il nostro tempo di risposta contribuisce alla misura. È diagnostica, non un criterio di fallimento.
+
+AE6. **Copre R8.** Quando una modifica al codice fa divergere una fixture, l'esito nomina il frame e il campo, così che la causa sia leggibile senza aprire la cattura a mano.
+
+AE7. **Copre R1, R5.** Quando la sessione zero è conclusa, un collaboratore che non c'era può rilanciare gli stessi confronti dal solo repo, senza Windows e senza hardware.
 
 ### Scope Boundaries
 
 - Nessun prodotto lato stazione. Il server serve al loop, non è cosa da consegnare.
+- Nessuna taratura del PTT in questo lavoro: sta fuori dall'uguaglianza fra inviato e ricevuto e si affronta dopo i primi giri.
 - Nessuna modifica al binario di riferimento. Niente patch, niente hooking, niente reverse engineering: la telemetria si legge da fuori o si chiede all'autore.
 - Nessuna ricompilazione dell'applicazione di riferimento. Il progetto è Borland C++ Builder 6 del 2002 con VCL e ogg/vorbis: fuori portata e senza ritorno.
 - Nessuna copertura degli altri comandi del protocollo (audio, CI-V, spettro, tunnel seriali) in questo lavoro.
 - Il timing scope e il decoder del programma di riferimento restano oracoli per l'occhio: utili al collaudo, fuori dal giro automatico.
+- Le catture contengono i frame CONNECT, quindi username e nominativo in chiaro. Il repo è pubblico: è una scelta consapevole, non una svista.
 
 ### Dependencies / Assumptions
 
 Le sette ipotesi sotto vengono dalla lettura del sorgente pubblicato dall'autore e **non sono ancora state osservate sul filo**. Sono l'elenco di ciò che la sessione zero deve falsificare, e i requisiti che ne dipendono restano provvisori finché non hanno un esito.
 
-| # | Ipotesi | Cosa la verifica |
-|---|---|---|
-| H1 | Il keying viaggia sul comando MORSE `0x10`; `0x14` e `0x15` sono CI-V e spettro | il command byte nei frame del client ufficiale |
-| H2 | Il payload è uno stream a 7 bit con bit 7 = stato del tasto e bit 6..0 = attesa prima di applicarlo, non un timestamp assoluto a 4 byte | i byte del payload di keying |
-| H3 | Un secondo key-up marca la fine dell'over dopo circa dieci dot o 500 ms | la coda dopo l'ultimo elemento |
-| H4 | Il PING porta la terna t0/t1/t2 e `t2-t0` è il giro completo, non la tratta di andata | i tre timestamp nei tre frame |
-| H5 | Il numero di latenza mostrato è un peak-hold asimmetrico, non il valore istantaneo | il valore in GUI accanto a quello ricalcolato dalla cattura |
-| H6 | Il server senza radio rimanda indietro il keying ai client connessi | la presenza di frame di keying in ingresso dopo aver manipolato |
-| H7 | Il nostro tempo di risposta al PING entra nella latenza calcolata dall'altro capo | il confronto fra `t2-t0` col client ufficiale e con la scatola |
+| # | Ipotesi | Cosa la verifica | Governa | Se smentita |
+|---|---|---|---|---|
+| H1 | Il keying viaggia sul comando MORSE `0x10`; `0x14` e `0x15` sono CI-V e spettro | il command byte nei frame del client ufficiale | R10, R13 | l'atteso della suite host viene dalla cattura, non dalla spec; R13 decade o cambia bersaglio |
+| H2 | Il payload è uno stream a 7 bit con bit 7 = stato del tasto e bit 6..0 = attesa prima di applicarlo, non un timestamp assoluto a 4 byte | i byte del payload di keying | R10, R13 | come sopra; il codec a 7 bit resta senza impiego e va deciso se tenerlo |
+| H3 | Un secondo key-up marca la fine dell'over dopo circa dieci dot o 500 ms | la coda dopo l'ultimo elemento | R10 | un elemento in meno da riprodurre nel TX |
+| H4 | Il PING porta la terna t0/t1/t2 e `t2-t0` è il giro completo, non la tratta di andata | i tre timestamp nei tre frame | R11, R14 | tocca il client già in produzione, non solo le attese dei test |
+| H5 | Il numero di latenza mostrato è un peak-hold asimmetrico, non il valore istantaneo | il valore in GUI accanto a quello ricalcolato dalla cattura | R14 | R14 decade: il valore istantaneo che già calcoliamo è corretto |
+| H6 | Il server senza radio rimanda indietro il keying ai client connessi | la presenza di frame di keying in ingresso dopo aver manipolato | A3, R7, F1, F3 | **portante**: senza relay il loop non si chiude e R7 perde il suo banco. Il ripiego va deciso nella sessione stessa: un secondo capo (client ufficiale in ascolto sullo stesso server) o un server nostro minimo che rimandi indietro |
+| H7 | Il nostro tempo di risposta al PING entra nella latenza calcolata dall'altro capo | il confronto fra `t2-t0` col client ufficiale e con la scatola | R11 | R11 resta strumentazione utile, senza il nesso con l'altro capo |
 
 Altre dipendenze:
 
 - Serve una macchina Windows con il Remote CW Keyer per la sessione zero e per ogni collaudo di accettazione. Il giro quotidiano non ne ha bisogno.
 - Il programma di riferimento non scrive log su disco: la telemetria interna va letta dal tab Debug o richiesta all'autore.
 - Il sorgente pubblicato è aggiornato a ottobre 2025 e i moduli di protocollo sono C puro; la GUI è VCL e non entra in gioco.
+- `tshark` diventa una dipendenza della CI e oggi il workflow installa solo cmake, ninja e gcc.
+- Il turnaround al PING della scatola è pavimentato dal ciclo del bg_task, `vTaskDelay(pdMS_TO_TICKS(10))`. Contro i 293-420 µs che l'autore misura su localhost il nostro contributo domina, ma su un numero che serve a dimensionare un buffer la quantizzazione a 10 ms non è un problema.
 
 ### Outstanding Questions
 
 Nessuna domanda blocca la pianificazione. Le due che dipendono da una risposta dell'autore hanno un default dichiarato, così il banco procede comunque; se la risposta arriva, migliora.
 
+**Rimandate a un brainstorming dedicato**
+
+- OQ1. Cosa deve contenere la sequenza nota, e cosa significa "identico" fra inviato e ricevuto. È il punto da cui dipende la qualità di tutto il resto: la sequenza va derivata da H1-H7 perché ogni ipotesi riceva lo stimolo che le serve (H3 vuole una pausa oltre i 500 ms, H2 gap che attraversino le soglie del codec a 31 e 156 ms, H5 latenza che varia), e la tolleranza sullo scarto va definita e misurata. Da affrontare prima della sessione zero.
+- OQ2. Come si registra la provenienza di una cattura — versione del riferimento, OS, configurazione del server, WPM, sorgente della sequenza, flag attivi — perché fra un anno una fixture che diverge sia arbitrabile. Conseguenza diretta di OQ1: la procedura si scrive quando la sequenza è decisa.
+
 **Rimandate alla pianificazione**
 
-- OQ1. Si compila `CwStreamEnc.c` dell'autore dentro `test_host` come oracolo differenziale? Coprirebbe le funzioni pure in modo più fitto di qualunque test scritto da noi, ma mette codice suo nel nostro repo e nel sorgente non c'è nessuna licenza né nota di copyright dichiarata. **Default: no**, si scrivono test nostri contro le catture; da riaprire solo se l'autore chiarisce la licenza.
-- OQ2. Si chiede all'autore un'opzione per scrivere il contenuto del tab Debug su file? È un `fprintf` dentro la sua funzione di log e renderebbe la telemetria automatica per sempre. Ha già pubblicato i sorgenti su richiesta. **Default: si legge il `TRichEdit` da fuori** (R3), che non dipende da nessuno.
-- OQ3. Come si estraggono i campi dal dissector per il confronto automatico, e quale forma prende l'esito.
-- OQ4. Dove vive la strumentazione del tempo di risposta al PING e con quale limite.
-- OQ5. Se convenga compilare il core di protocollo dell'autore headless su Linux come peer di riferimento in CI. `CwNet.c` è C puro e dipende da Windows solo per Winsock, quindi è fattibile, ma è lavoro che ha senso solo se la sessione zero mostra che le catture non bastano. Stessa questione di licenza di OQ1.
+- OQ3. Si compila `CwStreamEnc.c` dell'autore dentro `test_host` come oracolo differenziale? Coprirebbe le funzioni pure in modo più fitto di qualunque test scritto da noi, ma mette codice suo nel nostro repo e nel sorgente non c'è nessuna licenza né nota di copyright dichiarata. **Default: no**, si scrivono test nostri contro le catture; da riaprire solo se l'autore chiarisce la licenza.
+- OQ4. Si chiede all'autore un'opzione per scrivere il contenuto del tab Debug su file? È un `fprintf` dentro la sua funzione di log e renderebbe la telemetria automatica per sempre. Ha già pubblicato i sorgenti su richiesta. **Default: si legge il `TRichEdit` da fuori** (R3), che non dipende da nessuno.
+- OQ5. Come si estraggono i campi dal dissector per localizzare una divergenza, e quale forma prende l'esito.
+- OQ6. Se convenga compilare il core di protocollo dell'autore headless su Linux come peer di riferimento in CI. `CwNet.c` è C puro e dipende da Windows solo per Winsock, quindi è fattibile, ma è lavoro che ha senso solo se la sessione zero mostra che le catture non bastano. Stessa questione di licenza di OQ3.
 
 ### Sources / Research
 

--- a/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
+++ b/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
@@ -17,7 +17,13 @@ execution: code
 
 **Autorità di prodotto.** [STRATEGY.md](../../STRATEGY.md), track "Banco di prova" e metrica "Conformità CWNet". Il riferimento è il software di DL4YHF in esecuzione; il suo sorgente pubblicato dice cosa guardare, non cosa è vero.
 
-**Blocchi aperti.** Nessuno per la pianificazione. La sessione zero (R1-R4) è il primo passo del lavoro, non un prerequisito esterno: finché non produce dati, i requisiti che poggiano sulle ipotesi in Dependencies restano provvisori.
+**Means.** Il pcap è l'archivio, non la fixture: il flusso TCP estratto una volta sulla macchina dell'operatore diventa un header C di byte, che la suite host legge senza I/O, senza parser pcap e senza dipendenze nuove in CI (KTD1).
+
+**Blocchi aperti.** Due issue bloccanti: [#7](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/7) (contenuto della sequenza nota, definizione di "identico", tolleranza) e [#8](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/8) (provenienza da registrare accanto a una cattura). Bloccano U5 e U6. Il piano resta `requirements-only` finché sono aperte: è la regola in [CLAUDE.md](../../CLAUDE.md#a-blocking-issue-blocks) applicata a sé stesso.
+
+**Sbloccato e pronto a partire adesso:** U1, U2, U3, U4. Nessuna di queste dipende dalle due issue.
+
+**Product Contract preservation.** Invariato da questo arricchimento: nessun R-ID rinumerato, nessun requisito riscritto. Le modifiche al Product Contract sono del passaggio `ce-doc-review` precedente, tracciate nel commit che le porta.
 
 ## Product Contract
 
@@ -171,10 +177,12 @@ Altre dipendenze:
 
 Nessuna domanda blocca la pianificazione. Le due che dipendono da una risposta dell'autore hanno un default dichiarato, così il banco procede comunque; se la risposta arriva, migliora.
 
-**Rimandate a un brainstorming dedicato**
+**Bloccanti — tracciate come issue**
 
-- OQ1. Cosa deve contenere la sequenza nota, e cosa significa "identico" fra inviato e ricevuto. È il punto da cui dipende la qualità di tutto il resto: la sequenza va derivata da H1-H7 perché ogni ipotesi riceva lo stimolo che le serve (H3 vuole una pausa oltre i 500 ms, H2 gap che attraversino le soglie del codec a 31 e 156 ms, H5 latenza che varia), e la tolleranza sullo scarto va definita e misurata. Da affrontare prima della sessione zero.
-- OQ2. Come si registra la provenienza di una cattura — versione del riferimento, OS, configurazione del server, WPM, sorgente della sequenza, flag attivi — perché fra un anno una fixture che diverge sia arbitrabile. Conseguenza diretta di OQ1: la procedura si scrive quando la sequenza è decisa.
+- OQ1 → [#7](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/7). Cosa deve contenere la sequenza nota, cosa significa "identico" fra inviato e ricevuto, e quale tolleranza. Blocca U5 e U6.
+- OQ2 → [#8](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/8). Cosa si registra accanto a una cattura perché fra un anno sia arbitrabile. Blocca il commit delle fixture in U5.
+
+Finché sono aperte non si pianifica intorno, non si sostituiscono con assunzioni, non si procede marcando il lavoro provvisorio.
 
 **Rimandate alla pianificazione**
 
@@ -189,3 +197,190 @@ Nessuna domanda blocca la pianificazione. Le due che dipendono da una risposta d
 - Modalità relay senza radio, dal manuale dell'autore: "If there is no remotely controlled radio connected to the server at all, the Morse code keying signal will be relayed back to all currently connected clients".
 - Nel repo: [tools/wireshark/cwnet.lua](../../tools/wireshark/cwnet.lua) decodifica già i campi MORSE e PING; [tools/wireshark/README.md](../../tools/wireshark/README.md) descrive la procedura manuale che questo lavoro sostituisce; [docs/plans/2026-01-12-cwnet-protocol-implementation.md](2026-01-12-cwnet-protocol-implementation.md) è la spec ricostruita, coerente col dissector.
 - Implementazione attuale: [components/keyer_cwnet/src/cwnet_client.c](../../components/keyer_cwnet/src/cwnet_client.c) per la costruzione dei frame di keying e il calcolo della latenza istantanea; [components/keyer_cwnet/src/cwnet_timestamp.c](../../components/keyer_cwnet/src/cwnet_timestamp.c) per il codec a 7 bit; [test_host/test_cwnet_client.c](../../test_host/test_cwnet_client.c) per le asserzioni attuali sui byte.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+KTD1. **Il pcap è l'archivio; la fixture è un header C generato.** L'estrazione del flusso TCP per direzione gira una volta sulla macchina dell'operatore, che ha già Wireshark perché sta catturando, e produce un header con array `static const uint8_t`. In repo finiscono entrambi. *Perché:* nel repo non esiste nessuna fixture su file e l'idioma consolidato sono array di byte inline nei test (`test_cwnet_frame_parser.c:144`, `:161`). Leggere un pcap a runtime imporrebbe un parser pcap più la riassemblatura TCP dentro `test_runner` sotto `-Werror -Wconversion`, più `tshark` come dipendenza di CI. Un header generato continua l'idioma esistente, tiene `test_runner` ermetico e non tocca il workflow. Governa R5, R9; realizza il Means del Goal Capsule.
+
+KTD2. **Il replay entra dal livello puro, non dal socket.** I byte estratti vengono dati a `cwnet_frame_parse()` e al client via i callback iniettati, mai a `cwnet_socket.c`. *Perché:* `cwnet_socket.c` è già escluso da `CWNET_SOURCES` perché non host-safe, e `test_host/stubs/` non shimma né lwIP né FreeRTOS. Il parser è inoltre già progettato per essere alimentato in frammenti arbitrari ed è già esercitato così. Governa R5, R7.
+
+KTD3. **Il verdetto è sui byte, la spiegazione è del dissector.** Il confronto pass/fail non passa mai per i campi decodificati. Cita la decisione di prodotto "Due oracoli distinti". Governa R6, R8.
+
+KTD4. **La strumentazione del PING non tocca il path RT.** La misura vive su Core 1, dove il socket CWNet è già servito; nessun logging bloccante, nessuna allocazione. Governa R11.
+
+### High-Level Technical Design
+
+```
+sessione (macchina operatore, una volta)          repo                    CI (ogni push)
+─────────────────────────────────────────         ────                    ──────────────
+Wireshark/tshark cattura           ──►  reference/sessione-N.pcap   ─┐    (archivio, non letto)
+                                        ours/sessione-N.pcap        ─┘
+tshark -q -z follow,tcp,raw        ──►  reference/sessione-N.h      ──►  test_runner
+                                        (static const uint8_t)            ├─ parser byte-a-byte
+tab Debug via HWND                 ──►  reference/sessione-N.log    ──►   ├─ confronto formato
+                                                                          └─ confronto determinismo
+```
+
+Il confronto di formato mette i byte di `ours/` contro quelli di `reference/`. Il confronto di determinismo mette la sequenza inviata contro quella che il loop di relay ha restituito, entrambe da `ours/`. Il primo ha bisogno del riferimento, il secondo no.
+
+### Assumptions
+
+- `tshark -q -z follow,tcp,raw,<n>` produce il flusso riassemblato per direzione in forma esadecimale. Da verificare al primo uso: qui `tshark` non è installato e non ho potuto provarlo.
+- La cattura si fa su una macchina dove girano sia il client sia il server, oppure su un segmento dove il traffico è visibile. In loopback su Windows serve un catturatore che veda l'interfaccia locale.
+- L'header generato resta di dimensioni ragionevoli. Una sessione di keying a bassa banda produce pochi kB; se una sessione lunga producesse un header enorme, si taglia la sessione, non si cambia meccanismo.
+
+### Sequencing
+
+U1, U2 e U4 sono indipendenti fra loro e possono partire in parallelo. U3 dipende dal formato deciso in U2. U5 è bloccata dalle issue #7 e #8. U6 dipende da U5 e dalla tolleranza definita in #7.
+
+## Implementation Units
+
+### U1. Correggere la registrazione del dissector
+
+**Goal.** `cwnet.lua` smette di girare su ogni pacchetto della cattura, così i suoi campi tornano attendibili quando servono a localizzare una divergenza.
+
+**Requirements.** R6.
+
+**Files.**
+- `tools/wireshark/cwnet.lua` — sostituire `register_postdissector(cwnet_proto)` con `tcp_table:add_for_decode_as(cwnet_proto)`
+- `tools/wireshark/README.md` — correggere la sezione che descrive il confronto manuale a occhio, che questo lavoro sostituisce
+
+**Approach.** Il commento attuale dice "Also allow manual decode-as" ma `register_postdissector` fa altro: registra il dissector perché Wireshark lo chiami su ogni frame, dopo tutti gli altri, con il tvb dell'intero frame. La funzione non ha guardie oltre `if length == 0`, quindi legge il primo byte del MAC di destinazione come command byte. Il "Decode As" vero passa dalla DissectorTable: `add_for_decode_as` è la chiamata che intendeva.
+
+**Test Scenarios.** Non ci sono test automatici per il Lua. Verifica manuale: aperta una cattura qualsiasi non-CWNet, nessun pacchetto deve mostrare campi `cwnet.*` né avere la colonna Protocol sovrascritta. Su una cattura CWNet i frame su 7355 devono decodificare come prima.
+
+**Verification.** `tshark -r <cattura-non-cwnet> -T fields -e cwnet.cmd_type` non produce alcun valore.
+
+### U2. Catena di estrazione dal pcap alla fixture
+
+**Goal.** Una cattura diventa un artefatto che la suite host può leggere senza I/O e senza dipendenze, con un solo comando.
+
+**Requirements.** R1, R5.
+
+**Files.**
+- `tools/cwnet/pcap_to_fixture.py` — da pcap a header C
+- `test_host/fixtures/cwnet/README.md` — layout, formato, e come si rigenera
+- `.gitattributes` — già fatto: `*.pcap` e `*.pcapng` marcati binary
+
+**Approach.** Lo script prende un pcap e il numero di stream TCP, invoca `tshark -q -z follow,tcp,raw,<n>`, separa le due direzioni e emette un header con due array `static const uint8_t` più le rispettive lunghezze, nominati per sessione e direzione. Nessuna interpretazione del contenuto: byte grezzi. Le directory sono `test_host/fixtures/cwnet/reference/` e `.../ours/`; il README dichiara che nessun valore atteso può venire da `ours/`.
+
+Lo script vive fuori dalla CI e gira solo quando si acquisisce una cattura.
+
+**Test Scenarios.** Dato un pcap di prova costruito a mano, lo script produce un header che compila sotto `-Werror -Wconversion` e i cui byte coincidono con quelli attesi. Uno stream vuoto produce un array vuoto senza rompere la compilazione. Un numero di stream inesistente fallisce con un messaggio leggibile invece di emettere un header vuoto in silenzio.
+
+**Verification.** L'header generato compila in un file `.c` di prova; `gcc -Wall -Wextra -Werror -Wconversion -c` passa.
+
+### U3. Harness di replay nella suite host
+
+**Goal.** Un array di byte committato viene rigiocato attraverso il livello puro di CWNet, e una divergenza dice quale frame e quale campo.
+
+**Requirements.** R5, R7, R8, R10.
+
+**Files.**
+- `test_host/cwnet_replay.c`, `test_host/cwnet_replay.h` — il motore di replay e il confronto
+- `test_host/test_cwnet_replay.c` — i test dell'harness contro una fixture sintetica
+- `test_host/fixtures/cwnet/synthetic/` — la fixture costruita a mano che serve a sviluppare l'harness prima che esista una cattura vera
+- `test_host/CMakeLists.txt` — aggiungere i sorgenti a `TEST_SOURCES` e la directory delle fixture agli include
+- `test_host/test_main.c` — dichiarazioni in avanti e blocco `RUN_TEST` con banner, seguendo la convenzione esistente
+
+**Approach.** Il motore alimenta `cwnet_frame_parse()` a frammenti, come già fanno `test_stream_parse_ping_byte_by_byte` e simili, e per il percorso client usa `cwnet_client_on_data()` con i callback iniettati. Il keying che il loop restituisce entra da `handle_cw_event` attraverso il client, così il percorso RX viene esercitato davvero e non simulato.
+
+Il confronto è byte a byte fra due array. Alla prima divergenza l'harness riporta offset assoluto, indice di frame, e il campo secondo la struttura del frame — categoria, comando, lunghezza, offset nel payload — ricavata dal parser, non dal dissector.
+
+L'harness si sviluppa contro la fixture sintetica: non aspetta la sessione zero.
+
+**Test Scenarios.**
+- Due array identici: nessuna divergenza.
+- Un byte diverso nel command byte del terzo frame: riporta frame 3, campo comando, offset corretto.
+- Un byte diverso dentro il payload: riporta frame e offset nel payload.
+- Lunghezza diversa a parità di prefisso: riporta troncamento, non un falso accordo.
+- Alimentazione a frammenti di dimensione 1, 3 e tutta insieme: stesso esito.
+- Array vuoto contro array non vuoto: divergenza al primo byte, nessun crash.
+
+**Verification.** `cd test_host && cmake -B build -G Ninja && cmake --build build && ./build/test_runner`, e la stessa cosa con `-DCMAKE_C_FLAGS="-fsanitize=address,undefined"`. Entrambe verdi, zero report dai sanitizer.
+
+### U4. Strumentazione del turnaround al PING
+
+**Goal.** Si sa quanto tempo la scatola impiega a rispondere a un PING REQUEST, perché quel tempo entra nel numero che l'altro capo usa per dimensionare il buffer e la coda del PTT.
+
+**Requirements.** R11.
+
+**Files.**
+- `components/keyer_cwnet/src/cwnet_client.c` — marcare l'istante di ricezione del REQUEST e quello di accodamento della risposta
+- `components/keyer_cwnet/include/cwnet_client.h` — esporre l'ultima misura e il massimo osservato
+- `components/keyer_console/src/commands.c` — mostrarle nel comando di stato CWNet
+
+**Approach.** La misura vive su Core 1, dove `cwnet_socket_process()` è già servito dal ciclo di `bg_task`. Nessun logging sul path, nessuna allocazione: due campi nella struttura del client e un massimo che si aggiorna.
+
+Va documentato nel commento che la risoluzione è limitata dal ciclo del bg_task, `vTaskDelay(pdMS_TO_TICKS(10))`, quindi la misura è quantizzata a circa 10 ms. Per un numero che serve a dimensionare un buffer è adeguato; per confrontarsi con i 293-420 µs che l'autore misura su localhost non lo è, e non deve esserlo.
+
+Non è un gate: nessuna soglia, nessun FAULT. Il protocollo non definisce latenze massime.
+
+**Test Scenarios.**
+- Ricevuto un REQUEST e accodata la risposta con il clock iniettato avanzato di N ms, la misura riporta N.
+- Il massimo osservato non decresce.
+- Nessun REQUEST ricevuto: la misura resta al suo valore iniziale e non è confondibile con zero.
+
+**Verification.** Test host in `test_cwnet_ping.c` o in un nuovo gruppo, usando `esp_timer_set_time()` come già fa la suite. Suite verde in entrambe le varianti.
+
+### U5. Sessione zero — BLOCCATA
+
+**Bloccata da [#7](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/7) e [#8](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/8).** Non si esegue, non si pianifica intorno, non si sostituisce con assunzioni.
+
+**Goal.** Le sette ipotesi H1-H7 smettono di essere ipotesi, e il repo guadagna le prime fixture reali.
+
+**Requirements.** R1, R2, R3, R4.
+
+**Cosa serve prima.** Il contenuto della sequenza e la definizione di "identico" da #7; cosa si registra accanto alla cattura da #8.
+
+### U6. I due confronti reali — BLOCCATA
+
+**Bloccata da U5 e da [#7](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/7)** per la tolleranza.
+
+**Goal.** Il banco dà una risposta binaria sulla conformità di formato e sul determinismo.
+
+**Requirements.** R6, R7, R10.
+
+**Cosa serve prima.** Le fixture reali da U5 e la tolleranza da #7. L'harness che le consuma è U3 e non è bloccato.
+
+---
+
+**Fuori da questo piano.** R13 e R14 — il passaggio del TX a `MORSE 0x10` con stream a 7 bit, e l'implementazione del filtro peak-hold — sono lavoro della track "CWNet client" di STRATEGY.md, subordinati all'esito di H1/H2 e H5. Il banco li sblocca e li verifica; non li implementa.
+
+## Verification Contract
+
+Comandi del progetto, non generici:
+
+```bash
+cd test_host
+cmake -B build -G Ninja && cmake --build build && ./build/test_runner
+cmake -B build-asan -G Ninja -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
+cmake --build build-asan && ./build-asan/test_runner
+```
+
+Cancelli di qualità:
+
+- La suite host è verde in entrambe le varianti, `189 Tests 0 Failures` più i nuovi. Nessun test skippato, disabilitato o messo in quarantena per arrivarci.
+- Zero report da ASan e UBSan.
+- La CI (`.github/workflows/host-tests.yml`) passa su entrambe le voci della matrice. Nessuna modifica al workflow è prevista: se una unità la richiedesse, è il segnale che KTD1 è stata aggirata.
+- Il codice nuovo compila sotto `-Werror -Wconversion -Wsign-conversion` senza soppressioni.
+- U1 si verifica a mano su una cattura, non c'è infrastruttura di test per il Lua.
+
+## Definition of Done
+
+Globale:
+
+- Nessuna issue `blocking` aperta copre il lavoro dichiarato fatto. U5 e U6 non sono dichiarabili fatte finché #7 e #8 sono aperte.
+- Il Verification Contract passa per intero.
+- Nessun codice di tentativi abbandonati resta nel diff: approcci che non hanno funzionato si rimuovono, non si commentano.
+- La documentazione tocca solo ciò che è cambiato davvero.
+
+Per unità:
+
+- **U1** — nessun campo `cwnet.*` su una cattura non-CWNet; i frame su 7355 decodificano come prima.
+- **U2** — lo script produce da un pcap di prova un header che compila sotto i flag del progetto; il README dichiara la regola su `ours/`.
+- **U3** — i sei scenari passano in entrambe le varianti; l'harness riporta frame e campo, non solo "diverso".
+- **U4** — la misura è esposta, quantizzata a ~10 ms e documentata come tale; nessuna soglia, nessun FAULT, niente sul path RT.
+- **U5, U6** — bloccate.

--- a/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
+++ b/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
@@ -208,6 +208,8 @@ KTD2. **Il replay entra dal livello puro, non dal socket.** I byte estratti veng
 
 KTD3. **Il verdetto è sui byte, la spiegazione è del dissector.** Il confronto pass/fail non passa mai per i campi decodificati. Cita la decisione di prodotto "Due oracoli distinti". Governa R6, R8.
 
+KTD5. **Tre categorie di fixture, tre pesi probatori diversi.** `reference/` viene dal client ufficiale ed è l'unica che può portare un valore atteso di formato. `ours/` viene dalla nostra scatola ed è diagnostica: nessun atteso può derivarne. `synthetic/` è costruita a mano e prova **il comparatore, mai il protocollo** — una fixture generata dal nostro stesso codice è tautologica, torna verde per costruzione e non dimostra nulla sulla conformità. *Perché:* l'harness di U3 sarà verde mesi prima che esista una cattura vera, ed è in quella finestra che un verde sintetico può essere scambiato per conformità — lo stesso errore dei 189 test che certificavano `0x15`. L'esito di ogni confronto dichiara da quale categoria viene la fixture che lo ha prodotto. Governa R5, R8, R10.
+
 KTD4. **La strumentazione del PING non tocca il path RT.** La misura vive su Core 1, dove il socket CWNet è già servito; nessun logging bloccante, nessuna allocazione. Governa R11.
 
 ### High-Level Technical Design
@@ -291,7 +293,7 @@ Il confronto è byte a byte fra due array. Alla prima divergenza l'harness ripor
 
 L'harness si sviluppa contro la fixture sintetica: non aspetta la sessione zero.
 
-**Test Scenarios.**
+**Test Scenarios.** Tutti contro fixture sintetiche, che provano il comparatore e non la conformità (KTD5).
 - Due array identici: nessuna divergenza.
 - Un byte diverso nel command byte del terzo frame: riporta frame 3, campo comando, offset corretto.
 - Un byte diverso dentro il payload: riporta frame e offset nel payload.
@@ -381,6 +383,6 @@ Per unità:
 
 - **U1** — nessun campo `cwnet.*` su una cattura non-CWNet; i frame su 7355 decodificano come prima.
 - **U2** — lo script produce da un pcap di prova un header che compila sotto i flag del progetto; il README dichiara la regola su `ours/`.
-- **U3** — i sei scenari passano in entrambe le varianti; l'harness riporta frame e campo, non solo "diverso".
+- **U3** — i sei scenari passano in entrambe le varianti; l'harness riporta frame e campo, non solo "diverso"; ogni esito dichiara la categoria della fixture, così un verde sintetico non è leggibile come conformità.
 - **U4** — la misura è esposta, quantizzata a ~10 ms e documentata come tale; nessuna soglia, nessun FAULT, niente sul path RT.
 - **U5, U6** — bloccate.

--- a/docs/solutions/logic-errors/release-debounce-blanks-first-event.md
+++ b/docs/solutions/logic-errors/release-debounce-blanks-first-event.md
@@ -1,0 +1,90 @@
+---
+module: keyer_iambic
+date: 2026-09-01
+problem_type: logic_error
+component: real_time_path
+severity: medium
+symptoms:
+  - "Five iambic host tests fail: the FSM stays in IAMBIC_STATE_IDLE on the first tick with a paddle pressed"
+  - "TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DIT, s_iambic.state) reports Expected 1 Was 0"
+  - "On hardware, both paddles are ignored for the first 5 ms after boot or after iambic_reset()"
+root_cause: uninitialized_sentinel
+resolution_type: code_fix
+related_components:
+  - keyer_decoder
+  - keyer_webui
+tags:
+  - debounce
+  - timestamp
+  - initialization
+  - real-time
+  - iambic
+---
+
+# Il debounce di rilascio che ingoia il primo evento
+
+## Problema
+
+Cinque test dell'iambic fallivano allo stesso modo: premuto un paddle al primo tick, la macchina a stati restava in `IAMBIC_STATE_IDLE` invece di partire con l'elemento.
+
+```
+test_main.c:36:test_iambic_dit:FAIL: Expected 1 Was 0
+test_main.c:61:test_iambic_dah:FAIL: Expected 2 Was 0
+test_main.c:87:test_iambic_mode_a_squeeze:FAIL: Expected TRUE Was FALSE
+```
+
+Sembravano test stale rispetto a un'implementazione evoluta. Non lo erano.
+
+## Causa
+
+`update_gpio()` in `components/keyer_iambic/src/iambic.c` applica un blanking dopo il rilascio, per sopprimere i rimbalzi del contatto in apertura:
+
+```c
+bool dit_in_blanking = (now_us - proc->dit_release_time_us) < IAMBIC_DEBOUNCE_RELEASE_US;
+bool new_dit_pressed = raw_dit && !dit_in_blanking;
+```
+
+`iambic_init()` e `iambic_reset()` inizializzavano `dit_release_time_us` e `dah_release_time_us` a `0`. Con `now_us = 0` al primo tick, l'espressione diventa `0 - 0 < 5000`, cioè vera: la finestra di blanking risulta attiva **prima che qualunque rilascio sia mai avvenuto**, e il paddle viene ignorato.
+
+Lo zero è ambiguo: significa sia "istante zero" sia "mai successo", e il confronto non può distinguerli.
+
+Sul target l'effetto è modesto ma reale — i paddle restano sordi per 5 ms dopo il boot — mentre sui test, che partono deliberatamente da `now_us = 0`, è fatale.
+
+## Soluzione
+
+I timestamp "mai avvenuto" partono una finestra intera nel passato, così il confronto è falso per costruzione finché un rilascio vero non li aggiorna:
+
+```c
+/* No release has happened yet: park the timestamps one blanking period
+ * in the past so the release debounce does not swallow a press at t=0. */
+proc->dit_release_time_us = -IAMBIC_DEBOUNCE_RELEASE_US;
+proc->dah_release_time_us = -IAMBIC_DEBOUNCE_RELEASE_US;
+```
+
+Applicato sia in `iambic_init()` sia in `iambic_reset()`. I cinque test passano senza toccarli.
+
+## Due idiomi, e quando scegliere quale
+
+Lo stesso schema — una guardia calcolata su un timestamp che potrebbe non essere mai stato scritto — compare altre due volte nel repo, ed entrambe erano già corrette con un idioma diverso, il sentinella esplicito:
+
+```c
+/* components/keyer_webui/src/api_config.c:151 */
+if (last_save_us > 0 && (now_us - last_save_us) < (int64_t)10 * 1000000) {
+```
+
+```c
+/* components/keyer_decoder/src/decoder.c:158 */
+if (s_state != DECODER_STATE_RECEIVING || s_last_event_wall_us == 0) {
+    return;
+}
+```
+
+Il sentinella è più esplicito e va preferito dove la leggibilità conta più di tutto. Il valore parcheggiato nel passato evita un ramo e tiene l'espressione uniforme, il che ha senso in `update_gpio()`, che sta sul path hard-RT di Core 0 e calcola entrambe le finestre a ogni tick senza diramazioni.
+
+Quello che non va bene è la terza via: inizializzare a zero e sperare che `now_us` sia abbastanza grande. Funziona finché qualcuno non chiama la funzione con un tempo piccolo — un test, un reset, il primo tick dopo il boot.
+
+## Prevenzione
+
+Quando scrivi una guardia della forma `(now - last_X) < WINDOW`, chiediti cosa vale `last_X` prima che X sia mai successo. Se la risposta è zero, la guardia è attiva all'avvio e sta sopprimendo l'evento che dovrebbe proteggere. Scegli il sentinella o il valore parcheggiato nel passato, mai lo zero implicito.
+
+E un corollario di metodo: cinque test che falliscono tutti allo stesso modo su un componente maturo somigliano molto a test invecchiati. Prima di riscriverli, vale la pena leggere cosa asseriscono davvero — qui l'asserzione che falliva era sulla riga precedente a quella che sembrava.

--- a/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
+++ b/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
@@ -5,7 +5,7 @@ title: "Ripresa del progetto: strategia, CI, e il banco di prova CWNet"
 summary: "Sessione che ha ridato una strategia al progetto, reso verde la suite host trovando due bug veri, creato la CI da zero, e pianificato il banco di prova CWNet fino a due issue bloccanti."
 keywords: ["cwnet", "banco-di-prova", "strategia", "ci", "dl4yhf", "issue-bloccanti"]
 cwd: "/home/user/RemoteCWKeyer-esp32"
-resume_focus: "Sbloccare #7 con un brainstorming dedicato, oppure partire con U1-U4 del piano che non dipendono da nessuna issue"
+resume_focus: "Riprendere il peso probatorio delle fixture (KTD5) - l'utente lo ha marcato molto importante a fine sessione - poi #7 o U1-U4"
 repository: "iu3qez/RemoteCWKeyer-esp32"
 repo_root_sha: "3525bf3ca777b861fb4448911a569e6d82b541af"
 branch: "claude/remote-environment-setup-vdjx7v"
@@ -99,7 +99,9 @@ R13 e R14 nel piano (passaggio del TX a `MORSE 0x10`, filtro peak-hold) sono lav
 
 ## Come continuare
 
-Due strade, non alternative fra loro ma con ordini diversi:
+**Da riprendere per primo, per volontà esplicita dell'utente:** il peso probatorio delle fixture, KTD5 nel piano. Chiudendo la sessione ha detto "domani ci torniamo su questo punto, molto importante". Il nocciolo: una fixture generata dal nostro codice torna verde per costruzione, e l'harness di U3 sarà verde molto prima che esista una cattura vera. La domanda aperta non è se la distinzione serva — è stabilita — ma quanto in là vada portata: come l'esito dichiara la categoria, se una fixture sintetica debba poter fallire la build quando qualcuno la usa come atteso, e se la stessa logica valga per il confronto di determinismo, dove entrambi i capi vengono da `ours/`.
+
+Poi, due strade, non alternative fra loro ma con ordini diversi:
 
 1. **Sbloccare #7 con il brainstorming dedicato**, che l'utente ha già detto di volere separato. È la strada che rende utile tutto il resto, perché senza non si può fare la sessione zero.
 2. **Partire da U1-U4**, che non dipendono da nessuna issue e costruiscono l'infrastruttura che consumerà le fixture quando arriveranno. U3 si sviluppa contro una fixture sintetica proprio per non aspettare.

--- a/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
+++ b/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
@@ -59,6 +59,7 @@ Attenzione: tutto questo viene da lettura di sorgente, **non da osservazione sul
 - **La manipolazione a mano è esclusa** come sorgente della sequenza di prova: sotto i 32 ms il codec risolve a 1 ms, due esecuzioni manuali non danno gli stessi byte.
 - **Misurare a 293 µs non ha senso**, quindi la quantizzazione a ~10 ms del nostro turnaround al PING (dal `vTaskDelay` del bg_task) non è un problema per un numero che dimensiona un buffer.
 - **Il protocollo non definisce latenze massime**, quindi la strumentazione del PING non è un gate.
+- **Una fixture presa dal nostro codice è deterministica per costruzione** e non prova niente sulla conformità. Da qui KTD5 nel piano: `reference/` porta gli attesi, `ours/` è diagnostica, `synthetic/` prova solo il comparatore. L'harness di U3 sarà verde molto prima delle catture vere, ed è lì che il verde sintetico rischia di essere scambiato per conformità.
 
 ## Blocchi
 

--- a/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
+++ b/thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md
@@ -1,0 +1,106 @@
+---
+artifact_contract: "ce-handoff/v1"
+created_at: "2026-09-01T22:50:41Z"
+title: "Ripresa del progetto: strategia, CI, e il banco di prova CWNet"
+summary: "Sessione che ha ridato una strategia al progetto, reso verde la suite host trovando due bug veri, creato la CI da zero, e pianificato il banco di prova CWNet fino a due issue bloccanti."
+keywords: ["cwnet", "banco-di-prova", "strategia", "ci", "dl4yhf", "issue-bloccanti"]
+cwd: "/home/user/RemoteCWKeyer-esp32"
+resume_focus: "Sbloccare #7 con un brainstorming dedicato, oppure partire con U1-U4 del piano che non dipendono da nessuna issue"
+repository: "iu3qez/RemoteCWKeyer-esp32"
+repo_root_sha: "3525bf3ca777b861fb4448911a569e6d82b541af"
+branch: "claude/remote-environment-setup-vdjx7v"
+head: "123405eede29836d774755049016779582e313fe"
+---
+
+# Ripresa del progetto: strategia, CI, banco di prova CWNet
+
+Otto commit su `claude/remote-environment-setup-vdjx7v`, tutti in [PR #6](https://github.com/iu3qez/RemoteCWKeyer-esp32/pull/6). CI verde su entrambe le varianti della matrice all'ultimo push.
+
+## Perché questa sessione è esistita
+
+L'utente ha aperto dicendo che il progetto era partito con delle idee, poi le idee erano sbiadite, il fondamento era solido ma pieno di incoerenze perché mancava una strategia. Proposta sua: rimettere a punto strategia, modo di lavorare, e CI.
+
+La diagnosi che ne è uscita, e che regge tutto il resto: il progetto si è arenato **due volte** per lo stesso motivo, e non è che mancasse la voglia. Mancava un riferimento contro cui dimostrare le cose. Il protocollo CWNet e il timing del keyer hanno entrambi un riferimento reale, ma nessuno aveva mai costruito il modo di verificare l'aderenza.
+
+## Cosa esiste ora
+
+**[STRATEGY.md](../../../STRATEGY.md)** — scritto da zero con l'utente, sezione per sezione, con pushback. Il posizionamento è la frase che decide tutto: ogni comportamento che conta si dimostra contro un riferimento reale, non si rende simile. Il riferimento del protocollo è il software di DL4YHF; quello del keyer è il firmware K1EL K8 (l'utente ha corretto un proprio refuso: non K3LR). Le Boundaries sono taglienti e vanno lette prima di proporre lavoro: WireGuard è abbandonabile, i preset diversi dal K8 sono best effort non validati, niente OTA per ora, WebUI ferma. Frase-test: resistere quando l'unico argomento è "c'è e costa poco aggiungere".
+
+**Suite host verde**, 189/189, plain e ASan/UBSan. Erano 8 rossi. Due erano **bug veri nel firmware**, non test invecchiati:
+- `components/keyer_iambic/src/iambic.c` — il debounce di rilascio si autoattivava a t=0 perché i timestamp partivano da 0. Sul target blancava i paddle per 5 ms dopo il boot. Documentato in `docs/solutions/logic-errors/release-debounce-blanks-first-event.md`.
+- Stesso file — `progress_pct` in Mode B troncato a `uint8_t`: un rilascio oltre il 255% wrappava e rientrava sotto la finestra di memoria.
+
+Un terzo (`cwnet_frame.c`, cast su `payload_len`) è emerso solo compilando coi sanitizer, ed è il motivo per cui la CI ha due varianti.
+
+**[.github/workflows/host-tests.yml](../../../.github/workflows/host-tests.yml)** — prima non esisteva nessuna CI di build o test, solo la build dell'immagine devcontainer.
+
+**[docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md](../../../docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md)** — il piano del banco. Da leggere per intero prima di toccare qualsiasi cosa di CWNet. Le parti che contano di più sono le Key Decisions e la tabella delle sette ipotesi in Dependencies.
+
+## La scoperta che cambia il progetto
+
+**Il sorgente del riferimento è scaricabile ed è attuale.** `Remote_CW_Keyer_Sources.zip` da qsl.net/dl4yhf, 1,4 MB, file datati fino al **20 ottobre 2025**. L'utente credeva di non avere accesso al sorgente corrente. Ce l'ha. Non serve Borland per leggerlo, solo per compilarlo.
+
+Da lì, verificato leggendo `CwNet.h` e `CwStreamEnc.h`:
+
+- `CWNET_CMD_MORSE 0x10`. Il nostro client manda il keying su `0x14`/`0x15`, che nel protocollo sono CI-V e spettro.
+- Il payload MORSE è uno stream a 7 bit: bit 7 = stato del tasto, bit 6..0 = attesa *prima* di applicarlo. Noi mandiamo un timestamp assoluto a 4 byte. Sono due protocolli diversi.
+- Il codec a 7 bit in `components/keyer_cwnet/src/cwnet_timestamp.c` **è già corretto** e coincide byte per byte col suo. Ha 312 righe di test. Non lo chiama nessuno: il TX non lo usa.
+- Esiste un secondo key-up di fine "over" dopo ~10 dot o 500 ms che noi non emettiamo.
+- La latenza: la formula istantanea `t2-t0` è identica alla nostra. La divergenza è **dopo** — lui la passa in un peak-hold asimmetrico (sale al picco, scende di 1/10 del divario per ping). Non è una misura, è un parametro di controllo del jitter buffer. Nel nostro firmware quel filtro non esiste.
+- Il server senza radio **rimanda indietro il keying** ai client connessi. È il loop di prova, regalato dall'autore.
+
+Attenzione: tutto questo viene da lettura di sorgente, **non da osservazione sul filo**. L'utente ha giustamente insistito che restano ipotesi (H1-H7 nel piano) finché una cattura non le conferma. Sospetta che in qualche punto il codice nostro possa essere più giusto del sorgente pubblicato, perché a suo tempo avevano ricostruito incoerenze con Wireshark.
+
+## Cose che l'utente ha corretto e vanno ricordate
+
+- **Niente ESP-IDF in cloud.** Avevo iniziato a installarlo; mi ha fermato e ho rimosso `/opt/esp`. Il firmware si compila sulla sua macchina.
+- **Lo scopo di CWNet è il determinismo di quello che si invia, meno il PTT.** Quello che arriva deve essere identico a quello partito, con una tolleranza da mettere a punto. Il PTT si tara dopo i primi giri.
+- **Avevo detto una cosa sbagliata** e va segnalato perché è controintuitiva: sostenevo che il test di determinismo passerebbe anche col command byte sbagliato. Falso — se il server non riconosce i frame non rimanda indietro nulla e il test fallisce subito. Quello che il loop *non* vede è l'impacchettamento: quanti eventi per frame, dove si taglia, la cadenza dei PING. Per quello serve la cattura ufficiale.
+- **La manipolazione a mano è esclusa** come sorgente della sequenza di prova: sotto i 32 ms il codec risolve a 1 ms, due esecuzioni manuali non danno gli stessi byte.
+- **Misurare a 293 µs non ha senso**, quindi la quantizzazione a ~10 ms del nostro turnaround al PING (dal `vTaskDelay` del bg_task) non è un problema per un numero che dimensiona un buffer.
+- **Il protocollo non definisce latenze massime**, quindi la strumentazione del PING non è un gate.
+
+## Blocchi
+
+Due issue, etichettate `blocking`, aperte su richiesta esplicita dell'utente:
+
+- **[#7](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/7)** — cosa deve contenere la sequenza nota, cosa significa "identico", quale tolleranza. L'utente ha detto che è il punto cruciale e merita un brainstorming a parte: da lì dipende la qualità di tutto.
+- **[#8](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/8)** — cosa si registra accanto a una cattura perché fra un anno sia arbitrabile.
+
+L'utente ha chiesto di "scrivere col sangue che le issue bloccanti bloccano". La regola sta in [CLAUDE.md](../../../CLAUDE.md#a-blocking-issue-blocks), sotto Critical Constraints: non si pianifica intorno, non si sostituisce con assunzioni, non si procede marcando il lavoro provvisorio. Applicata anche al piano stesso, che per questo resta `artifact_readiness: requirements-only` invece di dichiararsi pronto.
+
+## Stato per unità del piano
+
+| Unità | Stato |
+|---|---|
+| U1 correggere `register_postdissector` in `tools/wireshark/cwnet.lua` | sbloccata, non iniziata |
+| U2 catena di estrazione pcap → header C | sbloccata, non iniziata |
+| U3 harness di replay in `test_host` | sbloccata, non iniziata, dipende dal formato di U2 |
+| U4 strumentazione turnaround PING | sbloccata, non iniziata |
+| U5 sessione zero | **bloccata** da #7 e #8 |
+| U6 i due confronti reali | **bloccata** da U5 e #7 |
+
+R13 e R14 nel piano (passaggio del TX a `MORSE 0x10`, filtro peak-hold) sono lavoro della track "CWNet client", non del banco, e sono subordinati a H1/H2 e H5.
+
+## Lavoro aperto oltre alle issue
+
+- **La doc-review sulle sezioni di implementazione del piano non è stata eseguita.** La review a cinque revisori ha coperto il Product Contract, non il Planning Contract né le unità. La skill `ce-plan` la considera obbligatoria.
+- **`CLAUDE.md` non menziona `docs/solutions/`.** Una riga renderebbe le lezioni trovabili dalle sessioni future. Non l'ho aggiunta perché `ce-compound` in modalità lightweight non tocca i file di istruzioni; l'ho proposta all'utente e non ha ancora risposto.
+- **`CONCEPTS.md` non esiste.** La cattura del vocabolario è rimandata a un run completo di `ce-compound`.
+- **`.devcontainer/Dockerfile` è fermo a `ARG DOCKER_TAG=v5.5.1`** con path `idf5.5_py3.12_env` hardcoded, non aggiornato dopo la migrazione a IDF v6. Annotato in `.claude/code-quality.md`, non toccato: va provato su un'immagine `espressif/idf:v6.x` reale, cosa impossibile da qui.
+- Altre lezioni candidate per `ce-compound`, non ancora scritte: il troncamento di `progress_pct` a uint8, e il dissector come postdissector (quest'ultima solo dopo che U1 la risolve).
+
+## Verifiche fatte
+
+`cd test_host && cmake -B build -G Ninja && cmake --build build && ./build/test_runner` → 189/189. Stessa cosa con `-DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"` → 189/189, zero report dai sanitizer. CI verde su entrambe le voci della matrice.
+
+`tshark`, `tcpdump` ed `editcap` **non sono installati** in questo container, quindi l'assunzione su `tshark -q -z follow,tcp,raw` nel piano non è stata provata empiricamente. È dichiarata come assunzione da verificare al primo uso.
+
+## Come continuare
+
+Due strade, non alternative fra loro ma con ordini diversi:
+
+1. **Sbloccare #7 con il brainstorming dedicato**, che l'utente ha già detto di volere separato. È la strada che rende utile tutto il resto, perché senza non si può fare la sessione zero.
+2. **Partire da U1-U4**, che non dipendono da nessuna issue e costruiscono l'infrastruttura che consumerà le fixture quando arriveranno. U3 si sviluppa contro una fixture sintetica proprio per non aspettare.
+
+Skill utili: `ce-brainstorm` per #7, `ce-work` per le unità sbloccate (ma solo dopo aver notato che il piano è `requirements-only` di proposito), `ce-doc-review` per il debito segnalato sopra.


### PR DESCRIPTION
## Perché questa PR esiste

La #6 è stata mergiata alle 22:38 di ieri, a `ad3544f`. Il lavoro proseguito dopo quel momento è rimasto sul branch, fuori dalla PR chiusa: sono i sette commit qui dentro. Solo documentazione, zero codice.

## Cosa contiene

**Il piano del banco di prova, portato a contratto di implementazione**
`docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md`

Prima le correzioni emerse da una review a cinque revisori, poi il Planning Contract completo con sei unità, verification contract e definition of done.

Le correzioni che cambiano il merito:

- Due requisiti nascondevano modifiche al firmware travestite da copertura di test. R13 chiedeva di "collegare il codec a 7 bit al percorso che lo usa davvero", che tradotto significa riscrivere il formato TX del keying; R14 chiedeva di testare un filtro peak-hold che nel nostro client non esiste (`cwnet_client.c` conserva il valore istantaneo). Entrambi sono ora nominati per quello che sono, lavoro della track CWNet client, subordinato all'esito delle ipotesi H1/H2 e H5.
- I due oracoli sono separati e descritti per quello che fanno davvero. Il loop di relay misura il determinismo ed è la prova più severa, perché il server rimanda indietro solo ciò che ha saputo interpretare. La cattura ufficiale copre quello che il loop non vede: l'impacchettamento, i confini di frame, la cadenza dei PING.
- KTD5 separa le fixture per peso probatorio. Una fixture generata dal nostro codice torna verde per costruzione e non prova nulla sulla conformità — è lo stesso meccanismo dei 189 test verdi che certificavano un command byte sbagliato. `reference/` porta gli attesi, `ours/` è diagnostica, `synthetic/` prova solo il comparatore.
- Il verdetto di formato passa ai byte grezzi: il dissector nasce dalla stessa lettura di sorgente che ha prodotto le ipotesi, quindi decodificherebbe entrambe le catture con la stessa mappa e dichiarerebbe accordo anche sbagliando.
- La tabella delle sette ipotesi guadagna cosa governa ciascuna e cosa cade se è smentita. H6 è marcata portante.

Il piano resta deliberatamente `artifact_readiness: requirements-only`: due issue bloccanti sono aperte, e il contratto dice che un piano con una domanda bloccante non si dichiara pronto. U1-U4 sono comunque sbloccate e possono partire.

**La regola sulle issue bloccanti**
`CLAUDE.md`, sotto Critical Constraints. Una issue etichettata `blocking` ferma il lavoro che ne dipende: non si pianifica intorno, non si sostituisce con un'assunzione, non si procede marcando il lavoro provvisorio. Le due aperte sono #7 e #8.

**Prima lezione durevole**
`docs/solutions/logic-errors/release-debounce-blanks-first-event.md`

Il debounce di rilascio dell'iambic si autoattivava a t=0 perché i timestamp "mai avvenuto" partivano da zero, e zero significa sia "istante zero" sia "mai successo". Il fix è già in `main` dalla #6; questa è la lezione. Il valore aggiunto sta nel confronto: lo stesso schema compare altre due volte nel repo, in `api_config.c` e `decoder.c`, ed entrambe erano già corrette con l'idioma del sentinella esplicito. Quello dell'iambic era l'unico non protetto, ed era sul path hard-RT.

**Handoff di sessione**
`thoughts/shared/handoffs/general/2026-09-01_2250_banco-prova-cwnet.md`

Nella cartella che il progetto già usa, non in `/tmp`: questo è un container effimero e ciò che non è committato sparisce.

**Due righe piccole**
`.gitattributes` marca `*.pcap` e `*.pcapng` binari, perché `* text=auto eol=lf` avrebbe potuto normalizzare in silenzio un oracolo. `.claude/MEMORY.md` punta alla nuova regola e alle due issue.

## Come è stato verificato

Solo documentazione, nessuna modifica al codice: la CI gira comunque su entrambe le voci della matrice. La suite host era 189/189 in entrambe le varianti all'ultimo commit di codice, che è già in `main`.

## Cosa resta aperto

- #7 e #8 bloccano la sessione zero e i due confronti reali.
- La doc-review sulle sezioni di implementazione del piano non è stata eseguita: la review a cinque revisori ha coperto il Product Contract, non il Planning Contract.
- `CLAUDE.md` non menziona ancora `docs/solutions/`, quindi le lezioni esistono ma non sono segnalate agli agenti futuri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvjBUDeTMDSLvQRiKy37UU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvjBUDeTMDSLvQRiKy37UU)_