### PR TITLE
CWNet zero session: five hypotheses closed against the real reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ ESP32-based CW (Morse code) keyer with a pure C implementation using ESP-IDF v6.
 ## Build & Run
 
 ```bash
-# ESP-IDF environment
+# ESP-IDF v6 environment. IDF_PATH is per-machine: point it at your install.
+export IDF_PATH=~/esp/esp-idf
 source "$IDF_PATH/export.sh"
 
 # Frontend deps (first time only)
@@ -105,7 +106,9 @@ The project was migrated from ESP-IDF v5 to v6. Things to know:
 
 ## Critical Constraints
 
-These rules are **non-negotiable**. Violating any of them will break real-time guarantees.
+These rules are **non-negotiable**. The first three govern how work is decided and
+tracked; the rest are the real-time rules, and violating any of those will break the
+timing guarantees.
 
 ### A Blocking Issue Blocks
 
@@ -137,7 +140,13 @@ A debt earns an issue when at least one is true:
 
 Then: one issue per problem, say what is wrong and what would make it right, and if it is blocked on a decision label it `blocking` — **A Blocking Issue Blocks** applies from that moment.
 
-**Everything lighter, just fix it.** A stale path, a wrong version, a rotten README line, a typo in a doc — anything you can correct *correctly* on the spot, where the fix is obvious and needs nobody's opinion. Filing those is QRM: it buries the issues that carry a real decision under a list nobody wants to read. If you cannot fix it correctly on the spot because you would be guessing, that is precisely the signal it needed an issue.
+**Everything lighter, just fix it.** A stale path, a rotten README line, a typo in a doc — anything you can correct *correctly* on the spot, where the fix is obvious and needs nobody's opinion. Filing those is QRM: it buries the issues that carry a real decision under a list nobody wants to read. If you cannot fix it correctly on the spot because you would be guessing, that is precisely the signal it needed an issue.
+
+**The four conditions win over "lighter".** They are not two tests to weigh against each other: if any condition holds, it is an issue, however small the edit looks. A one-line version bump you cannot verify here is an issue, not a light fix — the size of the diff is not the size of the risk.
+
+**A light fix still meets the Definition of done.** "Obvious" buys you the ceremony, never the evidence: a light change touching `keyer_cwnet/` or `keyer_iambic/` still ships with the host test that pins the behaviour against the reference.
+
+**One item, one home.** When something is already an open issue, it does not also live in the notes file, and the issue is authoritative. Where both exist today, the notes entry is the stale one.
 
 When a light debt cannot be fixed right now — wrong moment, unrelated to what you are doing — it goes as one line under **Da sistemare** in [.claude/code-quality.md](.claude/code-quality.md), never on the tracker. A session handoff carries only the subset the next session actually needs; it is not the backlog either.
 
@@ -145,7 +154,9 @@ That file also keeps *context* — what was tried, what was learnt. Context and 
 
 ### Changing How We Work Requires Review
 
-A change to the way of working — the rules in this file, the definition of done, what earns an issue, how a plan or a handoff is structured — **is reviewed before it stands**, like any other change.
+A change to the **normative** rules — the constraints in this file, the definition of done, what earns an issue, how a plan or a handoff is structured — is reviewed by the **maintainer** before it is acted on at scale. Correcting a fact in this file (a command, a path, a link, a version) is not a way-of-working change: fix those on the spot like any other light debt.
+
+**What "before it stands" means here.** This file is loaded into every session from the working tree, so a rule is in force the moment it is written — there is no state in which it is written but dormant. The reviewable window is therefore the **pull request**: a new normative rule lands on a branch, is reviewed there by the maintainer, and is not applied to anything beyond the change that introduced it until that review happens. An agent reviewing its own rule does not count; the point of the rule is a human in the loop.
 
 The reason is on the record above. The issue rule in the section before this one was written, applied immediately, and produced ten issues in one pass — two of which were QRM that had to be closed the same hour, because the rule as first written said "a problem, a debt, a stub" and drew no line at all. A wrong process rule does not fail loudly the way wrong code does: it quietly produces wrong work, in volume, and every piece of that work looks like it followed the rules.
 
@@ -199,15 +210,14 @@ When looking up API docs for ESP-IDF, FreeRTOS, or any library, **always use Con
 
 ## Session Memory
 
-Persistent notes live in `.claude/` and are tracked in git:
+Durable notes and knowledge, all tracked in git. **None of these is the work queue** — that is the GitHub tracker; see **Work That Needs Deciding Becomes an Issue**.
 
-- **[.claude/MEMORY.md](.claude/MEMORY.md)** — Memory index (loaded into every conversation)
-- **[.claude/feature-status.md](.claude/feature-status.md)** — Feature checklist by priority
-- **[.claude/code-quality.md](.claude/code-quality.md)** — Cleanup items, stubs, recent fixes
+- **[.claude/MEMORY.md](.claude/MEMORY.md)** — Memory index, loaded into every conversation. Keep it under 200 lines.
+- **[.claude/code-quality.md](.claude/code-quality.md)** — Context and light debt: what was tried, what was learnt, and small things not yet fixed.
+- **[.claude/feature-status.md](.claude/feature-status.md)** — Feature checklist by priority. Predates the issue rule and still lists work that now belongs on the tracker; read it for status, do not add to it.
 - **[docs/solutions/](docs/solutions/)** — Documented solutions to past problems (bugs, best practices, patterns), by category, with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in a documented area.
 - **[CONCEPTS.md](CONCEPTS.md)** — Shared domain vocabulary (CWNet, keying stream, timing). Relevant when orienting to the codebase or discussing domain concepts.
-
-Update these files as features are completed or new issues are found. Keep MEMORY.md concise (under 200 lines).
+- **[thoughts/shared/handoffs/](thoughts/shared/handoffs/)** — Session handoffs: what a following session needs to pick the work back up, and why it was left where it was.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,14 @@ When a light debt cannot be fixed right now — wrong moment, unrelated to what 
 
 That file also keeps *context* — what was tried, what was learnt. Context and light debt, not the work queue.
 
+### Changing How We Work Requires Review
+
+A change to the way of working — the rules in this file, the definition of done, what earns an issue, how a plan or a handoff is structured — **is reviewed before it stands**, like any other change.
+
+The reason is on the record above. The issue rule in the section before this one was written, applied immediately, and produced ten issues in one pass — two of which were QRM that had to be closed the same hour, because the rule as first written said "a problem, a debt, a stub" and drew no line at all. A wrong process rule does not fail loudly the way wrong code does: it quietly produces wrong work, in volume, and every piece of that work looks like it followed the rules.
+
+So: state the rule, say what it changes and what it would have changed in the recent past, and get it reviewed before acting on it at scale. Applying a fresh process rule to a backlog in the same breath as writing it is how you find out it was too broad — afterwards.
+
 ### The Stream is the Only Interface
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ ESP32-based CW (Morse code) keyer with a pure C implementation using ESP-IDF v6.
 
 ```bash
 # ESP-IDF environment
-source /home/sf/esp/esp-idf/export.sh
+source "$IDF_PATH/export.sh"
 
 # Frontend deps (first time only)
 cd components/keyer_webui/frontend && npm install && cd -
@@ -123,6 +123,25 @@ The only ways forward are: resolve the issue, or work on something that does not
 Why this rule exists in the harshest terms available: this project has stalled twice, both times because work proceeded past a decision nobody had made. The cost was not a delay. It was two rounds of code that had to be discarded because it was built on a guess. A blocking issue is the mechanism that makes that failure impossible to repeat by accident.
 
 When work is blocked, say so plainly, name the issue, and stop.
+
+### Work That Needs Deciding Becomes an Issue
+
+Real work — work someone has to **choose** to do — goes in a GitHub issue, in English, when it is found. It does not go only into a notes file, a plan's prose, or a session handoff: those are read by whoever is already inside the work, while an issue is read by whoever is deciding what to do next.
+
+A debt earns an issue when at least one is true:
+
+- It needs a **decision** before it can be done, or the fix commits us to something.
+- It is **big enough to schedule** — it will not happen inside whatever you are doing now.
+- It **cannot be validated here** (needs hardware, a Windows box, a real image build).
+- Leaving it costs something that compounds: wrong behaviour, wrong expectations, work built on a guess.
+
+Then: one issue per problem, say what is wrong and what would make it right, and if it is blocked on a decision label it `blocking` — **A Blocking Issue Blocks** applies from that moment.
+
+**Everything lighter, just fix it.** A stale path, a wrong version, a rotten README line, a typo in a doc — anything you can correct *correctly* on the spot, where the fix is obvious and needs nobody's opinion. Filing those is QRM: it buries the issues that carry a real decision under a list nobody wants to read. If you cannot fix it correctly on the spot because you would be guessing, that is precisely the signal it needed an issue.
+
+When a light debt cannot be fixed right now — wrong moment, unrelated to what you are doing — it goes as one line under **Da sistemare** in [.claude/code-quality.md](.claude/code-quality.md), never on the tracker. A session handoff carries only the subset the next session actually needs; it is not the backlog either.
+
+That file also keeps *context* — what was tried, what was learnt. Context and light debt, not the work queue.
 
 ### The Stream is the Only Interface
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ Persistent notes live in `.claude/` and are tracked in git:
 - **[.claude/MEMORY.md](.claude/MEMORY.md)** — Memory index (loaded into every conversation)
 - **[.claude/feature-status.md](.claude/feature-status.md)** — Feature checklist by priority
 - **[.claude/code-quality.md](.claude/code-quality.md)** — Cleanup items, stubs, recent fixes
+- **[docs/solutions/](docs/solutions/)** — Documented solutions to past problems (bugs, best practices, patterns), by category, with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in a documented area.
+- **[CONCEPTS.md](CONCEPTS.md)** — Shared domain vocabulary (CWNet, keying stream, timing). Relevant when orienting to the codebase or discussing domain concepts.
 
 Update these files as features are completed or new issues are found. Keep MEMORY.md concise (under 200 lines).
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,31 @@
+# Concepts
+
+> Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Protocollo
+
+### CWNet
+Il protocollo di rete del Remote CW Keyer di DL4YHF, che trasporta keying CW, audio, controllo radio e telemetria su un'unica connessione TCP. È il golden standard verso cui il progetto dimostra la propria compatibilità: non se ne fa un clone, se ne replica il comportamento osservabile sul percorso CW.
+
+### Golden standard
+L'implementazione di riferimento — client e server DL4YHF in esecuzione — contro cui ogni comportamento che conta viene *dimostrato*, non *reso simile*. Il suo sorgente pubblicato dice cosa guardare, non cosa è vero: la verità sono i byte sul filo, non il codice né i suoi commenti.
+*Avoid:* riferimento (quando ambiguo).
+
+## Keying
+
+### MORSE keying stream
+Il flusso di keying CW trasportato da CWNet come sequenza di byte a 7 bit — non testo, non un timestamp assoluto per evento. Ogni byte porta lo stato del tasto (giù/su) e il tempo di attesa prima di applicarlo. Viaggia su un proprio comando dedicato, distinto da quelli di CI-V, spettro e audio.
+
+### 7-bit timestamp
+La codifica non lineare del tempo di attesa fra due transizioni del tasto: risoluzione fine per gli intervalli brevi, via via più grossolana per quelli lunghi, così da coprire un ampio arco temporale in sette bit. Il codec è per costruzione a perdita sugli intervalli lunghi — il protocollo stesso quantizza il timing.
+
+### Over
+Un turno di trasmissione continuo. La sua fine è segnalata da un secondo comando di key-up dopo che è trascorsa una soglia di silenzio; il silenzio *fra* un over e il successivo non viaggia sul filo, quindi il determinismo del keying si può pretendere dentro un over, non fra over diversi.
+
+## Latenza
+
+### PING
+Lo scambio di misura del tempo di andata e ritorno, in tre fasi con tre timestamp: l'iniziatore segna la partenza, il peer inserisce il proprio, l'iniziatore segna l'arrivo. La differenza si calcola sempre sull'orologio di chi ha iniziato — il timestamp del peer serve solo alla diagnostica, mai a una sottrazione.
+
+### Peak-hold latency
+Il valore di latenza mostrato e usato per dimensionare il jitter buffer: sale immediatamente a ogni nuovo picco e scende lentamente, quindi diverge dal valore istantaneo di round-trip in presenza di jitter. È un parametro di controllo, non una misura istantanea.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,46 @@
-# RemoteCWKeyerV3
+# RemoteCWKeyer-esp32
 
-CW  keyer with remote operation capability, built in Rust for ESP32-S3/P4 platforms.
+A small ESP32-S3 box that lets you work a remote station in CW with your own paddle.
 
+It speaks **CWNet**, the network protocol of the
+[Remote CW Keyer](https://www.qsl.net/dl4yhf/Remote_CW_Keyer/Remote_CW_Keyer.htm)
+by Wolfgang Buescher, **DL4YHF** — so it connects to an existing Remote CW Keyer
+server the same way his client does. All credit for the protocol, and for the
+program this project is built to be compatible with, goes to him.
+
+## Why
+
+Today both ends of a CWNet link are a Windows PC. This project replaces the
+operator's end with a dedicated box: you plug in a paddle and headphones and
+operate, with no PC in the middle, no RS-232 to wire and nothing to configure
+at the station end.
+
+Compatibility with DL4YHF's program is the point of the project, not a
+side effect — behaviour is proven against that reference rather than made to
+look similar.
+
+## Status
+
+Early, and honest about it: the CW keyer and the CWNet client work, the
+protocol is still being tightened against the reference, and the remote
+operating experience is not finished. It is ready when it is ready.
 
 ## Hardware
 
-- **Target**: ESP32-S3, ESP32-P4 (dual-core with PSRAM)
-- **Paddle Input**: GPIO with internal pull-up
-- **Audio Output**: I2S DAC for sidetone
-- **TX Output**: GPIO for transmitter keying
+- **Target**: ESP32-S3
+- **Paddle input**: GPIO with internal pull-up
+- **Audio output**: I2S DAC for the sidetone
+- **TX output**: GPIO for keying the transmitter
 
 ## License
-GPL 
+
+[GPL-3.0](LICENSE).
 
 ## Contributing
 
-Contributions must comply with [ARCHITECTURE.md](ARCHITECTURE.md). Non-compliant PRs will not be merged.
+Contributions must comply with [ARCHITECTURE.md](ARCHITECTURE.md).
+Non-compliant PRs will not be merged.
 
 ## SAST Tools
 
-[PVS-Studio](https://pvs-studio.com/en/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C, C++, C#, and Java code.
+[PVS-Studio](https://pvs-studio.com/en/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) — static analyzer for C, C++, C#, and Java code.

--- a/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
+++ b/docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md
@@ -165,6 +165,20 @@ Le sette ipotesi sotto vengono dalla lettura del sorgente pubblicato dall'autore
 | H6 | Il server senza radio rimanda indietro il keying ai client connessi | la presenza di frame di keying in ingresso dopo aver manipolato | A3, R7, F1, F3 | **portante**: senza relay il loop non si chiude e R7 perde il suo banco. Il ripiego va deciso nella sessione stessa: un secondo capo (client ufficiale in ascolto sullo stesso server) o un server nostro minimo che rimandi indietro |
 | H7 | Il nostro tempo di risposta al PING entra nella latenza calcolata dall'altro capo | il confronto fra `t2-t0` col client ufficiale e con la scatola | R11 | R11 resta strumentazione utile, senza il nesso con l'altro capo |
 
+**Esiti della sessione zero parziale (2026-09-05).** Cattura reale del client ufficiale DL4YHF (utente con permesso TRANSMIT) verso un server DL4YHF senza radio, tramite un tap TCP; più lettura del sorgente pubblicato. Metodo e strumenti in [docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md](../solutions/architecture-patterns/reference-source-as-differential-oracle.md).
+
+| # | Esito | Evidenza |
+|---|---|---|
+| H1 | **confermata** | keying su `MORSE 0x10` (wire `0x50`); `0x14`/`0x15` sono CI-V e spettro nel sorgente e non compaiono nel keying |
+| H2 | **confermata** | payload stream a 7 bit come da ipotesi; il nostro `cwnet_timestamp.c` è identico byte per byte a `CwStreamEnc.c` su tutto il dominio (confronto esaustivo, UBSan pulito) |
+| H3 | **confermata, precisata** | secondo key-up di fine over presente; la soglia è **14 dot-time**, non «10 dot o 500 ms» — il commento del sorgente è errato, il codice (`KeyerThread.c`) e i byte concordano |
+| H4 | **confermata** | PING = byte di fase (00 REQUEST, 01 RESPONSE_1, 02 RESPONSE_2) + tre int32 LE; `t2-t0` sull'orologio dell'iniziatore |
+| H5 | **confermata** | il valore mostrato è un peak-hold asimmetrico con un difetto di divisione intera che lo pianta a `istantaneo + <10 ms`; osservato nel log GUI (`pk` fermo a 7 ms per 90 s con istantaneo 1–5) e replicato dai byte |
+| H6 | **smentita** | il server **non** rimanda indietro il keying: `MorseTxFifo` si riempie solo se `iFunctionality == CWNET_FUNC_CLIENT` (`KeyerThread.c`), e un'istanza server non emette mai `CWNET_CMD_MORSE`. Il loop di determinismo richiede un server-echo nostro (ripiego già previsto). |
+| H7 | **non osservabile in questa sessione** | richiede la nostra scatola sul filo; il client ufficiale da solo non lo mostra |
+
+Scoperte non previste: il PTT viaggia come stringa rigctld (`set_ptt 1/0`) in frame `0x06`, non come comando dedicato; il client **impacchetta** più eventi per frame quando ne trova in coda (a ≤40 WPM se ne vede uno solo perché il poll è ~20 ms), quindi il ricevitore deve accettare N eventi per frame; i permessi sono una bitmask (TALK 1, TRANSMIT 2, CTRL_RIG 4, ADMIN 8); l'app scrive `debug_run_log.txt` se lanciata con `/debug` (contrariamente all'assunzione «non scrive log su disco»).
+
 Altre dipendenze:
 
 - Serve una macchina Windows con il Remote CW Keyer per la sessione zero e per ogni collaudo di accettazione. Il giro quotidiano non ne ha bisogno.

--- a/docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md
+++ b/docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md
@@ -1,0 +1,81 @@
+---
+module: keyer_cwnet
+date: 2026-09-05
+problem_type: architecture_pattern
+component: testing_framework
+severity: high
+applies_when:
+  - "Serve dimostrare la conformità di keyer_cwnet al Remote CW Keyer di DL4YHF"
+  - "Un comportamento del protocollo poggia su una lettura di sorgente non ancora osservata sul filo"
+  - "Il riferimento è un binario Windows/Borland non ricompilabile su questa toolchain"
+  - "Il traffico da catturare gira su loopback e Npcap/Wireshark non lo intercetta"
+root_cause: missing_tooling
+resolution_type: tooling_addition
+related_components:
+  - test_host
+tags:
+  - cwnet
+  - dl4yhf
+  - oracle
+  - conformance
+  - differential-testing
+  - protocol
+  - tcp-tap
+---
+
+# Il sorgente del riferimento compilato come oracolo differenziale
+
+## Contesto
+
+La suite host aveva 189 test verdi che asserivano byte di protocollo **mai confrontati con il riferimento**: l'atteso e l'implementazione pescavano dalla stessa `#define`, quindi il test misurava l'implementazione contro sé stessa. È l'episodio `0x15` — il nostro TX manda il keying su `CWNET_CMD_CW_UP = 0x14` e `CWNET_CMD_CW_DOWN = 0x15` (`components/keyer_cwnet/include/cwnet_client.h:63-64`), che nel protocollo vero sono CI-V e spettro; il keying viaggia su `MORSE 0x10`. Verde per costruzione, sbagliato di fatto.
+
+La difficoltà: il golden standard è un eseguibile Windows compilato con Borland C++ Builder 6, non ricompilabile qui, e i suoi sorgenti pubblicati (`Remote_CW_Keyer_Sources.zip`, qsl.net/dl4yhf) sono incompleti — `CwNet.c` include header della libreria personale dell'autore che non sono nell'archivio (`StringLib.h`, `yhf_type.h`, `QFile.h`, `YHF_*.h`) e l'autore non li fornisce.
+
+## Guida
+
+Tre mosse, in ordine di forza probatoria.
+
+**1. Compila il modulo puro del riferimento come oracolo differenziale.** `CwStreamEnc.c` (il codec dello stream di keying) è 230 righe di C puro: dipende solo da `<string.h>` e da quattro typedef (`BYTE`, `WORD`, `DWORD`, `BOOL`), forniti con uno shim `yhf_type.h`. Compila al primo colpo con `clang -I shim`. Non usa `long`, `float` né `double` — solo interi a larghezza fissa — quindi le due fonti classiche di divergenza fra compilatori (modello dati ILP32 vs LP64, x87 vs SSE) **non si applicano**. Il dominio di ingresso è minuscolo (0–1040 ms in un verso, 0–127 nell'altro): il confronto contro il nostro `cwstream_encode_timestamp()` e `cwstream_decode_timestamp()` (`components/keyer_cwnet/src/cwnet_timestamp.c`) si fa **esaustivo, non campionato**. Esito: zero scarti su tutto il dominio, con UBSan pulito.
+
+**2. Quando il suo strato di rete non compila, non ti serve.** `CwNet.c` (4177 righe, 11 include di progetto) è fuori portata, ma il suo strato di rete non aggiunge verità: i byte sul filo li legge il *nostro* parser (`cwnet_frame_parse()`, `components/keyer_cwnet/include/cwnet_frame.h:124`). Alimentando i flussi grezzi al nostro parser più il *suo* codec per il payload, si decodifica una cattura reale senza ricompilare una riga della sua rete.
+
+**3. Cattura il loopback con un tap TCP, non con Npcap.** Quando client e server DL4YHF girano nella stessa VM e il loopback non è catturabile, un relay TCP trasparente in Python (il client punta al tap, il tap inoltra al server) registra i due versi come byte grezzi. Niente Wireshark, niente Npcap, niente sudo, niente estrazione pcap. L'unico effetto collaterale è la ri-segmentazione TCP, irrilevante perché a valle si lavora sul flusso riassemblato.
+
+## Perché conta
+
+Un oracolo ricompilato da un sorgente pubblicato è un riferimento **più debole** del binario in distribuzione: possono divergere (il CI-V del sorgente è dimostrabilmente più avanti dell'app). Quindi l'oracolo non è il riferimento — è un candidato che si guadagna il posto. Il suo primo test è: *dato lo stesso stimolo, riproduce byte per byte una cattura del binario vero?* Se sì, ha dimostrato la sua fedeltà su quel percorso e può generare i casi che la cattura non copre. Se no, non hai perso nulla: hai scoperto **dove** sorgente e binario divergono, che è l'informazione che mancava.
+
+Questo inverte il difetto dell'episodio `0x15`: l'atteso smette di venire da noi e viene da un artefatto esterno falsificabile.
+
+## Quando applicarla
+
+Prima di asserire come si comporta il protocollo DL4YHF, e ogni volta che una decisione poggia su una lettura del suo sorgente. Il sorgente dice **cosa guardare**, non cosa è vero: la conferma viene dai byte. Corollario emerso qui — il commento di `CwStreamEnc.c` sul fine over dice «ten dot-times or 500 ms», ma il codice (`KeyerThread.c`, `t_us > 14000 * iDotTime_ms`) e la cattura dicono **14 dot-time**. Il commento è sorgente quanto il codice, e può mentire; arbitrano i byte.
+
+## Esempi
+
+Confronto esaustivo del codec (l'oracolo differenziale):
+
+```c
+/* diff_main.c — suo codec vs nostro, tutto il dominio */
+for (int ms = -50; ms <= 2000; ms++)
+    if (CwStreamEnc_MillisecondsTo7BitTimestamp(ms) != cwstream_encode_timestamp(ms)) eb++;
+for (int b = 0; b <= 127; b++)
+    if (CwStreamEnc_7BitTimestampToMilliseconds((BYTE)b) != cwstream_decode_timestamp((uint8_t)b)) db++;
+/* -> ENCODE 0/2051, DECODE 0/128, UBSan pulito */
+```
+
+```bash
+clang -O1 -fsanitize=undefined -I shim -I <ref-src> -I <our-include> \
+      diff_main.c <ref-src>/CwStreamEnc.c <our-src>/cwnet_timestamp.c -o difftest
+```
+
+Il tap che rende catturabile un loopback non catturabile:
+
+```
+client CWNet (VM) --> tap TCP (Mac, 192.168.179.1:7355) --> server CWNet (VM)
+                          |                                   scrive i due versi
+                          '-> sess_N_client_to_server.bin      come byte grezzi
+                              sess_N_server_to_client.bin
+```
+
+Gli strumenti (`shim/yhf_type.h`, `difftest`, `cwnet_dump`, `pcap_to_stream.py`, `cwnet_tap.py`) sono l'unità U2 del piano banco-prova-cwnet, sbloccata, e vanno in `tools/cwnet/`. Le catture prodotte **non** si committano finché la issue #8 (provenienza) è aperta.

--- a/thoughts/shared/handoffs/general/2026-09-05_2145_sessione-zero-parziale.md
+++ b/thoughts/shared/handoffs/general/2026-09-05_2145_sessione-zero-parziale.md
@@ -1,0 +1,84 @@
+---
+artifact_contract: "ce-handoff/v1"
+created_at: "2026-09-05T19:45:00Z"
+title: "Sessione zero parziale: cinque ipotesi CWNet chiuse contro il riferimento vero"
+summary: "Prima cattura reale del client DL4YHF: H1-H5 confermate (H3 e H5 con correzioni), H6 smentita, strumenti del banco in repo, dieci issue aperte, workflow del debito ridefinito."
+keywords: ["cwnet", "dl4yhf", "sessione-zero", "oracolo-differenziale", "banco-di-prova", "issue-workflow"]
+cwd: "/Users/sf/Developer/RemoteCWKeyer-esp32"
+resume_focus: "Il loop di determinismo non ha più banco: H6 è smentita. Il primo lavoro sbloccato è #14, il server echo minimo. In alternativa #10 (TX su MORSE 0x10), che è la conformità vera."
+repository: "iu3qez/RemoteCWKeyer-esp32"
+repo_root_sha: "f153e01ec202b2cae17102fa0f355d657bb641c7"
+branch: "cwnet-bench-session-zero"
+head: "a7aef65"
+---
+
+# Sessione zero parziale — CWNet contro il riferimento vero
+
+Quattro commit su `cwnet-bench-session-zero`, PR aperta. Working tree pulito.
+
+## Cosa è successo
+
+L'handoff precedente diceva di ripartire dal peso probatorio delle fixture (KTD5). Ci abbiamo provato con `ce-brainstorm`, ma l'utente ha **riorientato la sessione** dopo poche battute: *«Lascia stare questo. Dobbiamo pensare come testare contro il golden standard DL4YHF»*. Il brainstorming su KTD5 è quindi **abbandonato, non concluso** — la domanda sulla durezza del meccanismo resta aperta e non è stata decisa.
+
+Da lì la sessione è diventata una sessione zero parziale, ed è andata molto oltre le previsioni del piano.
+
+## Il metodo che ha funzionato
+
+Documentato per intero in [docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md](../../../../docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md) — da leggere prima di toccare qualunque cosa di CWNet. In sintesi: `CwStreamEnc.c` di DL4YHF è C puro, compila con uno shim di quattro typedef, e il suo dominio di ingresso è abbastanza piccolo da fare un confronto **esaustivo** contro il nostro codec. Zero scarti. `CwNet.c` invece non compila (l'archivio pubblicato manca di `StringLib.h`, `yhf_type.h`, `QFile.h`, `YHF_*.h`, e l'autore non li dà: «sono lavori vecchi») — ma non serve, perché i byte li legge il nostro parser.
+
+**Il permesso di DL4YHF c'è**, per email, e l'utente si è irritato quando l'ho rimesso in discussione dopo che me l'aveva già detto. Non riaprire l'argomento.
+
+Il loopback della VM non era catturabile con Npcap, quindi il traffico è stato fatto passare da un **tap TCP** sul Mac. Gli strumenti sono in [tools/cwnet/](../../../../tools/cwnet/) con il README che spiega il fetch del codec di riferimento — che **non** è vendorizzato, per scelta esplicita dell'utente.
+
+## Esiti (tabella completa nel piano, sezione Dependencies)
+
+| | |
+|---|---|
+| H1, H2, H4 | confermate |
+| H3 | confermata **ma corretta**: fine over a **14 dot-time**, non «10 dot o 500 ms». Il commento nel sorgente è sbagliato; codice e byte concordano |
+| H5 | confermata, **con un difetto**: il peak-hold usa divisione intera, quindi si pianta a `istantaneo + <10 ms` e non scende più. Osservato nel log GUI dell'autore (`pk = 7 ms` fermo per 90 s con istantaneo 1–5) |
+| H6 | **smentita** — vedi sotto |
+| H7 | non osservabile senza la nostra scatola sul filo |
+
+Non previste: il **PTT viaggia come stringa rigctld** (`set_ptt 1/0`) in frame `0x06`; il client **impacchetta** più eventi per frame quando ne trova in coda; i permessi sono una bitmask.
+
+## H6 è il fatto che cambia i piani
+
+Il server **non rimanda indietro il keying**, e non è una questione di configurazione o di latenza (l'utente ha ipotizzato la latenza; il sorgente dice di no). `CWNET_CMD_MORSE` viene emesso da un solo punto di `CwNet.c`, e la FIFO che lo alimenta si riempie solo sotto `iFunctionality == CWNET_FUNC_CLIENT`: **un'istanza server non emette mai MORSE**. Collegare un secondo client non serve.
+
+Conseguenza: R7 perde il banco che il piano assumeva. Il ripiego era già previsto — un server echo nostro — ed è ora la issue #14. Regge, perché il confronto di **determinismo** non ha bisogno del riferimento ai capi; quello di **formato** sì, e quell'evidenza adesso ce l'abbiamo.
+
+## Stato del lavoro
+
+**Fatto e verificato.** Strumenti in `tools/cwnet/` (i tre programmi C compilano puliti, `difftest` con UBSan, `cwnet_dump` con `-Werror`; il confronto esaustivo dà 0 scarti). Esiti H1–H7 nel piano. Il learning di metodo. `CONCEPTS.md` creato da zero, 7 voci sul vocabolario CWNet. CLAUDE.md punta a `docs/solutions/` e `CONCEPTS.md`.
+
+**Non fatto.** La suite host non è stata rilanciata in questa sessione — nessun codice di produzione è stato toccato, quindi non ci si aspettano regressioni, ma non è verificato. Il firmware non è compilabile su questa macchina (nessun ESP-IDF installato).
+
+**Machine-local, non nel repo.** Le catture reali stanno in `/private/tmp/claude-501/-Users-sf-Developer-RemoteCWKeyer-esp32/bed2bd1e-*/scratchpad/oracle/*.bin` insieme al sorgente DL4YHF scaricato. **Sono già evaporate una volta** con un cambio di macchina in questa stessa sessione. Non sono committate perché #8 lo vieta. Se servono, si rifanno: il tap e la procedura sono in `tools/cwnet/README.md`.
+
+## Workflow cambiato in corsa
+
+L'utente ha introdotto una regola e poi l'ha **corretta due volte**, quindi conta la versione finale, in CLAUDE.md sotto *Work That Needs Deciding Becomes an Issue*: issue solo per lavoro che richiede una decisione, è schedulabile, non è validabile qui, o il cui costo si accumula. Tutto il resto si sistema sul posto — filare issue leggere è **QRM**. Debito leggero non sistemabile subito: una riga in `.claude/code-quality.md`.
+
+Applicata a ritroso: #18 e #20 chiuse come QRM e corrette direttamente (path IDF, README).
+
+Il README è stato riscritto **per un lettore esterno**, su indicazione dell'utente: niente banco di prova, niente istruzioni di build o di suite, DL4YHF citato e linkato.
+
+## Dieci issue aperte
+
+`#10` TX su MORSE 0x10 · `#11` RX multi-evento · `#12` filtro peak-hold (con la decisione se replicare il bug) · `#13` PTT rigctld · `#14` server echo · `#15` dissector U1 · `#16` devcontainer IDF v5.5.1 · `#17` stub USB · `#19` doc-review del piano.
+
+Restano bloccanti `#7` (sequenza nota, cosa significa «identico», tolleranza) e `#8` (provenienza delle catture). **Bloccano ancora U5 e U6 e il commit delle fixture.** Nulla di quanto sopra le aggira.
+
+## Come continuare
+
+Il lavoro sbloccato più prossimo è **#14, il server echo**: senza, il determinismo non ha banco, ed è il pezzo che il resto del banco presuppone.
+
+In alternativa, **#10 (TX su MORSE 0x10)**: è la conformità vera, quella per cui esiste il progetto, ed è ora dimostrabile invece che supposta. Non è in conflitto con #14 — sono due strade, non due opzioni esclusive; #14 serve a *misurare*, #10 a *essere corretti*.
+
+Due cose in sospeso che non sono issue:
+
+- **Il brainstorming su KTD5 non è stato concluso.** Se lo si riprende, la domanda aperta è quanto in là portare la distinzione fra fixture `reference/`, `ours/` e `synthetic/` — se una sintetica usata come atteso debba rompere la build, e se valga anche per il confronto di determinismo dove entrambi i capi vengono da `ours/`.
+- **H5 porta con sé una decisione**, registrata in #12: replicare il difetto della divisione intera per massimizzare l'accordo col riferimento, o correggerlo e produrre un numero migliore che non corrisponderà.
+
+Skill utili: `ce-work` per le issue sbloccate, `ce-brainstorm` se si riprende KTD5, `ce-doc-review` per #19.

--- a/tools/cwnet/README.md
+++ b/tools/cwnet/README.md
@@ -1,0 +1,64 @@
+# tools/cwnet — strumenti del banco di prova CWNet (U2)
+
+Estrazione e decodifica del traffico CWNet contro il golden standard DL4YHF.
+Metodo e razionale: [docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md](../../docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md).
+
+Nessuna dipendenza esterna: gli script sono Python 3 stdlib, i programmi C
+compilano con clang/gcc. In particolare `pcap_to_stream.py` sostituisce
+`tshark`, che così **non** diventa una dipendenza della CI.
+
+## Strumenti nostri
+
+| File | Cosa fa |
+|---|---|
+| `cwnet_tap.py` | Relay TCP trasparente: il client CWNet punta al tap, il tap inoltra al server e registra i due versi come byte grezzi. Cattura il loopback quando Wireshark/Npcap non lo intercetta. |
+| `pcap_to_stream.py` | Estrae i flussi TCP da un pcap/pcapng e li scrive come byte grezzi, una direzione per file (solo stdlib, gestisce Ethernet/loopback/SLL/raw). |
+| `cwnet_dump.c` | Decodifica un flusso grezzo: parser di frame **nostro** + codec del keying **di DL4YHF**. Diagnostico, non asserisce. |
+| `diff_main.c` | Confronto esaustivo del nostro `cwnet_timestamp.c` contro `CwStreamEnc.c` di DL4YHF, tutto il dominio di ingresso. |
+| `gen_synth.c` | Genera uno stream MORSE sintetico con l'encoder DL4YHF, per collaudare il decodificatore. |
+| `shim/yhf_type.h` | I quattro typedef (`BYTE`/`WORD`/`DWORD`/`BOOL`) che l'archivio pubblicato di DL4YHF non include. Scritto da noi. |
+| `shim/Elbug.h` | Stub: `CwStreamEnc.c` include `Elbug.h` ma non usa alcun simbolo di Elbug, solo i typedef. Lo stub evita di dover scaricare `Elbug.{c,h}`. Scritto da noi. |
+
+## Sorgente DL4YHF (non vendorizzato qui)
+
+`cwnet_dump.c`, `diff_main.c` e `gen_synth.c` compilano contro `CwStreamEnc.c`
+e `CwStreamEnc.h` di DL4YHF. **Permesso:** l'autore (Wolfgang Buescher,
+DL4YHF) ha autorizzato per email l'uso libero dei suoi sorgenti. Il modulo
+`CwStreamEnc.*` è C puro e dipende solo dallo shim qui sopra.
+
+Non è committato in questo repo per ora — è una decisione a parte dal
+committare i nostri strumenti. Per ottenerlo:
+
+```sh
+curl -sO https://www.qsl.net/dl4yhf/Remote_CW_Keyer/Remote_CW_Keyer_Sources.zip
+unzip -j Remote_CW_Keyer_Sources.zip \
+  'Remote_CW_Keyer/sources/CwStreamEnc.c' \
+  'Remote_CW_Keyer/sources/CwStreamEnc.h' -d ref/
+# archivio verificato: sha256 d960d6b9…, file datati 2025-10-20
+```
+
+## Uso
+
+```sh
+REF=ref                     # dove hai messo CwStreamEnc.{c,h}
+OUR=../../components/keyer_cwnet
+
+# confronto esaustivo del codec (deve dare 0 scarti)
+clang -O1 -fsanitize=undefined -I shim -I "$REF" -I "$OUR/include" \
+      diff_main.c "$REF/CwStreamEnc.c" "$OUR/src/cwnet_timestamp.c" -o difftest && ./difftest
+
+# decodifica di una cattura
+clang -O1 -Wall -Wextra -fsanitize=address,undefined -I shim -I "$REF" -I "$OUR/include" \
+      cwnet_dump.c "$REF/CwStreamEnc.c" "$OUR/src/cwnet_frame.c" -o cwnet_dump
+
+# tap dal vivo: client -> tap -> server, un file per direzione
+python3 cwnet_tap.py --listen 0.0.0.0:7355 --server <ip-server>:7355 --out sess
+# oppure estrai da un pcap:
+python3 pcap_to_stream.py cattura.pcapng --port 7355 --out sess
+./cwnet_dump sess_1_*.bin
+```
+
+## Fixture
+
+Le catture prodotte **non** si committano finché la issue #8 (provenienza da
+registrare accanto a ogni cattura) è aperta. Vedi il piano del banco di prova.

--- a/tools/cwnet/cwnet_dump.c
+++ b/tools/cwnet/cwnet_dump.c
@@ -1,0 +1,41 @@
+/* cwnet_dump - decodifica un flusso CWNet grezzo (una direzione).
+ * Parser di frame: il nostro. Codec del keying: DL4YHF. Strumento diagnostico. */
+#include "yhf_type.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "CwStreamEnc.h"
+#include "cwnet_frame.h"
+#define CMD_MORSE 0x10
+static const char *nm(uint8_t c){switch(c){
+ case 0x10:return "MORSE (DL4YHF)"; case 0x03:return "PING";
+ case 0x14:return "CI-V  (= nostro CW_UP)"; case 0x15:return "SPECTRUM (= nostro CW_DOWN)";
+ case 0x01:return "CONNECT"; case 0x02:return "DISCONNECT"; case 0x11:return "AUDIO";
+ case 0x04:return "PRINT"; case 0x05:return "TX_INFO"; default:return "?";}}
+static void morse(const uint8_t *p, uint16_t n){
+  long t=0; printf("      stream a 7 bit, %u eventi:\n", n);
+  for(uint16_t i=0;i<n;i++){int d=(p[i]&0x80)?1:0;
+    int w=CwStreamEnc_7BitTimestampToMilliseconds((BYTE)(p[i]&0x7F)); t+=w;
+    printf("        [%3u] 0x%02X  attesa %4d ms -> t=%6ld ms  key %s\n",i,p[i],w,t,d?"DOWN":"up");}}
+int main(int argc,char**argv){
+  if(argc<2){fprintf(stderr,"uso: cwnet_dump <flusso.bin> [frammento]\n");return 2;}
+  FILE*f=fopen(argv[1],"rb"); if(!f){perror(argv[1]);return 2;}
+  static uint8_t buf[1<<22]; size_t len=fread(buf,1,sizeof buf,f); fclose(f);
+  size_t frag=(argc>2)?(size_t)atoi(argv[2]):0;
+  printf("== %s: %zu byte ==\n\n",argv[1],len);
+  cwnet_frame_parser_t ps; cwnet_frame_parser_init(&ps);
+  size_t off=0,tot=0; int nf=0;
+  while(tot<len){
+    size_t ch=len-tot; if(frag&&ch>frag) ch=frag;
+    cwnet_parse_result_t r=cwnet_frame_parse(&ps,buf+tot,ch);
+    if(r.status==CWNET_PARSE_ERROR){printf("offset %zu: ERRORE DI PARSING\n",tot);break;}
+    if(r.status==CWNET_PARSE_OK){nf++;
+      printf("frame %d @ offset %zu: cmd 0x%02X %-24s payload %u byte\n",nf,off,r.command,nm(r.command),r.payload_len);
+      if(r.payload_len&&r.payload){printf("      hex:");
+        for(uint16_t i=0;i<r.payload_len&&i<32;i++)printf(" %02X",r.payload[i]);
+        if(r.payload_len>32)printf(" ...");printf("\n");
+        if(r.command==CMD_MORSE) morse(r.payload,r.payload_len);}
+      off=tot+r.bytes_consumed;}
+    if(r.bytes_consumed==0){printf("nessun progresso, mi fermo\n");break;}
+    tot+=r.bytes_consumed;}
+  printf("\n== %d frame, %zu/%zu byte consumati ==\n",nf,tot,len);
+  return 0;}

--- a/tools/cwnet/cwnet_tap.py
+++ b/tools/cwnet/cwnet_tap.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Relay TCP trasparente che registra i byte nei due versi.
+
+Il client CWNet si connette a questo processo invece che al server; il processo
+inoltra al server vero e scrive due file di byte grezzi, uno per direzione,
+nello stesso formato che cwnet_dump si aspetta.
+
+Non interpreta il protocollo: copia byte. L'unica cosa che cambia rispetto a una
+connessione diretta e' la segmentazione TCP, che e' irrilevante perche' a valle
+si lavora sul flusso riassemblato.
+
+  python3 cwnet_tap.py --listen 0.0.0.0:7355 --server 192.168.179.128:7355 --out sess1
+"""
+import argparse, socket, threading, sys, time
+
+def hostport(s):
+    h, _, p = s.rpartition(":")
+    return h, int(p)
+
+def pump(src, dst, f, label, stop):
+    n = 0
+    try:
+        while not stop.is_set():
+            b = src.recv(65536)
+            if not b:
+                break
+            f.write(b); f.flush()
+            n += len(b)
+            print(f"  {label}: +{len(b):5d} byte (totale {n})", flush=True)
+            dst.sendall(b)
+    except OSError:
+        pass
+    finally:
+        stop.set()
+        for s in (src, dst):
+            try: s.shutdown(socket.SHUT_RDWR)
+            except OSError: pass
+    print(f"  {label}: chiuso, {n} byte totali", flush=True)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--listen", default="0.0.0.0:7355")
+    ap.add_argument("--server", required=True, help="IP:porta del server CWNet vero")
+    ap.add_argument("--out", default="sess", help="prefisso dei file di uscita")
+    a = ap.parse_args()
+
+    lh, lp = hostport(a.listen)
+    sh, sp = hostport(a.server)
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((lh, lp)); srv.listen(4)
+    print(f"in ascolto su {lh}:{lp}, inoltro a {sh}:{sp}")
+    print("il client CWNet deve puntare a questo indirizzo. Ctrl-C per finire.\n")
+
+    conn_no = 0
+    try:
+        while True:
+            cli, addr = srv.accept()
+            conn_no += 1
+            print(f"[{time.strftime('%H:%M:%S')}] connessione {conn_no} da {addr[0]}:{addr[1]}")
+            try:
+                up = socket.create_connection((sh, sp), timeout=10)
+            except OSError as e:
+                print(f"  impossibile raggiungere il server: {e}")
+                cli.close(); continue
+            cli.settimeout(None); up.settimeout(None)
+            f_c2s = open(f"{a.out}_{conn_no}_client_to_server.bin", "wb")
+            f_s2c = open(f"{a.out}_{conn_no}_server_to_client.bin", "wb")
+            stop = threading.Event()
+            threading.Thread(target=pump, args=(cli, up, f_c2s, f"c{conn_no} client->server", stop), daemon=True).start()
+            threading.Thread(target=pump, args=(up, cli, f_s2c, f"c{conn_no} server->client", stop), daemon=True).start()
+    except KeyboardInterrupt:
+        print("\nfine.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/cwnet/diff_main.c
+++ b/tools/cwnet/diff_main.c
@@ -1,0 +1,14 @@
+#include "yhf_type.h"
+#include <stdio.h>
+#include <stdint.h>
+#include "CwStreamEnc.h"
+#include "cwnet_timestamp.h"
+int main(void) {
+    int eb = 0, db = 0;
+    for (int ms = -50; ms <= 2000; ms++)
+        if (CwStreamEnc_MillisecondsTo7BitTimestamp(ms) != cwstream_encode_timestamp(ms)) eb++;
+    for (int b = 0; b <= 127; b++)
+        if (CwStreamEnc_7BitTimestampToMilliseconds((BYTE)b) != cwstream_decode_timestamp((uint8_t)b)) db++;
+    printf("ENCODE scarti: %d su 2051 | DECODE scarti: %d su 128\n", eb, db);
+    return (eb || db) ? 1 : 0;
+}

--- a/tools/cwnet/gen_synth.c
+++ b/tools/cwnet/gen_synth.c
@@ -1,0 +1,11 @@
+#include "yhf_type.h"
+#include <stdio.h>
+#include "CwStreamEnc.h"
+int main(void){
+  struct{int down,wait;}ev[]={{1,0},{0,180},{1,60},{0,60},{1,180},{0,60},{1,60},{0,180},
+    {1,180},{0,60},{1,180},{0,60},{1,60},{0,60},{1,180},{0,500},{0,0}};
+  int n=(int)(sizeof ev/sizeof ev[0]); unsigned char fr[160]; int k=0;
+  fr[k++]=0x10|0x40; fr[k++]=(unsigned char)n;
+  for(int i=0;i<n;i++) fr[k++]=(unsigned char)((ev[i].down?0x80:0)|CwStreamEnc_MillisecondsTo7BitTimestamp(ev[i].wait));
+  FILE*f=fopen("synth_morse.bin","wb"); fwrite(fr,1,(size_t)k,f); fclose(f);
+  printf("synth_morse.bin: %d byte\n",k); return 0;}

--- a/tools/cwnet/pcap_to_stream.py
+++ b/tools/cwnet/pcap_to_stream.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Estrae i flussi TCP da un pcap/pcapng e li scrive come byte grezzi, una
+direzione per file. Solo libreria standard: niente tshark, niente dipendenze in CI.
+
+  python3 pcap_to_stream.py cattura.pcapng --port 7355 --out sessione1
+"""
+import argparse, struct, sys
+from collections import defaultdict
+
+LT_ETHERNET, LT_NULL, LT_RAW, LT_SLL = 1, 0, 101, 113
+
+
+def read_pcap(path):
+    with open(path, "rb") as f:
+        data = f.read()
+    magic = data[:4]
+    if magic in (b"\xa1\xb2\xc3\xd4", b"\xa1\xb2\x3c\x4d"):
+        endian = ">"
+    elif magic in (b"\xd4\xc3\xb2\xa1", b"\x4d\x3c\xb2\xa1"):
+        endian = "<"
+    elif magic == b"\x0a\x0d\x0d\x0a":
+        return read_pcapng(data)
+    else:
+        sys.exit(f"formato non riconosciuto: magic {magic.hex()}")
+    linktype = struct.unpack(endian + "I", data[20:24])[0]
+    off, pkts = 24, []
+    while off + 16 <= len(data):
+        _, _, incl, _ = struct.unpack(endian + "IIII", data[off:off + 16])
+        off += 16
+        pkts.append(data[off:off + incl])
+        off += incl
+    return linktype, pkts
+
+
+def read_pcapng(data):
+    endian, off, linktype, pkts = "<", 0, None, []
+    while off + 12 <= len(data):
+        btype, = struct.unpack(endian + "I", data[off:off + 4])
+        if btype == 0x0A0D0D0A:
+            bom, = struct.unpack("<I", data[off + 8:off + 12])
+            endian = "<" if bom == 0x1A2B3C4D else ">"
+        blen, = struct.unpack(endian + "I", data[off + 4:off + 8])
+        if blen < 12:
+            break
+        body = data[off + 8:off + blen - 4]
+        if btype == 0x00000001:
+            linktype = struct.unpack(endian + "H", body[0:2])[0]
+        elif btype == 0x00000006:
+            caplen = struct.unpack(endian + "I", body[12:16])[0]
+            pkts.append(body[20:20 + caplen])
+        off += blen
+    return (linktype if linktype is not None else LT_ETHERNET), pkts
+
+
+def strip_link(lt, pkt):
+    if lt == LT_ETHERNET:
+        if len(pkt) < 14:
+            return None
+        etype = struct.unpack("!H", pkt[12:14])[0]
+        off = 14
+        while etype in (0x8100, 0x88A8):
+            etype = struct.unpack("!H", pkt[off + 2:off + 4])[0]
+            off += 4
+        return pkt[off:] if etype == 0x0800 else None
+    if lt == LT_NULL:
+        return pkt[4:] if len(pkt) >= 4 else None
+    if lt == LT_SLL:
+        return pkt[16:] if len(pkt) >= 16 else None
+    if lt == LT_RAW:
+        return pkt
+    return None
+
+
+def parse_tcp(ip):
+    if len(ip) < 20 or (ip[0] >> 4) != 4 or ip[9] != 6:
+        return None
+    ihl = (ip[0] & 0x0F) * 4
+    total = struct.unpack("!H", ip[2:4])[0]
+    src = ".".join(str(b) for b in ip[12:16])
+    dst = ".".join(str(b) for b in ip[16:20])
+    tcp = ip[ihl:total if total else len(ip)]
+    if len(tcp) < 20:
+        return None
+    sport, dport, seq = struct.unpack("!HHI", tcp[0:8])
+    doff = (tcp[12] >> 4) * 4
+    return (src, sport, dst, dport, seq, tcp[doff:])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pcap")
+    ap.add_argument("--port", type=int, help="tieni solo i flussi che toccano questa porta")
+    ap.add_argument("--out", default="stream")
+    a = ap.parse_args()
+
+    lt, pkts = read_pcap(a.pcap)
+    segs = defaultdict(dict)
+    for pkt in pkts:
+        ip = strip_link(lt, pkt)
+        if not ip:
+            continue
+        t = parse_tcp(ip)
+        if not t:
+            continue
+        src, sp, dst, dp, seq, payload = t
+        if a.port and a.port not in (sp, dp):
+            continue
+        if payload:
+            segs[(src, sp, dst, dp)].setdefault(seq, payload)
+
+    if not segs:
+        sys.exit("nessun payload TCP trovato (porta sbagliata? cattura vuota?)")
+
+    print(f"linktype {lt}, {len(pkts)} pacchetti, {len(segs)} direzioni con dati\n")
+    for i, (key, bysec) in enumerate(sorted(segs.items()), 1):
+        src, sp, dst, dp = key
+        out, expect, gaps = bytearray(), None, 0
+        for seq in sorted(bysec):
+            p = bysec[seq]
+            if expect is not None and seq != expect:
+                gaps += 1
+            out += p
+            expect = seq + len(p)
+        name = f"{a.out}_{i}_{src}-{sp}_to_{dst}-{dp}.bin"
+        with open(name, "wb") as f:
+            f.write(out)
+        flag = f"   ATTENZIONE: {gaps} discontinuita' di sequenza" if gaps else ""
+        print(f"  {name}  {len(out)} byte{flag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/cwnet/shim/Elbug.h
+++ b/tools/cwnet/shim/Elbug.h
@@ -1,0 +1,7 @@
+/* Stub: CwStreamEnc.c include "Elbug.h" ma non usa alcun simbolo di Elbug,
+ * solo i typedef. Fornirli via yhf_type.h basta a compilare il codec da solo,
+ * senza scaricare Elbug.{c,h} di DL4YHF. Scritto da noi. */
+#ifndef _ELBUG_STUB_H_
+#define _ELBUG_STUB_H_
+#include "yhf_type.h"
+#endif

--- a/tools/cwnet/shim/yhf_type.h
+++ b/tools/cwnet/shim/yhf_type.h
@@ -1,0 +1,11 @@
+#ifndef _YHF_TYPE_H_
+#define _YHF_TYPE_H_
+typedef unsigned char  BYTE;
+typedef unsigned short WORD;
+typedef unsigned int   DWORD;
+typedef int            BOOL;
+#ifndef TRUE
+# define TRUE 1
+# define FALSE 0
+#endif
+#endif


### PR DESCRIPTION
First capture of the official DL4YHF client on the wire, plus a reading of its published source. Five of the seven bench hypotheses now have a recorded outcome (R4), and one of them changes the plan.

## What the session established

| | |
|---|---|
| H1, H2, H4 | confirmed |
| H3 | confirmed **but corrected**: end-of-over is **14 dot-times**, not the "10 dots or 500 ms" the source comment claims. Code and captured bytes agree; the comment is wrong. |
| H5 | confirmed, **with a defect**: the reference's peak-hold latency filter decays by integer division, so it pins at `instantaneous + <10 ms` and stops descending. Observed in the author's own GUI log (`pk = 7 ms` unchanged for 90 s against an instantaneous 1–5 ms). |
| H6 | **refuted** — see below |
| H7 | not observable without our box on the wire |

Also found, none of it anticipated: PTT travels as a rigctld `set_ptt` string in `0x06` frames, not a dedicated command; the client **does** pack multiple keying events into one frame when they queue up; permissions are a bitmask.

## H6 changes the bench

A radio-less server does not relay keying back. `CWNET_CMD_MORSE` is emitted from exactly one place in the reference, and the FIFO feeding it fills only under `iFunctionality == CWNET_FUNC_CLIENT` — a server instance never emits MORSE at all. Connecting a second client does not help.

R7 therefore loses the bench it assumed. The fallback the plan already anticipated — our own minimal echo server — is now #14. It holds up: the **determinism** comparison does not need the reference at either end, and the **format** comparison, which does, now has its evidence.

## What is in here

- `tools/cwnet/` — the tooling that made it possible (U2): a transparent TCP tap for loopback traffic Npcap could not capture, a stdlib pcap extractor (so `tshark` never becomes a CI dependency), a stream decoder, and an exhaustive differential test of our 7-bit codec against the reference's. Zero divergences over the whole input domain.
- Outcomes recorded in the bench plan.
- The method captured as a durable learning: the reference's own source compiled as a differential oracle, and why it must earn its place against a real capture rather than be trusted a priori.
- `CONCEPTS.md`, seeded with the CWNet keying vocabulary verified against source.
- A workflow rule for what earns a GitHub issue versus what gets fixed on the spot — and, after that rule immediately produced two QRM issues, a second rule requiring review before a change to the way of working stands.
- README rewritten for an outside reader: it claimed the project was built in Rust.

## What is deliberately not in here

No captures. Issue #8 (provenance to record alongside a capture) is open and blocks committing fixtures; the tooling to regenerate them is here instead. The DL4YHF codec source is not vendored either — the README records the author's permission and the one-step fetch.

Issues #7 and #8 remain blocking, and nothing here works around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2JCa1s31gkBRavvYMnpmV