### PR TITLE
tools/cwnet: record capture provenance in a manifest beside every capture (#8)

### DIFF
--- a/tools/cwnet/README.md
+++ b/tools/cwnet/README.md
@@ -60,5 +60,8 @@ python3 pcap_to_stream.py cattura.pcapng --port 7355 --out sess
 
 ## Fixture
 
-Le catture prodotte **non** si committano finché la issue #8 (provenienza da
-registrare accanto a ogni cattura) è aperta. Vedi il piano del banco di prova.
+Ogni sessione di cattura è accompagnata da un `manifest.yaml` accanto ai suoi
+file, compilato a partire da
+[`manifest.template.yaml`](manifest.template.yaml). Una cattura senza
+manifesto non è una prova: non si committa. Vedi il
+[piano del banco di prova](../../docs/plans/2026-09-01-2157-feat-banco-prova-cwnet-plan.md).

--- a/tools/cwnet/manifest.template.yaml
+++ b/tools/cwnet/manifest.template.yaml
@@ -1,0 +1,50 @@
+# manifest.yaml — provenance for one CWNet capture session.
+#
+# Copy this file to manifest.yaml next to the session's capture files
+# (e.g. sess1_1_client_to_server.bin, sess1_1_server_to_client.bin) and
+# fill in every field. A capture without a manifest is not evidence.
+
+reference:
+  # DL4YHF Remote_CW_Keyer source archive used as the golden reference.
+  # No build version string is published — for this archive the operative
+  # version is the source zip's sha256, as recorded in README.md ("archivio
+  # verificato: sha256 d960d6b9...").
+  version: null
+  build_date: null    # date embedded in the archive/sources, e.g. 2025-10-20
+  source_url: null    # where it was fetched from, e.g. the qsl.net URL in README.md
+
+host:
+  os: null            # OS of the machine running the DL4YHF reference server
+  server_relay_mode: null   # relay mode the server was configured with
+  # Bitmask of the *connected user's* permissions (not a global server
+  # setting): TALK 1, TRANSMIT 2, CTRL_RIG 4, ADMIN 8 (see
+  # tools/wireshark/README.md). The zero session used a TRANSMIT user.
+  server_permissions: null
+  server_port: null         # TCP port the server was listening on
+
+keying:
+  # One manifest covers a single rendition at a single WPM. #7's reference
+  # sequence is sent at two WPM, so a two-WPM session needs two manifests.
+  wpm: null
+  # Deterministic source per #7: text_keyer_send() from keyer_text. Hand
+  # keying is excluded — below 32 ms the codec resolves to 1 ms and two
+  # manual runs never produce the same bytes.
+  sequence_source: null
+  sequence: null          # the actual sequence keyed during the session
+
+diagnostics:
+  flags: []          # diagnostic flags active in the reference during the session, e.g. /debug
+
+capture:
+  end_captured: null # free prose identifying the captured instance/machine,
+                      # e.g. "DL4YHF client in the Windows VM" (zero session)
+  role: null         # client | server
+  tool: null         # e.g. tools/cwnet/cwnet_tap.py
+  file_naming: null  # naming scheme used, e.g. sessN_M_client_to_server.bin
+
+ours:
+  tree_sha: null        # git rev-parse HEAD at capture time
+  cwnet_tools_sha: null # git rev-parse HEAD:tools/cwnet at capture time
+
+runbook:
+  section: null # pointer to the doc that reproduces this setup, as document#section


### PR DESCRIPTION
Resolves the decision in #8. A capture without provenance is not evidence: a fixture that diverges a year from now cannot be arbitrated on bytes alone — was our code wrong, or was the capture taken against a different build of a reference that ships day-dated sources?

**The rule.** Every capture session ships one `manifest.yaml`, from `tools/cwnet/manifest.template.yaml`, beside its capture files. A capture without one is not evidence.

The template carries exactly the fields #8 lists — reference build, server host and configuration, keying parameters, active diagnostic flags, which end was captured in which role, our own SHAs, and a runbook pointer — and nothing more. No schema, no validator, no script.

**Reviewed adversarially before this PR opened.** Verdict was *merge after fixes*; ten findings, all applied. The one that mattered: the template offered `hand` as a sequence source, which #7's closed decision **excludes** — a manifest could have been filled in complete and conforming on a capture that #7 declares cannot be evidence. Also fixed: the reference block could not actually pin the moving target (now points at the archive sha256 the README already records), `end_captured` and `role` were the same enum twice, and the two git SHA fields named two different git objects without saying how to obtain either.

**What this does not do.** It does not decide the fixture directory layout (`reference/` vs `ours/` vs `synthetic/`) — that question is still open. It commits no captures.

**#8 stays open and `blocking` until the maintainer closes it**, with the decision recorded as a comment there. Merging this does not by itself unblock committing fixtures. Once it closes, five documents still say captures wait on #8 and go stale: the solution doc, the bench plan, the two handoffs, and `.claude/MEMORY.md`.

No C changed, so no host-test run is due.