### PR TITLE
cwnet: reach READY on the CONNECT echo, and refuse to key without TRANSMIT (#23)

### DIFF
--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -17,7 +17,7 @@
  *
  * Protocol flow:
  *   DISCONNECTED -> on_connected() -> CONNECTING (sends IDENT)
- *   CONNECTING -> recv WELCOME -> READY
+ *   CONNECTING -> recv CONNECT echo -> READY
  *   READY -> recv PING_REQUEST -> send RESPONSE_1, sync timer
  *   READY -> recv PING_RESPONSE_2 -> update latency
  *   READY -> send_key_event() -> send CW_DOWN/CW_UP
@@ -56,8 +56,7 @@
  * To build command byte: (category << 6) | command
  */
 typedef enum {
-    CWNET_CMD_WELCOME = 0x00,   /**< Server -> Client: connection accepted */
-    CWNET_CMD_CONNECT = 0x01,   /**< Client -> Server: connection request */
+    CWNET_CMD_CONNECT = 0x01,   /**< Client -> Server request; echoed back by the server to confirm */
     CWNET_CMD_DISCONNECT = 0x02,/**< Bidirectional: disconnect */
     CWNET_CMD_PING = 0x03,      /**< Bidirectional: time sync */
     CWNET_CMD_CW_UP = 0x14,     /**< Key up event */
@@ -68,6 +67,7 @@ typedef enum {
 #define CWNET_CONNECT_USERNAME_LEN  44
 #define CWNET_CONNECT_CALLSIGN_LEN  44
 #define CWNET_CONNECT_PAYLOAD_LEN   92  /**< 44 + 44 + 4 */
+#define CWNET_CONNECT_PERMISSIONS_OFFSET 88 /**< Permissions bitmask, uint32 LE */
 
 /*===========================================================================*/
 /* Client State                                                              */
@@ -78,8 +78,8 @@ typedef enum {
  */
 typedef enum {
     CWNET_STATE_DISCONNECTED = 0,  /**< Not connected */
-    CWNET_STATE_CONNECTING,        /**< TCP connected, waiting for WELCOME */
-    CWNET_STATE_READY,             /**< WELCOME received, can send/receive CW */
+    CWNET_STATE_CONNECTING,        /**< TCP connected, waiting for the CONNECT echo */
+    CWNET_STATE_READY,             /**< Connection confirmed, can send/receive CW */
 } cwnet_client_state_t;
 
 /**
@@ -199,6 +199,9 @@ typedef struct {
     /* Latency measurement */
     int32_t latency_ms;  /**< Last measured RTT, -1 if unknown */
 
+    /* Permissions granted by the server in its CONNECT echo */
+    uint32_t permissions;
+
     /* Frame parser for incoming data */
     cwnet_frame_parser_t parser;
 } cwnet_client_t;
@@ -278,6 +281,17 @@ void cwnet_client_on_disconnected(cwnet_client_t *client);
  * @param data Received data
  * @param len Data length
  */
+/**
+ * @brief Permissions the server granted, from its CONNECT echo
+ *
+ * Zero until the connection is confirmed. Bits: TALK 1, TRANSMIT 2,
+ * CTRL_RIG 4, ADMIN 8.
+ *
+ * @param client Client context
+ * @return uint32_t Granted permission bitmask, 0 if client is NULL
+ */
+uint32_t cwnet_client_get_permissions(const cwnet_client_t *client);
+
 void cwnet_client_on_data(cwnet_client_t *client,
                            const uint8_t *data,
                            size_t len);

--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -69,6 +69,12 @@ typedef enum {
 #define CWNET_CONNECT_PAYLOAD_LEN   92  /**< 44 + 44 + 4 */
 #define CWNET_CONNECT_PERMISSIONS_OFFSET 88 /**< Permissions bitmask, uint32 LE */
 
+/** Permission bits the server grants in its CONNECT echo */
+#define CWNET_PERMISSION_TALK      0x01u  /**< May talk to other users */
+#define CWNET_PERMISSION_TRANSMIT  0x02u  /**< May transmit (CW) */
+#define CWNET_PERMISSION_CTRL_RIG  0x04u  /**< May control the remote rig */
+#define CWNET_PERMISSION_ADMIN     0x08u  /**< Is the server administrator */
+
 /*===========================================================================*/
 /* Client State                                                              */
 /*===========================================================================*/
@@ -91,6 +97,7 @@ typedef enum {
     CWNET_CLIENT_ERR_NOT_READY,    /**< Not in READY state */
     CWNET_CLIENT_ERR_SEND_FAILED,  /**< Send callback failed */
     CWNET_CLIENT_ERR_PROTOCOL,     /**< Protocol error */
+    CWNET_CLIENT_ERR_NOT_PERMITTED,/**< Server did not grant TRANSMIT */
 } cwnet_client_err_t;
 
 /*===========================================================================*/

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -480,5 +480,12 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
         return CWNET_CLIENT_ERR_NOT_READY;
     }
 
+    /* A server that did not grant TRANSMIT discards our keying without saying
+     * so, which would leave the operator listening to their own sidetone and
+     * believing they were on the air. Refuse instead. */
+    if ((client->permissions & CWNET_PERMISSION_TRANSMIT) == 0) {
+        return CWNET_CLIENT_ERR_NOT_PERMITTED;
+    }
+
     return send_cw_event(client, key_down);
 }

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -184,9 +184,19 @@ static cwnet_client_err_t send_cw_event(cwnet_client_t *client, bool key_down) {
 /*===========================================================================*/
 
 /**
- * @brief Handle WELCOME frame
+ * @brief Handle the server's CONNECT echo, which confirms the connection
  */
-static void handle_welcome(cwnet_client_t *client) {
+static void handle_connect_echo(cwnet_client_t *client,
+                                const uint8_t *payload,
+                                size_t len) {
+    /* The server returns the record we sent with the permissions field filled
+     * in; that field is how we learn what this connection is allowed to do. */
+    if (len >= CWNET_CONNECT_PAYLOAD_LEN) {
+        const uint8_t *p = &payload[CWNET_CONNECT_PERMISSIONS_OFFSET];
+        client->permissions = (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+                              ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    }
+
     if (client->state == CWNET_STATE_CONNECTING) {
         set_state(client, CWNET_STATE_READY);
     }
@@ -277,8 +287,8 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
     size_t payload_len = result->payload_len;
 
     switch (cmd) {
-        case CWNET_CMD_WELCOME:
-            handle_welcome(client);
+        case CWNET_CMD_CONNECT:
+            handle_connect_echo(client, payload, payload_len);
             break;
 
         case CWNET_CMD_PING:
@@ -357,6 +367,13 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     cwnet_frame_parser_init(&client->parser);
 
     return CWNET_CLIENT_OK;
+}
+
+uint32_t cwnet_client_get_permissions(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return 0;
+    }
+    return client->permissions;
 }
 
 cwnet_client_state_t cwnet_client_get_state(const cwnet_client_t *client) {

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -267,6 +267,43 @@ void test_client_keeps_permissions_from_connect_echo(void) {
     TEST_ASSERT_EQUAL_HEX32(0x00000007, cwnet_client_get_permissions(&client));
 }
 
+
+/*
+ * Without TRANSMIT the server silently discards our keying: no rejection
+ * frame, so the operator would hear their own sidetone and believe they were
+ * on the air. Refusing is the fault-philosophy reading -- corrupted or ignored
+ * CW is worse than silence.
+ *
+ * The bytes are the session-10 echo with the permissions field changed to TALK
+ * only. That combination is one the reference supports and our capture never
+ * exercised, because the test account was granted 0x07.
+ */
+void test_client_refuses_to_key_without_transmit_permission(void) {
+    test_setup();
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "Moritz",
+        .send_cb = mock_send,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+
+    uint8_t echo[sizeof(ref_connect_echo)];
+    memcpy(echo, ref_connect_echo, sizeof(echo));
+    echo[2 + CWNET_CONNECT_PERMISSIONS_OFFSET] = CWNET_PERMISSION_TALK;
+    cwnet_client_on_data(&client, echo, sizeof(echo));
+
+    /* The connection is up: this is not a connection failure. */
+    TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
+
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_ERR_NOT_PERMITTED,
+                      cwnet_client_send_key_event(&client, true));
+}
+
 /*===========================================================================*/
 /* PING Handling Tests                                                       */
 /*===========================================================================*/

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -49,6 +49,32 @@ static void test_setup(void) {
     mock_time_ms = 1000;
 }
 
+/*
+ * The reference protocol has no WELCOME: 0x00 is CWNET_CMD_NONE, "dummy command
+ * to send HTTP instead of our binary protocol" (CwNet.h). A real server confirms
+ * a connection by echoing the 92-byte CONNECT record back with the permissions
+ * field filled in, then sending a PRINT with the greeting.
+ *
+ * These are the first 94 bytes of the server-to-client direction of session 10
+ * of the 2026-09-05 capture of the official DL4YHF client and server: the
+ * CONNECT echo, user "Moritz", permissions 0x07 where the client had sent 0.
+ */
+static const uint8_t ref_connect_echo[] = {
+    0x41, 0x5C, 0x4D, 0x6F, 0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x6F,
+    0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+};
+
+/* Drive the client to READY the way a real server does. */
+static void feed_connect_echo(void) {
+    cwnet_client_on_data(&client, ref_connect_echo, sizeof(ref_connect_echo));
+}
+
 /*===========================================================================*/
 /* Initialization Tests                                                      */
 /*===========================================================================*/
@@ -194,11 +220,15 @@ void test_client_sends_ident_on_connect(void) {
     TEST_ASSERT_EQUAL(0x41, mock_tx_buffer[0]);  /* CONNECT with category 1 (short payload) */
 }
 
-void test_client_receives_welcome_transitions_to_ready(void) {
+
+
+
+void test_client_reaches_ready_on_connect_echo(void) {
+    test_setup();
     cwnet_client_config_t config = {
         .server_host = "test.server.com",
         .server_port = 7373,
-        .username = "TEST",
+        .username = "Moritz",
         .send_cb = mock_send,
         .get_time_ms_cb = mock_get_time_ms,
         .user_data = NULL
@@ -207,12 +237,34 @@ void test_client_receives_welcome_transitions_to_ready(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    /* Simulate receiving WELCOME from server */
-    /* CMD_WELCOME = 0x00 (no payload category) */
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    cwnet_client_on_data(&client, ref_connect_echo, sizeof(ref_connect_echo));
 
     TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
+}
+
+
+/*
+ * The permissions bitmask (H4) is how the client learns what the server allows:
+ * it sends zero and the server returns the granted bits in the echo. In the
+ * session-10 capture that is 0x07 = TALK | TRANSMIT | CTRL_RIG.
+ */
+void test_client_keeps_permissions_from_connect_echo(void) {
+    test_setup();
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "Moritz",
+        .send_cb = mock_send,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+
+    feed_connect_echo();
+
+    TEST_ASSERT_EQUAL_HEX32(0x00000007, cwnet_client_get_permissions(&client));
 }
 
 /*===========================================================================*/
@@ -233,8 +285,7 @@ void test_client_responds_to_ping_request(void) {
     cwnet_client_on_connected(&client);
 
     /* Get to READY state */
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
     mock_tx_len = 0;
 
     /* Simulate PING REQUEST from server */
@@ -275,8 +326,7 @@ void test_client_syncs_timer_on_ping_request(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
 
     /* Initial timer offset should be 0 */
     mock_time_ms = 0;
@@ -314,8 +364,7 @@ void test_client_updates_latency_on_ping_response2(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
 
     /* Initial latency should be -1 (unknown) */
     TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_ms(&client));
@@ -354,8 +403,7 @@ void test_client_sends_key_down_event(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
     mock_tx_len = 0;
 
     /* Send key down event */
@@ -382,8 +430,7 @@ void test_client_sends_key_up_event(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
     mock_tx_len = 0;
 
     /* Send key up event */
@@ -430,8 +477,7 @@ void test_client_handles_invalid_frame(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
 
     /* Send garbage data */
     uint8_t garbage[] = {0xFF, 0xFF, 0xFF, 0xFF};
@@ -454,8 +500,7 @@ void test_client_handles_disconnect_during_operation(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
     TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
 
     cwnet_client_on_disconnected(&client);
@@ -483,11 +528,11 @@ void test_client_handles_fragmented_frame(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    /* Send WELCOME in two fragments */
-    uint8_t frag1[] = {0x00};  /* Just the command byte */
-    cwnet_client_on_data(&client, frag1, sizeof(frag1));
+    /* A 94-byte CONNECT echo does not arrive in one TCP segment. Split it. */
+    cwnet_client_on_data(&client, ref_connect_echo, 40);
+    TEST_ASSERT_EQUAL(CWNET_STATE_CONNECTING, cwnet_client_get_state(&client));
 
-    /* WELCOME has no payload, so single byte should complete it */
+    cwnet_client_on_data(&client, ref_connect_echo + 40, sizeof(ref_connect_echo) - 40);
     TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
 }
 
@@ -504,8 +549,7 @@ void test_client_handles_ping_in_fragments(void) {
     cwnet_client_init(&client, &config);
     cwnet_client_on_connected(&client);
 
-    uint8_t welcome[] = {0x00};
-    cwnet_client_on_data(&client, welcome, sizeof(welcome));
+    feed_connect_echo();
     mock_tx_len = 0;
 
     /* Send PING REQUEST in fragments */
@@ -549,7 +593,7 @@ void run_cwnet_client_tests(void) {
 
     /* Protocol Handshake */
     RUN_TEST(test_client_sends_ident_on_connect);
-    RUN_TEST(test_client_receives_welcome_transitions_to_ready);
+    RUN_TEST(test_client_reaches_ready_on_connect_echo);
 
     /* PING Handling */
     RUN_TEST(test_client_responds_to_ping_request);

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -231,7 +231,8 @@ void test_client_init_empty_username(void);
 void test_client_connect_transitions_to_connecting(void);
 void test_client_disconnect_from_any_state(void);
 void test_client_sends_ident_on_connect(void);
-void test_client_receives_welcome_transitions_to_ready(void);
+void test_client_reaches_ready_on_connect_echo(void);
+void test_client_keeps_permissions_from_connect_echo(void);
 void test_client_responds_to_ping_request(void);
 void test_client_syncs_timer_on_ping_request(void);
 void test_client_updates_latency_on_ping_response2(void);
@@ -528,7 +529,8 @@ int main(void) {
     RUN_TEST(test_client_disconnect_from_any_state);
     /* Protocol Handshake */
     RUN_TEST(test_client_sends_ident_on_connect);
-    RUN_TEST(test_client_receives_welcome_transitions_to_ready);
+    RUN_TEST(test_client_reaches_ready_on_connect_echo);
+    RUN_TEST(test_client_keeps_permissions_from_connect_echo);
     /* PING Handling */
     RUN_TEST(test_client_responds_to_ping_request);
     RUN_TEST(test_client_syncs_timer_on_ping_request);

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -233,6 +233,7 @@ void test_client_disconnect_from_any_state(void);
 void test_client_sends_ident_on_connect(void);
 void test_client_reaches_ready_on_connect_echo(void);
 void test_client_keeps_permissions_from_connect_echo(void);
+void test_client_refuses_to_key_without_transmit_permission(void);
 void test_client_responds_to_ping_request(void);
 void test_client_syncs_timer_on_ping_request(void);
 void test_client_updates_latency_on_ping_response2(void);
@@ -531,6 +532,7 @@ int main(void) {
     RUN_TEST(test_client_sends_ident_on_connect);
     RUN_TEST(test_client_reaches_ready_on_connect_echo);
     RUN_TEST(test_client_keeps_permissions_from_connect_echo);
+    RUN_TEST(test_client_refuses_to_key_without_transmit_permission);
     /* PING Handling */
     RUN_TEST(test_client_responds_to_ping_request);
     RUN_TEST(test_client_syncs_timer_on_ping_request);


### PR DESCRIPTION
Closes #23.

## The bug

`CWNET_CMD_WELCOME = 0x00` was invented. In the reference header `0x00` is `CWNET_CMD_NONE`, *"dummy command to send HTTP instead of our binary protocol"*, and across all 32 files of the 2026-09-05 capture **no frame in either direction carries command `0x00`**.

`handle_welcome()` was the only transition from `CONNECTING` to `READY`, and `send_key_event()` refuses to send in any other state. Against a real server the client sat in `CONNECTING` for ever and never emitted a single keying event. This is independent of the MORSE framing defect (#10): that one is about what the events look like; this one stopped anything being sent at all.

## The real handshake

The server confirms a connection by echoing the 92-byte CONNECT record back with the permissions field filled in — the client sends `00 00 00 00`, the server returns `07 00 00 00` — then sends a `PRINT 0x04` with the greeting. The client now transitions on that echo and keeps the granted bitmask.

## The permissions are used, not just kept

Maintainer decision taken during implementation: without `TRANSMIT`, `send_key_event()` returns `CWNET_CLIENT_ERR_NOT_PERMITTED` rather than sending. A server that did not grant it discards our keying silently, and the operator would hear their own sidetone and believe they were on the air — the failure the fault philosophy exists to prevent. The connection stays `READY`: not being permitted to transmit is not a connection failure, and the box can still receive.

Surfacing that state where the operator can see it is #26; the key-holder layer above it is #25.

## Tests

Bytes come from the capture, not from our reading of the protocol — the same discipline that let `WELCOME` exist for months. The fixture is the first 94 bytes of the server-to-client direction of session 10.

- `test_client_reaches_ready_on_connect_echo` — the real echo drives `CONNECTING → READY`.
- `test_client_keeps_permissions_from_connect_echo` — `0x07` survives into the client.
- `test_client_refuses_to_key_without_transmit_permission` — the one derived fixture: the same echo with permissions set to TALK only, a configuration the reference supports and the capture never exercised. It says so where it is defined.
- Five existing tests reached `READY` by feeding the fictional `0x00`; they now feed the real echo.
- `test_client_handles_fragmented_frame` sent a single byte and asserted `READY`, testing nothing its name claims. It now splits the 94-byte echo across two `on_data` calls and asserts the client does **not** go `READY` on the first half.

191 tests green, plain and under ASan/UBSan. No RT-path code touched: `keyer_cwnet` runs on Core 1.