### PR TITLE
fix(config): generate config_nvs.c into src/, so the firmware links

### DIFF
--- a/scripts/gen_config_c.py
+++ b/scripts/gen_config_c.py
@@ -596,7 +596,7 @@ int config_save_to_nvs(void);
 def generate_config_nvs_c(params: List[Dict], families: List[Dict], output_dir: Path):
     """Generate config_nvs.c - NVS persistence implementation"""
 
-    src_dir = output_dir / "src"
+    src_dir = output_dir.parent / "src"
     src_dir.mkdir(parents=True, exist_ok=True)
 
     code = """/* Auto-generated from parameters.yaml - DO NOT EDIT MANUALLY */


### PR DESCRIPTION
**The firmware does not build on `main`.** It fails at 1071/1225:

```
cc1: fatal error: components/keyer_config/src/config_nvs.c: No such file or directory
```

## Cause

Three functions in `scripts/gen_config_c.py` generate a `.c` file, and one computes its destination differently:

| function | line | destination |
|---|---|---|
| `generate_config_c` | 418 | `output_dir.parent / "src"` |
| `generate_config_nvs_c` | 599 | `output_dir / "src"` ← |
| `generate_config_console_c` | 890 | `output_dir.parent / "src"` |

`keyer_config/CMakeLists.txt` passes `include/` as `output_dir`, so `config_nvs.c` was written to `components/keyer_config/include/src/` — a directory that existed in the tree as evidence — while `CMakeLists.txt` lists `src/config_nvs.c` in `SRCS` and `.gitignore` ignores `components/keyer_config/src/config_nvs.c`. Both agree the file belongs in `src/`; only line 599 disagreed.

## Why nothing caught it

- **Host tests**: `keyer_config` is generated and is not in the suite.
- **CI**: runs the host tests only; it never builds the firmware.
- **A hardware test**: unreachable, since no binary is produced.
- **Code review**: the line is correct in isolation and wrong only relative to its two siblings.

Only `idf.py build` finds it, and that had not been run since the ESP-IDF v6 migration in May.

## Verification

`idf.py build` on ESP-IDF v6.0.2, target esp32s3: completes, `keyer_c.bin` 0x12a460 bytes, 42% of the app partition free, no errors and no warnings. Host suite unaffected — no C source changed.

## Worth following up separately

CI does not build the firmware, which is why a four-month-old link failure was invisible. That is a real gap but a bigger change than this fix, and it needs a decision about build time and toolchain caching in Actions.