### PR TITLE
strategy: a boundary forbids building, not remembering

### DIFF
--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -50,6 +50,15 @@ non è dimostrato. Il suo strumento è la console seriale, non la WebUI.
 - Il log seriale su ESP32 blocca il real time: nessun log bloccante sul
   path RT, mai.
 
+Un boundary vieta di **costruire**, non di **ricordare**. Aprire una issue su
+qualcosa che sta fuori dai confini non è investimento: è il modo di non
+riscoprirlo daccapo fra sei mesi, e di sapere cosa aspetta quando il confine
+si sposterà. Quello che il boundary esclude è la schedulazione - il lavoro
+parcheggiato non passa davanti a banco di prova, CWNet e K8.
+
+Il tracker registra anche ciò che non faremo adesso. Un backlog che contiene
+solo il lavoro autorizzato non è disciplina: è amnesia.
+
 _Resist a change when:_ l'unico argomento è "c'è e costa poco aggiungere",
 o non può essere dimostrata contro il riferimento (client DL4YHF, sorgente
 K8).


### PR DESCRIPTION
`STRATEGY.md`'s **Boundaries** list what this project will not build. Read strictly, several entries — *"nessun investimento"*, *"niente OTA ora"* — also read as instructions not to talk about the thing, which is how parked work gets rediscovered from scratch rather than waiting where it was left.

Two sentences make the distinction explicit: a boundary excludes **scheduling**, not **recording**. An issue against something out of bounds costs nothing and jumps no queue.

## What prompted it

While recording the maintainer's decision to expose the iambic parameters in the Web UI (#32), I framed it as a *"recorded deviation"* from `STRATEGY.md:49` and justified it. The maintainer's correction: **"aprire issue non è investimento, è ricordare."** They were right — nothing was being built, and the boundary was never crossed.

The framing mattered: treating the tracker as expenditure is what makes a backlog contain only the work already approved, which is not discipline but amnesia.

## What it would have changed

`#26` (LED and Web UI diagnostics), `#17` (USB stubs, on the parked "postazione senza attrito" track) and the Web UI half of `#32` were all filed against parked tracks. Under the strict reading, all three were arguably out of order. Under this clarification they are exactly right, and their priority is unchanged: still behind bench, CWNet and K8.

Normative change, so it lands here for review before it applies beyond itself (CLAUDE.md, *Changing How We Work Requires Review*).