### PR TITLE
feat(iambic): the K1EL K8 sampling rule as the default squeeze_mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ components/src/config.c
 test_host/build*/
 .claude/settings.local.json
 .claude/worktrees/
+
+# K1EL K8 reference: fetched, never vendored (see tools/k8/README.md)
+morse8.zip
+morse8.asm
+tools/k8/ref/

--- a/components/keyer_iambic/CLAUDE.md
+++ b/components/keyer_iambic/CLAUDE.md
@@ -23,5 +23,7 @@ Gotchas:
 - Mode A stops immediately on paddle release; Mode B completes the current element plus one bonus element — do not "simplify" this asymmetry away.
 - Memory window: paddle presses are only latched between start%/end% of the element; presses before start% (debounce) or after end% are dropped by design.
 - Release debounce: `IAMBIC_DEBOUNCE_RELEASE_US` (5ms) blanks re-presses of the same paddle after release to kill contact bounce.
-- squeeze_mode LATCH_OFF = live paddle sampling, LATCH_ON = snapshot at element start — different feel, both intentional.
+- squeeze_mode has three values and they are three different observation rules, not settings of one: SAMPLED (default) reads the paddle *level* on a one-unit grid phase-locked to the element boundary and at no other instant — the K1EL K8 rule, see issue #32; LATCH_OFF and LATCH_ON both detect an *edge* inside a percentage window, live and snapshot-at-element-start respectively. The window is an extension for high speeds, not a generalisation containing the reference: it captures short taps the K8 drops.
+- SAMPLED arms only the *opposite* element type. The K8 clears the same-type latch after the final sample, so a held paddle continues through the live state read at the element boundary, not through memory.
+- The grid uses `elem_anchor_us`, not `element_start_us`: the latter is re-anchored when the gap begins, while the grid spans mark *and* trailing space (a dit element = 2 units, a dah = 4).
 <!-- END treecode (auto) -->

--- a/components/keyer_iambic/include/iambic.h
+++ b/components/keyer_iambic/include/iambic.h
@@ -78,7 +78,7 @@ typedef struct {
     .wpm = 20, \
     .mode = IAMBIC_MODE_B, \
     .memory_mode = MEMORY_MODE_DOT_AND_DAH, \
-    .squeeze_mode = SQUEEZE_MODE_LATCH_OFF, \
+    .squeeze_mode = SQUEEZE_MODE_SAMPLED, \
     .mem_window_start_pct = 0, \
     .mem_window_end_pct = 100 \
 }

--- a/components/keyer_iambic/include/iambic.h
+++ b/components/keyer_iambic/include/iambic.h
@@ -194,6 +194,14 @@ typedef struct {
     bool squeeze_seen;         /**< Squeeze detected during current element */
     bool squeeze_latched;      /**< Latched squeeze state (for LATCH_ON mode) */
 
+    /* Unit-grid sampling (SQUEEZE_MODE_SAMPLED only).
+     * The grid is phase-locked to the element boundary and spans mark AND the
+     * trailing space, so it cannot use element_start_us, which tick_sending()
+     * re-anchors when the gap begins. */
+    int64_t elem_anchor_us;    /**< Start of the current element, mark through space */
+    iambic_element_t elem_type; /**< Type of the element in progress */
+    uint8_t samples_taken;     /**< Grid instants already sampled this element */
+
     /* Output state */
     bool key_down;             /**< Current key output state */
 } iambic_processor_t;

--- a/components/keyer_iambic/include/iambic_preset.h
+++ b/components/keyer_iambic/include/iambic_preset.h
@@ -66,6 +66,23 @@ typedef enum {
 typedef enum {
     SQUEEZE_MODE_LATCH_OFF = 0,  /**< Live/immediate - check paddle state continuously */
     SQUEEZE_MODE_LATCH_ON  = 1,  /**< Snapshot/latch - capture at element start */
+    /**
+     * Sampled: read the paddle *level* on a one-unit grid phase-locked to the
+     * element boundary, and at no other instant. This is the K1EL K8 rule.
+     *
+     * A dit element spans 2 units (1u mark + 1u space) and is sampled at 1u and
+     * 2u; a dah element spans 4 units (3u + 1u) and is sampled at 1u, 2u, 3u
+     * and 4u. A press that opens and closes strictly between two instants is
+     * never seen. Level, not edge: what matters is that the contact is closed
+     * *at* instant k*u, not that a transition happened somewhere inside a span.
+     *
+     * Same-type memory is not armed at all during an element (the K8 clears the
+     * latch after the final sample); a held paddle continues through the live
+     * state read at the element boundary instead.
+     *
+     * See issue #32 for the verified reading of the K8 sampling schedule.
+     */
+    SQUEEZE_MODE_SAMPLED   = 2,
 } squeeze_mode_t;
 
 /* ============================================================================

--- a/components/keyer_iambic/src/iambic.c
+++ b/components/keyer_iambic/src/iambic.c
@@ -52,6 +52,9 @@ void iambic_init(iambic_processor_t *proc, const iambic_config_t *config) {
     proc->squeeze_seen = false;
     proc->squeeze_latched = false;
     proc->key_down = false;
+    proc->elem_anchor_us = 0;
+    proc->elem_type = ELEMENT_DIT;
+    proc->samples_taken = 0;
 }
 
 void iambic_set_config(iambic_processor_t *proc, const iambic_config_t *config) {
@@ -109,6 +112,9 @@ void iambic_reset(iambic_processor_t *proc) {
     proc->dah_release_time_us = -IAMBIC_DEBOUNCE_RELEASE_US;
     proc->dit_press_start_us = 0;
     proc->dah_press_start_us = 0;
+    proc->elem_anchor_us = 0;
+    proc->elem_type = ELEMENT_DIT;
+    proc->samples_taken = 0;
 }
 
 /* ============================================================================
@@ -145,6 +151,62 @@ static bool is_in_memory_window(const iambic_processor_t *proc, int64_t now_us) 
     return iambic_in_memory_window(progress_pct,
                                     proc->config.mem_window_start_pct,
                                     proc->config.mem_window_end_pct);
+}
+
+/**
+ * @brief Sample the paddle level on the one-unit grid (SQUEEZE_MODE_SAMPLED)
+ *
+ * The K1EL K8 reads the paddle level once per dit-unit and at no other instant.
+ * The grid is phase-locked to the start of the element and runs through the
+ * trailing space: a dit element spans 2 units and is sampled at 1u and 2u, a
+ * dah element spans 4 units and is sampled at 1u, 2u, 3u, 4u.
+ *
+ * Only the OPPOSITE element type is armed. The K8 clears the same-type latch
+ * after the final sample (`morse8.asm:374` and `:409`), so a same-type press
+ * never survives its own element; a held paddle continues through the live
+ * state read at the element boundary instead, which is Priority 3 of
+ * decide_next_element(). See issue #32.
+ *
+ * We poll at 1 ms (main/rt_task.c:176), so instant k*u is resolved at the first
+ * tick at or after it. That quantisation is the tolerance this rule carries.
+ */
+static void sample_on_unit_grid(iambic_processor_t *proc, int64_t now_us) {
+    if (proc->state != IAMBIC_STATE_SEND_DIT &&
+        proc->state != IAMBIC_STATE_SEND_DAH &&
+        proc->state != IAMBIC_STATE_GAP) {
+        return;  /* No element in progress: nothing is phase-locked. */
+    }
+
+    const int64_t unit_us = iambic_dit_duration_us(&proc->config);
+    if (unit_us <= 0) {
+        return;
+    }
+
+    /* Total grid instants in this element, mark plus trailing space. */
+    const uint8_t total_samples = (proc->elem_type == ELEMENT_DAH) ? 4u : 2u;
+
+    int64_t elapsed = now_us - proc->elem_anchor_us;
+    if (elapsed < 0) {
+        elapsed = 0;
+    }
+    int64_t crossed = elapsed / unit_us;
+    if (crossed > (int64_t)total_samples) {
+        crossed = (int64_t)total_samples;
+    }
+
+    while ((int64_t)proc->samples_taken < crossed) {
+        proc->samples_taken++;
+
+        /* Level at this instant, not an edge somewhere inside a span. */
+        if (proc->elem_type != ELEMENT_DIT && proc->dit_pressed &&
+            iambic_dit_memory_enabled(proc->config.memory_mode)) {
+            proc->dit_memory = true;
+        }
+        if (proc->elem_type != ELEMENT_DAH && proc->dah_pressed &&
+            iambic_dah_memory_enabled(proc->config.memory_mode)) {
+            proc->dah_memory = true;
+        }
+    }
 }
 
 static void update_gpio(iambic_processor_t *proc, gpio_state_t gpio, int64_t now_us) {
@@ -202,6 +264,13 @@ static void update_gpio(iambic_processor_t *proc, gpio_state_t gpio, int64_t now
     /* Arm memory ONLY during element transmission (not gap, not idle)
      * Memory window prevents arming at beginning (debounce) and end (too late).
      * During gap, we rely on Priority 3 (current paddle state) for squeeze alternation. */
+    if (proc->config.squeeze_mode == SQUEEZE_MODE_SAMPLED) {
+        /* The K8 rule replaces the window test with a grid-crossing test, and
+         * runs through the trailing space as well as the mark. */
+        sample_on_unit_grid(proc, now_us);
+        return;
+    }
+
     if (proc->state == IAMBIC_STATE_SEND_DIT || proc->state == IAMBIC_STATE_SEND_DAH) {
         bool in_window = is_in_memory_window(proc, now_us);
         bool can_arm_dit = (proc->state != IAMBIC_STATE_SEND_DIT);
@@ -362,4 +431,11 @@ static void start_element(iambic_processor_t *proc, iambic_element_t element, in
     proc->element_start_us = now_us;
     proc->element_duration_us = duration;
     proc->element_end_us = now_us + duration;
+
+    /* Anchor the unit grid to the element boundary. Unlike element_start_us,
+     * this survives the mark-to-gap transition, because the K8 keeps sampling
+     * through the trailing space. */
+    proc->elem_anchor_us = now_us;
+    proc->elem_type = element;
+    proc->samples_taken = 0;
 }

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -116,8 +116,8 @@ families:
 
       squeeze_mode:
         type: enum
-        enum_values: [LATCH_OFF, LATCH_ON]
-        default: LATCH_OFF
+        enum_values: [LATCH_OFF, LATCH_ON, SAMPLED]
+        default: SAMPLED
         nvs_key: "sqz_mode"
         runtime_change: idle_only
         priority: 4
@@ -129,11 +129,15 @@ families:
             en: "Squeeze Timing"
             it: "Temporizzazione Squeeze"
           description:
-            en: "When to sample paddle state (Live=continuous, Snapshot=latch at start)"
-            it: "Quando campionare lo stato dei paddle (Live=continuo, Snapshot=latch all'inizio)"
+            en: "When to sample paddle state (Sampled=once per unit, the K1EL K8 rule; Live=continuous; Snapshot=latch at start)"
+            it: "Quando campionare lo stato dei paddle (Sampled=una volta per unita, la regola del K1EL K8; Live=continuo; Snapshot=latch all'inizio)"
           widget: dropdown
           widget_config:
             options:
+              - value: SAMPLED
+                label:
+                  en: "Sampled (K1EL K8)"
+                  it: "Campionato (K1EL K8)"
               - value: LATCH_OFF
                 label:
                   en: "Live (immediate)"
@@ -256,7 +260,7 @@ families:
             default: DOT_AND_DAH
           squeeze_mode:
             type: enum
-            enum_values: [LATCH_OFF, LATCH_ON]
+            enum_values: [LATCH_OFF, LATCH_ON, SAMPLED]
             default: LATCH_ON
           mem_block_start_pct:
             type: f32

--- a/test_host/test_iambic.c
+++ b/test_host/test_iambic.c
@@ -252,3 +252,272 @@ void test_iambic_squeeze_prolonged(void) {
 
     (void)sample;
 }
+
+/* ============================================================================
+ * SQUEEZE_MODE_SAMPLED — the K1EL K8 sampling rule (issue #32)
+ *
+ * The K8 reads the paddle *level* on a one-unit grid phase-locked to the
+ * element boundary. A dah element spans 4 units (3u mark + 1u space) and is
+ * sampled at 1u, 2u, 3u, 4u. A press that opens and closes strictly between
+ * two instants is never observed.
+ *
+ * These tests drive the FSM at 1 ms, the same cadence as rt_task.c:176, so a
+ * sample instant is resolved at the first tick at or after k*u.
+ * ============================================================================
+ */
+
+#define K8_U_US  DIT_DURATION_20WPM      /* one dit-unit at 20 WPM = 60 ms */
+
+/* Elements started so far, as Morse: '.' = dit, '-' = dah. */
+#define K8_MAX_ELEMS 16
+static char k8_seq[K8_MAX_ELEMS + 1];
+static int  k8_seq_len;
+static iambic_state_t k8_prev_state;
+
+static void k8_seq_reset(void) {
+    k8_seq_len = 0;
+    k8_seq[0] = '\0';
+    k8_prev_state = IAMBIC_STATE_IDLE;
+}
+
+/** Tick the FSM at 1 ms from its current time up to (and including) t_end,
+ *  recording each element the FSM starts. 1 ms is rt_task.c's own cadence. */
+static void k8_run_until(int64_t *now_us, int64_t t_end, bool dit, bool dah) {
+    gpio_state_t gpio = gpio_from_paddles(dit, dah);
+    for (int64_t t = *now_us; t <= t_end; t += 1000) {
+        esp_timer_set_time(t);
+        (void)iambic_tick(&s_iambic, t, gpio);
+        if (s_iambic.state != k8_prev_state && k8_seq_len < K8_MAX_ELEMS) {
+            if (s_iambic.state == IAMBIC_STATE_SEND_DIT) {
+                k8_seq[k8_seq_len++] = '.';
+            } else if (s_iambic.state == IAMBIC_STATE_SEND_DAH) {
+                k8_seq[k8_seq_len++] = '-';
+            }
+            k8_seq[k8_seq_len] = '\0';
+        }
+        k8_prev_state = s_iambic.state;
+        *now_us = t;
+    }
+    *now_us = t_end + 1000;
+}
+
+static void k8_setup_sampled(void) {
+    iambic_config_t config = IAMBIC_CONFIG_DEFAULT;
+    config.wpm = 20;
+    config.mode = IAMBIC_MODE_A;          /* isolate sampling from the Mode B bonus */
+    config.squeeze_mode = SQUEEZE_MODE_SAMPLED;
+    config.memory_mode = MEMORY_MODE_DOT_AND_DAH;
+    iambic_init(&s_iambic, &config);
+    k8_seq_reset();
+}
+
+/** Same, with the memory disabled: DJ5IL's plain-iambic control case. */
+static void k8_setup_sampled_no_memory(void) {
+    iambic_config_t config = IAMBIC_CONFIG_DEFAULT;
+    config.wpm = 20;
+    config.mode = IAMBIC_MODE_A;
+    config.squeeze_mode = SQUEEZE_MODE_SAMPLED;
+    config.memory_mode = MEMORY_MODE_NONE;
+    iambic_init(&s_iambic, &config);
+    k8_seq_reset();
+}
+
+/**
+ * A dit tap that opens and closes strictly BETWEEN two sample instants is lost.
+ * Press at 1.2u, release at 1.6u: the grid ticks at 1u and 2u, so nothing sees
+ * it. This is the assertion a percentage-window model cannot satisfy, because
+ * 1.2u..1.6u lies inside [0%, 100%] of the dah mark.
+ */
+void test_iambic_k8_tap_between_instants_is_lost(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    /* Start a dah: 3u mark + 1u space. */
+    k8_run_until(&now, (K8_U_US * 12) / 10 - 1000, false, true);
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DAH, s_iambic.state);
+
+    /* Tap dit from 1.2u to 1.6u, entirely between the 1u and 2u instants. */
+    k8_run_until(&now, (K8_U_US * 16) / 10 - 1000, true, true);
+    k8_run_until(&now, K8_U_US * 4 + 2000, false, true);
+
+    /* The tap was never sampled, so no dit may have been queued. */
+    TEST_ASSERT_FALSE(s_iambic.dit_memory);
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DAH, s_iambic.state);
+}
+
+/**
+ * The same tap, moved so that it spans the 2u instant, IS observed.
+ * Press at 1.8u, release at 2.2u. Same duration as above, different phase:
+ * the difference is the grid, not the length of the press.
+ */
+void test_iambic_k8_tap_spanning_instant_is_seen(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    k8_run_until(&now, (K8_U_US * 18) / 10 - 1000, false, true);
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DAH, s_iambic.state);
+
+    /* Tap dit from 1.8u to 2.2u, crossing the 2u instant. */
+    k8_run_until(&now, (K8_U_US * 22) / 10 - 1000, true, true);
+    k8_run_until(&now, K8_U_US * 4 - 1000, false, true);
+
+    /* The 2u sample found the contact closed, so a dit is queued and sent. */
+    k8_run_until(&now, K8_U_US * 4 + 2000, false, true);
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DIT, s_iambic.state);
+}
+
+/**
+ * DJ5IL's memory test, [Lit4]: key an "N" with both levers released before the
+ * dash-element completes. With dot memory the dash is followed by a dot and you
+ * get N; without it the dot is lost and you get T.
+ *
+ * On the K8 the dah element spans 4u and is sampled at 1u, 2u, 3u and 4u, so a
+ * dit held across any of those instants survives.
+ */
+void test_iambic_k8_lit4_memory_gives_N(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    /* Dah first, dit joins at 0.5u, both released at 2.5u — well before the
+     * element boundary at 4u, but across the 1u and 2u instants. */
+    k8_run_until(&now, K8_U_US / 2 - 1000, false, true);
+    k8_run_until(&now, (K8_U_US * 25) / 10 - 1000, true, true);
+    k8_run_until(&now, K8_U_US * 8, false, false);
+
+    TEST_ASSERT_EQUAL_STRING("-.", k8_seq);
+}
+
+void test_iambic_k8_lit4_no_memory_gives_T(void) {
+    k8_setup_sampled_no_memory();
+    int64_t now = 0;
+
+    k8_run_until(&now, K8_U_US / 2 - 1000, false, true);
+    k8_run_until(&now, (K8_U_US * 25) / 10 - 1000, true, true);
+    k8_run_until(&now, K8_U_US * 8, false, false);
+
+    TEST_ASSERT_EQUAL_STRING("-", k8_seq);
+}
+
+/**
+ * DJ5IL's [Lit5], settled against the emulator rather than against his wording:
+ * a dash pressed during a dot and released BEFORE the 1u sample is lost, giving
+ * E; released after it, the 1u sample latches it, giving A.
+ *
+ * Both cases pin real K8 behaviour. The reference is the K8, not the article,
+ * so the release instants are concrete and the label is what may be debated.
+ */
+void test_iambic_k8_lit5_release_before_first_sample_gives_E(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    /* Dit starts at 0. Dah pressed 0.3u, both released 0.8u: nothing is sampled
+     * at 0.8u, and the first instant is 1u. */
+    k8_run_until(&now, (K8_U_US * 3) / 10 - 1000, true, false);
+    k8_run_until(&now, (K8_U_US * 8) / 10 - 1000, true, true);
+    k8_run_until(&now, K8_U_US * 6, false, false);
+
+    TEST_ASSERT_EQUAL_STRING(".", k8_seq);
+}
+
+void test_iambic_k8_lit5_release_after_first_sample_gives_A(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    /* Same press, released at 1.5u instead: the 1u sample found it closed. */
+    k8_run_until(&now, (K8_U_US * 3) / 10 - 1000, true, false);
+    k8_run_until(&now, (K8_U_US * 15) / 10 - 1000, false, true);
+    k8_run_until(&now, K8_U_US * 8, false, false);
+
+    TEST_ASSERT_EQUAL_STRING(".-", k8_seq);
+}
+
+/**
+ * DJ5IL's A-versus-B test, [Lit6]/[Lit7]: squeeze a "K" and release both levers
+ * during the second dash. Mode A completes it and gives K; Mode B adds one
+ * alternate element and gives C.
+ *
+ * The maintainer's note applies: from idle the K8 sends DIT on a simultaneous
+ * squeeze, so the operator must press dah first and close dit after.
+ */
+static void k8_squeeze_K(int64_t *now, bool mode_b) {
+    iambic_config_t config = IAMBIC_CONFIG_DEFAULT;
+    config.wpm = 20;
+    config.mode = mode_b ? IAMBIC_MODE_B : IAMBIC_MODE_A;
+    config.squeeze_mode = SQUEEZE_MODE_SAMPLED;
+    config.memory_mode = MEMORY_MODE_DOT_AND_DAH;
+    iambic_init(&s_iambic, &config);
+    k8_seq_reset();
+    *now = 0;
+
+    /* dah, then close dit: elements alternate dah, dit, dah (4u + 2u + 4u).
+     * Release both inside the second dah, which runs from 6u to 10u. */
+    k8_run_until(now, K8_U_US / 4 - 1000, false, true);
+    k8_run_until(now, (K8_U_US * 7) - 1000, true, true);
+    k8_run_until(now, K8_U_US * 16, false, false);
+}
+
+void test_iambic_k8_lit6_mode_a_squeeze_gives_K(void) {
+    int64_t now;
+    k8_squeeze_K(&now, false);
+    TEST_ASSERT_EQUAL_STRING("-.-", k8_seq);
+}
+
+void test_iambic_k8_lit7_mode_b_squeeze_gives_C(void) {
+    int64_t now;
+    k8_squeeze_K(&now, true);
+    TEST_ASSERT_EQUAL_STRING("-.-.", k8_seq);
+}
+
+/**
+ * A simultaneous squeeze from idle sends DIT first. In the K8 this falls out of
+ * NSAMPLE evaluating GP0 then GP1, so INLAST ends up reflecting the right
+ * contact and CHK_SINGLE falls through to CHK_S1 (issue #32).
+ */
+void test_iambic_k8_first_element_of_squeeze_is_dit(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    k8_run_until(&now, K8_U_US / 2, true, true);
+
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DIT, s_iambic.state);
+    TEST_ASSERT_EQUAL_STRING(".", k8_seq);
+}
+
+/**
+ * The grid is not anchored to the first unit only: a tap between the 2u and 3u
+ * instants of a dah is lost just as one between 1u and 2u is. Guards the grid
+ * arithmetic against an off-by-one that would only get the first instant right.
+ */
+void test_iambic_k8_tap_between_later_instants_is_lost(void) {
+    k8_setup_sampled();
+    int64_t now = 0;
+
+    k8_run_until(&now, (K8_U_US * 22) / 10 - 1000, false, true);
+    k8_run_until(&now, (K8_U_US * 27) / 10 - 1000, true, true);  /* 2.2u .. 2.7u */
+    k8_run_until(&now, K8_U_US * 8, false, false);
+
+    TEST_ASSERT_EQUAL_STRING("-", k8_seq);
+}
+
+/**
+ * The grid follows the dit-unit, not a hard-coded millisecond value. Same
+ * scenario at 12 WPM, where a unit is 100 ms instead of 60 ms.
+ */
+void test_iambic_k8_grid_scales_with_wpm(void) {
+    iambic_config_t config = IAMBIC_CONFIG_DEFAULT;
+    config.wpm = 12;
+    config.mode = IAMBIC_MODE_A;
+    config.squeeze_mode = SQUEEZE_MODE_SAMPLED;
+    config.memory_mode = MEMORY_MODE_DOT_AND_DAH;
+    iambic_init(&s_iambic, &config);
+    k8_seq_reset();
+
+    const int64_t u = 100000;  /* 1200000 / 12 */
+    int64_t now = 0;
+
+    k8_run_until(&now, (u * 12) / 10 - 1000, false, true);
+    k8_run_until(&now, (u * 16) / 10 - 1000, true, true);  /* 1.2u .. 1.6u */
+    k8_run_until(&now, u * 8, false, false);
+
+    TEST_ASSERT_EQUAL_STRING("-", k8_seq);
+}

--- a/test_host/test_iambic.c
+++ b/test_host/test_iambic.c
@@ -150,6 +150,12 @@ void test_iambic_memory(void) {
     iambic_config_t config = IAMBIC_CONFIG_DEFAULT;
     config.wpm = 20;
     config.mode = IAMBIC_MODE_B;
+    /* This test asserts on dah_memory halfway through the dit mark, which is a
+     * property of the windowed edge model, not of iambic keying as such: under
+     * SQUEEZE_MODE_SAMPLED no grid instant has been crossed at 0.5u, so the
+     * memory is legitimately still clear there. Name the mode explicitly rather
+     * than letting the test track whatever the default happens to be. */
+    config.squeeze_mode = SQUEEZE_MODE_LATCH_OFF;
     iambic_init(&s_iambic, &config);
 
     /* Start DIT */

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -20,6 +20,17 @@ void test_iambic_mode_a_squeeze(void);
 void test_iambic_mode_b_squeeze(void);
 void test_iambic_memory(void);
 void test_iambic_squeeze_prolonged(void);
+void test_iambic_k8_tap_between_instants_is_lost(void);
+void test_iambic_k8_tap_spanning_instant_is_seen(void);
+void test_iambic_k8_lit4_memory_gives_N(void);
+void test_iambic_k8_lit4_no_memory_gives_T(void);
+void test_iambic_k8_lit5_release_before_first_sample_gives_E(void);
+void test_iambic_k8_lit5_release_after_first_sample_gives_A(void);
+void test_iambic_k8_lit6_mode_a_squeeze_gives_K(void);
+void test_iambic_k8_lit7_mode_b_squeeze_gives_C(void);
+void test_iambic_k8_first_element_of_squeeze_is_dit(void);
+void test_iambic_k8_tap_between_later_instants_is_lost(void);
+void test_iambic_k8_grid_scales_with_wpm(void);
 
 void test_preset_init(void);
 void test_preset_activate(void);
@@ -273,6 +284,17 @@ int main(void) {
     RUN_TEST(test_iambic_mode_b_squeeze);
     RUN_TEST(test_iambic_memory);
     RUN_TEST(test_iambic_squeeze_prolonged);
+    RUN_TEST(test_iambic_k8_tap_between_instants_is_lost);
+    RUN_TEST(test_iambic_k8_tap_spanning_instant_is_seen);
+    RUN_TEST(test_iambic_k8_lit4_memory_gives_N);
+    RUN_TEST(test_iambic_k8_lit4_no_memory_gives_T);
+    RUN_TEST(test_iambic_k8_lit5_release_before_first_sample_gives_E);
+    RUN_TEST(test_iambic_k8_lit5_release_after_first_sample_gives_A);
+    RUN_TEST(test_iambic_k8_lit6_mode_a_squeeze_gives_K);
+    RUN_TEST(test_iambic_k8_lit7_mode_b_squeeze_gives_C);
+    RUN_TEST(test_iambic_k8_first_element_of_squeeze_is_dit);
+    RUN_TEST(test_iambic_k8_tap_between_later_instants_is_lost);
+    RUN_TEST(test_iambic_k8_grid_scales_with_wpm);
 
     /* Iambic Preset tests */
     printf("\n=== Iambic Preset Tests ===\n");

--- a/tools/k8/README.md
+++ b/tools/k8/README.md
@@ -30,11 +30,17 @@ fetch, verify the checksum, and keep the working copy out of git.
 The file is 64176 bytes and carries a timestamp of 1999-09-06 inside the
 archive it was distributed in.
 
-> **Source URL: not yet recorded.** The archived copy was supplied to the
-> project directly rather than fetched from a public snapshot. The Wayback
-> Machine holds only 34 captures of `k1el.com` and none of them is this file, so
-> the origin cannot be reconstructed from here. Whoever has the provenance
-> should record it in this table. Until then, verify by checksum only.
+**Where to get it.** The file is available on archive.org. No specific snapshot
+URL is recorded here on purpose: archive.org is slow and not reliable enough to
+sit in the path of a build or a test run.
+
+If we ever need a copy we can depend on, the answer is a **private repository of
+our own** holding it. The licence permits that — redistribution is allowed as
+long as the file is not sold or exploited for profit — and a private mirror
+keeps the GPL conflict away from this tree, which is the whole reason the file
+is not vendored here.
+
+Either way, **verify by checksum**, not by where it came from.
 
 Anything that does not match the checksum above is a different file, and the
 tests in `test_host/test_iambic.c` that pin K8 behaviour do not describe it.

--- a/tools/k8/README.md
+++ b/tools/k8/README.md
@@ -1,0 +1,88 @@
+# K1EL K8 — the keying reference, fetched and never vendored
+
+The K8 is the reference this project pins its iambic behaviour against
+(issue #32). Its source is **not** in this repository and must not be added to
+it. This directory holds the pointer, the checksum and the recipe to reproduce
+the oracle locally.
+
+## Why not vendored
+
+The licence, from the header of `morse8.asm`:
+
+> Copyright (C) 1998 Steven T. Elliott. All rights reserved.
+> Permission is granted to use, modify, or redistribute this software
+> so long as it is not sold or exploited for profit.
+
+Redistribution is permitted, so mirroring would be lawful. It is still not done,
+for a different reason: **the no-commercial-exploitation condition is
+incompatible with the GPL**, and vendoring the file would attach that condition
+to a tree that must stay redistributable under ordinary open-source terms. So we
+fetch, verify the checksum, and keep the working copy out of git.
+
+`tools/k8/ref/` is the conventional place for the fetched copy and is ignored.
+
+## What to fetch
+
+| file | sha256 |
+|---|---|
+| `morse8.asm` | `432df077a19774661c20cc87827d4f1290b7505daa722154b8b3c331a6e0c8de` |
+
+The file is 64176 bytes and carries a timestamp of 1999-09-06 inside the
+archive it was distributed in.
+
+> **Source URL: not yet recorded.** The archived copy was supplied to the
+> project directly rather than fetched from a public snapshot. The Wayback
+> Machine holds only 34 captures of `k1el.com` and none of them is this file, so
+> the origin cannot be reconstructed from here. Whoever has the provenance
+> should record it in this table. Until then, verify by checksum only.
+
+Anything that does not match the checksum above is a different file, and the
+tests in `test_host/test_iambic.c` that pin K8 behaviour do not describe it.
+
+## Reproducing the oracle
+
+Assembling for `gpasm` needs exactly one patch to the original: the label
+`CONFIG` must be renamed (we use `CONFIGM`), because `gpasm` reserves it. Keep
+the original file untouched and patch a copy.
+
+```bash
+gpasm --mpasm-compatible -p p12c509 -o morse8.hex morse8_gpasm.asm
+gpsim -i -p pic12c509 -c experiment.stc morse8.hex
+```
+
+Pin map, as wired in the experiment scripts:
+
+| pin | signal |
+|---|---|
+| gpio0 | DIT paddle |
+| gpio1 | DAH paddle |
+| gpio2 | KEY output |
+| gpio3 | push button |
+| gpio4 | sidetone |
+
+Inputs are pulled up, so **a closed contact reads 0**.
+
+The sign-on message runs at power-up until roughly cycle 591556 with the
+transmitter squelched. Drive the paddles only after that, or the first elements
+are swallowed.
+
+## Measured constants
+
+At `TIMEBASE 70`, which is about 14.2 WPM, with a 4 MHz clock and therefore
+1 µs per instruction cycle:
+
+| quantity | cycles |
+|---|---|
+| mark | 84566 |
+| space | 84382 |
+| sidetone period | 1208 |
+
+## What the reference actually says
+
+The verified reading of the sampling schedule, the latch-clearing rule and the
+maintainer's decisions all live on **issue #32**, which is authoritative. Read
+its comments from the bottom up: each later comment corrects the one before it.
+
+The implementation is `SQUEEZE_MODE_SAMPLED` in
+`components/keyer_iambic/src/iambic.c`; the tests that pin it are the
+`test_iambic_k8_*` group in `test_host/test_iambic.c`.


### PR DESCRIPTION
Implements the K1EL K8 sampling rule as a third `squeeze_mode` and makes it the
default, per the decisions recorded on #32.

## What changes

The K8 reads the paddle **level** on a one-unit grid phase-locked to the element
boundary, and at no other instant. A dit element spans 2 units and is sampled at
1u and 2u; a dah spans 4 and is sampled at 1u..4u. A press that opens and closes
strictly between two instants is never observed.

Our two existing squeeze modes both detect an **edge** inside a percentage
window, which is a different rule: it captures short taps the K8 drops. The
window stays, as an extension for high speeds — but it is not a generalisation
containing the reference, and #32 records why it cannot be: a single
`[start, end]` pair cannot encode the K8's asymmetric per-type behaviour, and a
window catches edges where the K8 only reads levels at instants.

Only the opposite element type is armed. The K8 clears the same-type latch after
the final sample (`morse8.asm:374` and `:409`), so a same-type press never
survives its own element; a held paddle continues through the live state read at
the element boundary, which is already Priority 3 of `decide_next_element()`.

The grid needs its own anchor. `element_start_us` is re-anchored by
`tick_sending()` when the gap begins, while the K8 keeps sampling through the
trailing space — hence `elem_anchor_us`, `elem_type` and `samples_taken`.

Cost: 76 lines in `iambic.c`, inside the "a few dozen lines" estimate the
approval on #32 was conditional on.

## The default

`parameters.yaml` gains `SAMPLED` in both enum lists and switches
`keyer.squeeze_mode` to it. `IAMBIC_CONFIG_DEFAULT` is aligned so that reading
`iambic.h` does not tell you the default is `LATCH_OFF` while the shipped
firmware runs `SAMPLED`.

`preset_template.squeeze_mode` keeps its own default of `LATCH_ON`. That store is
deprecated in favour of `g_config` and its default already disagreed with the
active parameter before this change; the divergence is existing tracked debt and
is deliberately not resolved here.

## On the tests, honestly

Eleven `test_iambic_k8_*` tests. Re-running every scenario with `squeeze_mode`
forced back to `LATCH_OFF` shows that only **four** discriminate the new rule:
the tap lost between 1u and 2u, the same between 2u and 3u, DJ5IL's `[Lit5]`
case A, and the grid scaling with WPM.

The other seven pin invariants both models share — memory present or absent,
Mode A versus Mode B on a squeezed K, the first element of a simultaneous
squeeze. They are regression guards, not evidence for the new rule, and the PR
should be read that way.

`test_iambic_memory` began failing when the default changed, because it asserted
that `dah_memory` is set halfway through the dit mark. That is a property of the
windowed edge model, not of iambic keying: under the sampled rule no grid instant
has been crossed at 0.5u. It now names `LATCH_OFF` explicitly instead of tracking
whatever the default happens to be. Its behaviour is unchanged.

Host suite **202/202 green, plain and ASan/UBSan**.

## `tools/k8/`

Records what a fresh clone needs to rebuild the oracle: the checksum, the single
label rename `gpasm` requires, the pin map, the power-up sign-on that swallows
early paddle input, and the measured constants at `TIMEBASE 70`.

Fetch, never vendor. Redistribution is permitted by the header, so mirroring
would be lawful; the reason not to is that the no-commercial-exploitation
condition is incompatible with the GPL and would attach itself to this tree. The
source is on archive.org and no snapshot URL is pinned, deliberately — if a
dependable copy is ever needed the answer is a private repository of our own.

`morse8.zip` and a loose `morse8.asm` are now ignored, closing the trap the last
handoff flagged: the archive sat untracked in the repository root where a
`git add -A` would have committed it.

## What this does not do

#32 stays open, and its narrowing comment says why. The tolerance was not written
down before the tests, `test_iambic.c:88`'s vacuous assertion is still there
(these tests were added next to it, not in place of it), and the timing
comparison against gpsim traces has not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
