### PR TITLE
workflow: fix the shape of issues and pull requests, with templates

### DIFF
--- a/.claude/skills/issue-sweep/SKILL.md
+++ b/.claude/skills/issue-sweep/SKILL.md
@@ -16,7 +16,9 @@ condition against the tree, read-only.
 1. **List.** `gh issue list --state open --json number,title,labels` (or only `$ARGUMENTS`).
 2. **Read every body.** `gh issue view N --json body,comments`. Extract the resolution condition —
    the *What would make it right* paragraph, or the equivalent. If an issue has no testable
-   condition, say so: that is a finding, not a pass.
+   condition, say so: that is a finding, not a pass. A `Parked:` issue keeps its condition under
+   *What would unpark it*; when it holds, the verdict is `narrowed` (it becomes a Work issue),
+   never `closable`.
 3. **Test the condition against the tree.** Read-only: `grep`, `ls`, `git log -S`, `git show`.
    Name the exact evidence — `file:line`, a commit SHA, a file that now exists or no longer does.
    Do not infer from titles, from memory of the session, or from a handoff's claims.

--- a/.compound-engineering/config.yaml
+++ b/.compound-engineering/config.yaml
@@ -1,0 +1,8 @@
+# Compound-engineering skill configuration for this repository.
+# Read by the ce-* skills. A git-ignored config.local.yaml beside this file
+# wins over it, per machine.
+#
+# PR bodies carry no "New concepts" teaching section. The reader is the
+# maintainer, once, at review: a PR body is evidence against the Definition
+# of done (.github/pull_request_template.md), not a lesson.
+pr_teaching_section: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/decision.md
+++ b/.github/ISSUE_TEMPLATE/decision.md
@@ -1,0 +1,48 @@
+---
+name: Decision
+about: Work depends on a choice nobody has made. Labelled blocking; only the maintainer closes it, by deciding.
+title: ""
+labels: ["blocking"]
+---
+
+<!--
+Remove every comment block before filing. Keep the headings verbatim.
+
+A blocking issue holds a decision, not a code condition. It stops the work
+that depends on it, completely, until the maintainer decides (CLAUDE.md,
+"A Blocking Issue Blocks"). /issue-sweep never closes it.
+
+Same rules as a Work issue on reader, length (body under 300 words), refs,
+title and comments. In addition:
+
+OPTIONS   Each option: what it is, what it costs, what it commits us to.
+          A recommendation is one line, marked "Recommendation:". The choice
+          is the maintainer's.
+DECISION  When taken, it is written under "Decision" with the date, by
+          editing the body, not in a comment, and the maintainer closes the
+          issue. The work it unblocks is a Work issue that names this one
+          under "Blocked on".
+-->
+
+## The decision needed
+
+<!-- One question, answerable by a choice. Two questions are two issues. -->
+
+## Why it cannot be assumed
+
+<!-- What gets built on the guess if work proceeds without it: which
+behaviour, which test, which downstream work. -->
+
+## Options
+
+<!-- One per item: what it is, what it costs, what it commits us to.
+Recommendation, if any, as one line. -->
+
+## What it blocks
+
+<!-- Issue numbers, or the work by name. -->
+
+## Decision
+
+<!-- Empty until the maintainer decides. Then: the choice, the date, one
+line of why. -->

--- a/.github/ISSUE_TEMPLATE/parked.md
+++ b/.github/ISSUE_TEMPLATE/parked.md
@@ -1,0 +1,39 @@
+---
+name: Parked
+about: Outside the current boundaries. Recorded so it is not rediscovered, not scheduled.
+title: "Parked: "
+labels: []
+---
+
+<!--
+Remove every comment block before filing. Keep the headings verbatim.
+
+A boundary forbids building, not remembering (STRATEGY.md, "Boundaries").
+This issue records something we will not do now, so it is not rediscovered
+in six months and so we know what waits when the boundary moves. It does not
+pass in front of the bench, CWNet and K8.
+
+Same rules as a Work issue on reader, length (body under 300 words), refs
+and comments.
+
+CLOSING   When the boundary moves it becomes a Work issue: rewrite the body,
+          drop the prefix. /issue-sweep reports it as `narrowed`, never
+          `closable`. Or it is discarded, with one line saying why.
+-->
+
+## What it is
+
+<!-- Two to four sentences. -->
+
+## Which boundary parks it
+
+<!-- The line in STRATEGY.md. -->
+
+## What would unpark it
+
+<!-- The condition, so the sweep can see it move. -->
+
+## What is already known
+
+<!-- Links to what was learnt: a file, a source, a comment elsewhere. Not
+the analysis itself. -->

--- a/.github/ISSUE_TEMPLATE/work.md
+++ b/.github/ISSUE_TEMPLATE/work.md
@@ -1,0 +1,57 @@
+---
+name: Work
+about: Something in the tree is wrong or missing, and the condition that fixes it can be tested against the tree.
+title: ""
+labels: []
+---
+
+<!--
+Remove every comment block before filing. Keep the four headings verbatim:
+/issue-sweep looks for them.
+
+READER    Whoever decides what to do next, not the session doing the work.
+          Analysis, reading notes and worked reasoning go in a file in the
+          repo (docs/solutions/, a module CLAUDE.md, a handoff); the issue
+          links it.
+LENGTH    Body under 300 words. If it does not fit, it is two issues, or the
+          analysis belongs in a file.
+ONE       One problem per issue. A second problem found on the way is a
+          second issue, or a light fix done on the spot (CLAUDE.md, "Work
+          That Needs Deciding Becomes an Issue").
+REFS      `file:line` only under "What would make it right" and toward frozen
+          references (morse8.asm, DL4YHF traces). In prose about our own
+          code name the function: line numbers rot at the next commit.
+TITLE     What is wrong, as observed. Not the fix, not the plan.
+NO        Narrating which rule this issue honours. "Nobody had noticed."
+          Prose whose reader is its author.
+
+COMMENTS  State changes and decisions only, under 150 words each. A longer
+          analysis goes in a file; the comment carries the link and one line
+          of outcome. A decision that supersedes an earlier one edits the
+          body, never appends "this supersedes the above": a thread that must
+          be read bottom-up is a log, not an issue.
+CLOSING   On evidence: a comment naming the commit or `file:line` where the
+          condition below holds. Not when the work feels done, not when the
+          session ends.
+-->
+
+## What is wrong
+
+<!-- What happens and what should happen, in two to four sentences. No
+history of how it was found. -->
+
+## Evidence
+
+<!-- What shows it: a failing test, a trace, a measurement, a reference that
+says otherwise. Cite; do not reproduce. -->
+
+## What would make it right
+
+<!-- One condition, testable against the tree by someone with no memory of
+this session. If a decision has to be taken first, file a Decision issue and
+name it under "Blocked on". -->
+
+## Blocked on
+
+<!-- Issue numbers, or "nothing". A `blocking` issue here stops this work
+completely (CLAUDE.md, "A Blocking Issue Blocks"). -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Remove the comment blocks before filing. Keep the headings. Under a heading
+that does not apply write "n/a" and nothing else.
+
+READER    The maintainer, once, at review. Say what is now different and why
+          it was worth doing. Do not restate the diff: the Files tab does.
+EVIDENCE  The Definition of done (CLAUDE.md) is answered with evidence, not
+          checkmarks: a number, a test name, a `file:line`. A line that
+          cannot be filled honestly is a PR that is not done.
+NO        Narrating which rule this PR honours. Model or harness signatures
+          (CLAUDE.md, "Git conventions").
+-->
+
+## What changes
+
+<!-- One or two sentences a reviewer can stop after. Then only what the diff
+does not show: the decision taken, the alternative rejected. -->
+
+## Closes
+
+<!-- Issue #N, the condition under its "What would make it right", and where
+it now holds: `file:line` or commit. Or "none". If only part of the
+condition holds, say which part and that the issue stays open. -->
+
+## Definition of done
+
+- Host tests: <!-- N/N plain, N/N ASan/UBSan. n/a for a docs-only change. -->
+- Reference test: <!-- keyer_cwnet or keyer_iambic only: the test function, and the reference it pins against. Otherwise n/a. -->
+- RT path: <!-- untouched, or what changed on Core 0 and why it stays inside the 100 µs ceiling. -->
+- Blocking issues open on this work: <!-- none. If not none, this PR should not exist yet. -->
+
+## Not done here
+
+<!-- Deliberately deferred scope, stated once, with where it is tracked. Or
+"nothing". -->

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ test_host/build*/
 morse8.zip
 morse8.asm
 tools/k8/ref/
+
+# compound-engineering: per-machine overrides, never committed
+.compound-engineering/config.local.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ A debt earns an issue when at least one is true:
 
 Then: one issue per problem, say what is wrong and what would make it right, and if it is blocked on a decision label it `blocking` — **A Blocking Issue Blocks** applies from that moment.
 
+The shape and the caps are fixed by the templates in [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) — `Work`, `Decision`, `Parked`: body under 300 words; a comment under 150 and carrying only a state change or a decision; analysis in a file the issue links, never in the thread; a decision that supersedes an earlier one written by editing the body. Read the template before `gh issue create`, and file with `--body-file` from a filled copy with the comment blocks removed. The rules bind comments and edits, not only filing.
+
 **Everything lighter, just fix it.** A stale path, a rotten README line, a typo in a doc — anything you can correct *correctly* on the spot, where the fix is obvious and needs nobody's opinion. Filing those is QRM: it buries the issues that carry a real decision under a list nobody wants to read. If you cannot fix it correctly on the spot because you would be guessing, that is precisely the signal it needed an issue.
 
 **The four conditions win over "lighter".** They are not two tests to weigh against each other: if any condition holds, it is an issue, however small the edit looks. A one-line version bump you cannot verify here is an issue, not a light fix — the size of the diff is not the size of the risk.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ From [STRATEGY.md](STRATEGY.md): behaviour that matters is proven against a real
 - A change touching CWNet (`keyer_cwnet/`) or the iambic FSM (`keyer_iambic/`) ships with a host test that pins the behaviour against the reference (DL4YHF client/server traces, K1EL K8 source).
 - Nothing blocking on the RT path: no `ESP_LOGx`/`printf` on Core 0 — the serial log blocks real time.
 
+A pull request answers these with evidence, not checkmarks, in the shape of [.github/pull_request_template.md](.github/pull_request_template.md): test counts, the test function that pins the reference, the issue condition it makes true and where. A line that cannot be filled honestly is a PR that is not done.
+
 ---
 
 ## ESP-IDF v6 Notes


### PR DESCRIPTION
## What changes

Issues and pull requests get a fixed shape. Filed as a PR per *Changing How We Work Requires Review*; nothing is applied to the backlog until reviewed.

- **Three issue templates** in `.github/ISSUE_TEMPLATE/`. **Work**: something in the tree is wrong, closes on evidence — What is wrong · Evidence · What would make it right · Blocked on. **Decision**: labelled `blocking`, closed by the maintainer writing the choice into the body. **Parked**: outside a STRATEGY.md boundary, becomes Work when the boundary moves. Caps: body under 300 words; a comment under 150, carrying only a state change or a decision; analysis in a file the issue links, never in the thread; a superseding decision edits the body.
- **One PR template**, `.github/pull_request_template.md`: the Definition of done as questions answered with evidence, not checkmarks. This body is its first instance.
- **`.compound-engineering/config.yaml`** with `pr_teaching_section: false`: the CE skill stops appending a "New concepts" section to PR bodies. The skill picks up the PR template on its own as a structural contract. The issue templates need the pointer in `CLAUDE.md` instead, because `gh issue create --body-file` bypasses anything GitHub validates.
- **`CLAUDE.md`**: one paragraph under the issue rule, one under the Definition of done. **`issue-sweep`**: a Parked issue keeps its condition under *What would unpark it* and is `narrowed`, never `closable`.

**What it would have changed.** #32: a body of 1121 words; 16 comments in nine hours, 46k characters, two of them 9k-character analyses; one declares it supersedes everything above, three open with "Correction"; `tools/k8/README.md` now tells the reader to read that thread bottom-up. Under this rule the analyses would be two files under `docs/solutions/`, the decisions would sit in the body, and the thread would hold the four status changes that actually happened. The other nineteen open issues are 120–580 words and pass as they are.

## To decide in review

- The two numbers, 300 and 150.
- Whether a decision that edits the body also leaves a one-line comment, for the notification.
- Whether #32 is rewritten to the Work shape now, or left as the last thread of the old kind.

## Closes

none

## Definition of done

- Host tests: n/a, templates and docs only; no source touched.
- Reference test: n/a
- RT path: untouched
- Blocking issues open on this work: none

## Not done here

#32 is not rewritten. It is the maintainer's, and it is the first application of the Work template.
