### PR TITLE
test(iambic): pin the first element of a simultaneous squeeze to DIT

### DIFF
--- a/test_host/test_iambic.c
+++ b/test_host/test_iambic.c
@@ -83,9 +83,13 @@ void test_iambic_mode_a_squeeze(void) {
     esp_timer_set_time(0);
     stream_sample_t sample = iambic_tick(&s_iambic, 0, gpio);
 
-    /* Should start with DIT (or DAH depending on implementation) */
+    /* A simultaneous squeeze from idle starts with DIT. This is not an
+     * implementation choice: in the K8 it falls out of NSAMPLE evaluating GP0
+     * before GP1, so a sample finding both contacts closed leaves INLAST
+     * reflecting the right contact and CHK_SINGLE falls through to CHK_S1
+     * (morse8.asm:882). See issue #32. */
     TEST_ASSERT_TRUE(s_iambic.key_down);
-    TEST_ASSERT_TRUE(s_iambic.state == IAMBIC_STATE_SEND_DIT || s_iambic.state == IAMBIC_STATE_SEND_DAH);
+    TEST_ASSERT_EQUAL(IAMBIC_STATE_SEND_DIT, s_iambic.state);
 
     /* Release during element - Mode A should stop */
     gpio = gpio_from_paddles(false, false);


### PR DESCRIPTION
## What changes

`test_iambic.c:88` asserted that a squeeze from idle starts with `SEND_DIT` or
`SEND_DAH`, commented *"depending on implementation"*. Both branches of a
boolean are always true, so the line could not fail and pinned nothing. It now
asserts DIT.

It is not an implementation choice. In the K8 it falls out of `NSAMPLE`
evaluating GP0 before GP1: a sample finding both contacts closed leaves `INLAST`
reflecting the right contact, so `CHK_SINGLE` falls through to `CHK_S1`
(`morse8.asm:882`).

## Closes

Issue #32, condition 3 of *What would make it right* — "host tests that pin the
three exact decisions, replacing `test_iambic.c:88`'s vacuous assertion". The
replacement now holds at `test_host/test_iambic.c:92`.

The issue **stays open**: conditions 1 and 2 hold, condition 4 was reported in
the thread, but this only completes the replacement half of condition 3.

## Definition of done

- Host tests: 202/202 plain, 202/202 ASan/UBSan.
- Reference test: `test_iambic_mode_a_squeeze`, pinning the first element of a
  simultaneous squeeze against the K8 (`morse8.asm:882`). Inverting the
  assertion to `SEND_DAH` makes it fail, which the old line could not do.
- RT path: untouched, test-only change.
- Blocking issues open on this work: none.

## Not done here

Nothing.
