### PR TITLE
fix(wireshark): drop redundant postdissector registration

### DIFF
--- a/tools/wireshark/cwnet.lua
+++ b/tools/wireshark/cwnet.lua
@@ -355,7 +355,4 @@ end
 local tcp_table = DissectorTable.get("tcp.port")
 tcp_table:add(7355, cwnet_proto)
 
--- Also allow manual decode-as
-register_postdissector(cwnet_proto)
-
 print("CWNet dissector loaded - port 7355")


### PR DESCRIPTION
## What changes

`tools/wireshark/cwnet.lua` deletes the redundant `register_postdissector(cwnet_proto)` call (and the stale "manual decode-as" comment above it). The dissector already registers correctly as a port-scoped dissector on TCP 7355 (`tcp_table:add(7355, cwnet_proto)`, unchanged since the file's only commit) — the postdissector call was the second, wrong registration running the dissector against every captured frame regardless of port. No alternative considered: the issue's narrowing comment already pinned the exact line, this is a one-line deletion plus removing the comment that only described it.

## Closes

Issue #15, "What would make it right": register as a normal dissector bound to TCP 7355 instead of a postdissector. That already held before this PR (`:355-356`); this PR removes the remaining `register_postdissector(cwnet_proto)` at what was `tools/wireshark/cwnet.lua:359` (see the 2026-09-06 issue-sweep comment on #15). After this change the file registers only via `tcp_table:add(7355, cwnet_proto)` — `tools/wireshark/cwnet.lua:355-356`, and does not call `register_postdissector` anywhere.

## Definition of done

- Host tests: 202/202 plain, 202/202 ASan/UBSan (macOS; ASan leak detection unsupported on this platform, so `ASAN_OPTIONS=detect_leaks=1` was dropped for the run — UBSan halt-on-error still enabled). Sanity check only: this change touches a standalone Lua tool, not anything host-tested.
- Reference test: n/a — not CWNet or iambic C code, a Wireshark Lua dissector.
- RT path: untouched.
- Blocking issues open on this work: none.

## Not done here

Nothing. The dissector's field decoding logic is unchanged; only the redundant registration is removed.
