### PR TITLE
console: one place draws the line, so the screen cannot contradict the buffer

### DIFF
--- a/components/keyer_console/CLAUDE.md
+++ b/components/keyer_console/CLAUDE.md
@@ -6,7 +6,8 @@ interactive text console. Parses input a character at a time, maintains history 
 tab completion, dispatches parsed commands to handlers, and prints results. It is a
 user-facing interface: it runs only on Core 1 (background) and must NEVER touch the
 hard RT path or block it. It does not own the USB transport — bytes are fed in by
-keyer_usb; on-host builds it can echo directly.
+keyer_usb — but it does own the echo: one internal function repaints the whole line
+from the buffer, and no caller echoes on its own.
 
 Key abstractions:
 - `console_push_char()` / `console_process_char()` — feed one input byte; return true

--- a/components/keyer_console/include/console.h
+++ b/components/keyer_console/include/console.h
@@ -127,6 +127,10 @@ void console_task(void *arg);
 
 /**
  * @brief Process single character input
+ *
+ * Thin wrapper around console_push_char(); kept as the entry point for the
+ * getchar() loop in console_task().
+ *
  * @param c Input character
  * @return true if command was executed
  */
@@ -135,7 +139,8 @@ bool console_process_char(char c);
 /**
  * @brief Push character to console (from USB callback)
  *
- * Same as console_process_char but without echo (echo handled by USB).
+ * Owns the echo: the character is judged once, against the line buffer, and
+ * the line is repainted from that buffer. Callers must not echo themselves.
  *
  * @param c Input character
  * @return true if command was executed
@@ -144,6 +149,8 @@ bool console_push_char(char c);
 
 /**
  * @brief Print the console prompt
+ *
+ * Repaints the current line; with an empty buffer that is the prompt alone.
  */
 void console_print_prompt(void);
 

--- a/components/keyer_console/src/completion.c
+++ b/components/keyer_console/src/completion.c
@@ -340,12 +340,13 @@ bool console_complete(char *line, size_t *pos, size_t max_len) {
         return true;
     }
 
-    /* Multiple matches - show all and complete common prefix */
-    printf("\n");
+    /* Multiple matches - show all and complete common prefix.
+     * CRLF, not LF: the console terminal is raw, a bare LF would staircase. */
+    printf("\r\n");
     for (size_t i = 0; i < match_count; i++) {
         printf("%s ", matches[i]);
     }
-    printf("\n");
+    printf("\r\n");
     fflush(stdout);
 
     /* Complete to common prefix if longer than current */

--- a/components/keyer_console/src/console.c
+++ b/components/keyer_console/src/console.c
@@ -38,6 +38,23 @@ typedef enum {
 
 static escape_state_t s_escape_state = ESC_NONE;
 
+/**
+ * @brief The one place that draws.
+ *
+ * Repaints the whole line from the buffer: carriage return, prompt, the
+ * s_line_pos characters the buffer actually holds, erase-to-end-of-line.
+ * Nothing else in the console emits an incremental correction, so what the
+ * operator sees is a function of (s_line_buf, s_line_pos) and cannot
+ * disagree with it. This is also the only occurrence of the prompt string.
+ */
+static void console_redraw_line(void) {
+    const char *callsign = g_config.system.callsign;
+    printf("\r%s> %.*s\033[K",
+           (callsign[0] != '\0') ? callsign : "",
+           (int)s_line_pos, s_line_buf);
+    fflush(stdout);
+}
+
 void console_init(void) {
     s_line_pos = 0;
     memset(s_line_buf, 0, sizeof(s_line_buf));
@@ -46,13 +63,8 @@ void console_init(void) {
 }
 
 void console_print_prompt(void) {
-    const char *callsign = g_config.system.callsign;
-    if (callsign[0] != '\0') {
-        printf("%s> ", callsign);
-    } else {
-        printf("> ");
-    }
-    fflush(stdout);
+    /* The prompt is the line drawn over an empty buffer. */
+    console_redraw_line();
 }
 
 bool console_push_char(char c) {
@@ -75,10 +87,7 @@ bool console_push_char(char c) {
                 s_line_buf[CONSOLE_LINE_MAX - 1] = '\0';
                 s_line_pos = strlen(s_line_buf);
 
-                /* Clear and redraw line */
-                const char *call1 = g_config.system.callsign;
-                printf("\r%s> %s\033[K", call1[0] ? call1 : "", s_line_buf);
-                fflush(stdout);
+                console_redraw_line();
             }
             return false;
         } else if (c == 'B') {
@@ -100,10 +109,7 @@ bool console_push_char(char c) {
                 }
             }
 
-            /* Clear and redraw line */
-            const char *call2 = g_config.system.callsign;
-            printf("\r%s> %s\033[K", call2[0] ? call2 : "", s_line_buf);
-            fflush(stdout);
+            console_redraw_line();
             return false;
         }
         return false;
@@ -126,13 +132,10 @@ bool console_push_char(char c) {
 
     /* Handle Tab completion */
     if (c == 0x09) {
-        /* Tab character - try to complete */
-        if (console_complete(s_line_buf, &s_line_pos, CONSOLE_LINE_MAX)) {
-            /* Completion succeeded - redraw line */
-            const char *call3 = g_config.system.callsign;
-            printf("\r%s> %s", call3[0] ? call3 : "", s_line_buf);
-            fflush(stdout);
-        }
+        /* Try to complete, then repaint whatever the buffer now holds.
+         * console_complete() may itself have printed a list of matches. */
+        (void)console_complete(s_line_buf, &s_line_pos, CONSOLE_LINE_MAX);
+        console_redraw_line();
         return false;
     }
 
@@ -163,12 +166,15 @@ bool console_push_char(char c) {
         s_saved_pos = 0;
         return true;  /* Always reprint prompt after Enter */
     } else if (c == '\b' || c == 0x7F) {
-        /* Backspace */
+        /* Backspace: on an empty line the buffer does not change, and the
+         * repaint therefore does not change the screen either. */
         if (s_line_pos > 0) {
             s_line_pos--;
         }
+        console_redraw_line();
     } else if (c == 0x03) {
         /* Ctrl+C - cancel current line */
+        printf("^C\r\n");
         s_line_pos = 0;
         s_saved_pos = 0;
         return true;
@@ -176,29 +182,22 @@ bool console_push_char(char c) {
         /* Ctrl+U - clear line */
         s_line_pos = 0;
         s_saved_pos = 0;
+        console_redraw_line();
     } else if (c >= 0x20 && c <= 0x7E) {
-        /* Printable character */
+        /* Printable character. A character refused because the buffer is
+         * full is not drawn either: the repaint shows the buffer. */
         if (s_line_pos < CONSOLE_LINE_MAX - 1) {
             s_line_buf[s_line_pos++] = c;
         }
+        console_redraw_line();
     }
 
     return false;
 }
 
 bool console_process_char(char c) {
-    /* Echo character (for non-USB usage) */
-    if (c >= 0x20 && c <= 0x7E) {
-        putchar(c);
-    } else if (c == '\r' || c == '\n') {
-        printf("\r\n");
-    } else if (c == '\b' || c == 0x7F) {
-        printf("\b \b");
-    } else if (c == 0x03) {
-        printf("^C\r\n");
-    }
-    fflush(stdout);
-
+    /* No echo here: console_push_char() draws. Retained as the entry point
+     * for the getchar() loop below. */
     return console_push_char(c);
 }
 

--- a/components/keyer_usb/CLAUDE.md
+++ b/components/keyer_usb/CLAUDE.md
@@ -9,7 +9,8 @@ bytes only — command parsing lives in keyer_console, log formatting in keyer_l
 Key abstractions:
 - `usb_cdc_init()` / `usb_cdc_write()` / `usb_cdc_flush()` / `usb_cdc_connected()` — raw
   per-interface I/O. CDC0=console, CDC1=log, CDC2=Winkeyer (reserved).
-- `usb_console_*` — CDC0 RX callback echoes and pushes chars into console_push_char;
+- `usb_console_*` — CDC0 RX callback pushes chars into console_push_char, which owns
+  the echo (the callback deliberately does not echo);
   `usb_console_printf()` is the console output sink.
 - `usb_log_*` — CDC1 drain task pulls the RT-safe log ring buffer and applies
   global/per-tag level filters (`usb_log_set_level`, `usb_log_set_tag_level`).

--- a/components/keyer_usb/src/usb_console.c
+++ b/components/keyer_usb/src/usb_console.c
@@ -16,37 +16,11 @@
 static const char *TAG = "usb_console";
 
 /**
- * @brief Echo single character to CDC0
- */
-static void echo_char(char c) {
-    uint8_t buf[4];
-    size_t len = 0;
-
-    if (c >= 0x20 && c <= 0x7E) {
-        /* Printable character */
-        buf[0] = (uint8_t)c;
-        len = 1;
-    } else if (c == '\r' || c == '\n') {
-        /* Enter - echo CRLF */
-        buf[0] = '\r';
-        buf[1] = '\n';
-        len = 2;
-    } else if (c == 0x08 || c == 0x7F) {
-        /* Backspace or DEL - destructive backspace */
-        buf[0] = '\b';
-        buf[1] = ' ';
-        buf[2] = '\b';
-        len = 3;
-    }
-    /* Ctrl+C, Ctrl+U: no echo */
-
-    if (len > 0) {
-        tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, len);
-    }
-}
-
-/**
- * @brief RX callback for CDC0 - immediate echo
+ * @brief RX callback for CDC0
+ *
+ * Bytes go straight into the console state machine, which draws them.
+ * This callback deliberately does not echo: an echo here would be a second
+ * judgement of the same keystroke, made without sight of the line buffer.
  */
 static void console_rx_callback(int itf, cdcacm_event_t *event) {
     (void)event;
@@ -64,14 +38,8 @@ static void console_rx_callback(int itf, cdcacm_event_t *event) {
     }
 
     for (size_t i = 0; i < len; i++) {
-        char c = (char)buf[i];
-
-        /* Echo immediately */
-        echo_char(c);
-
-        /* Push to console state machine */
-        bool cmd_complete = console_push_char(c);
-        if (cmd_complete) {
+        /* Push to console state machine (it echoes by repainting the line) */
+        if (console_push_char((char)buf[i])) {
             usb_console_prompt();
         }
     }


### PR DESCRIPTION
## What changes

The console line editor now has one function that draws — `console_redraw_line()`
(`components/keyer_console/src/console.c:41-56`) — which repaints the whole line
from the buffer: `\r`, prompt, the `s_line_pos` characters the buffer actually
holds, `\033[K`. Every site that previously attempted its own incremental
correction calls it, and the USB RX callback no longer echoes at all.

**I took option 1, "one place draws", not the two-line patch.** The reasoning:

- The two-line patch fixes the two symptoms that were reported. It does not fix
  the third instance of the same split, which was already in the code and which
  nobody had reported: at 63 characters `console_push_char()` refuses the
  keystroke while `echo_char()` echoed it anyway. Finding that by reading, in a
  56-line function, is the argument against leaving the structure in place — the
  next instance is cheap to write and expensive to notice.
- The cost of the repaint is bytes on CDC0. Worst case is ~76 bytes per keystroke
  (`CONSOLE_LINE_MAX` is 64, prompt is a callsign), against a 4096-byte TX buffer
  (`sdkconfig.defaults:27`), on Core 1. The console is not on the RT path and USB
  CDC is not a 1200-baud link; this is the same full-line repaint that linenoise
  and every other small line editor does on every keystroke.
- It removes the prompt duplication as a side effect rather than as a second
  change: the prompt string now occurs once, and `console_print_prompt()` is
  defined as the line drawn over an empty buffer.

What that makes structurally impossible: the drawn output is a function of
(`s_line_buf`, `s_line_pos`). A future call site cannot reintroduce the class,
because there is nothing else to call.

Two behaviour changes fall out of unifying the USB and UART paths, both
deliberate and both listed here because the diff shows the code and not the
intent: Ctrl+C now echoes `^C` on USB as it already did on UART, and Enter no
longer advances two lines on USB (`echo_char()` and `console_push_char()` were
each emitting a CRLF — a third divergence, found while removing the first).

One line outside the two reported symptoms: the Tab match list printed a bare LF
(`completion.c:345,349`), which staircases on the raw console terminal. It is part
of the same drawing mechanism and becomes visible exactly when the Tab redraw
works, so it is a CRLF now.

## Closes

Closes #30. Its condition — "One place draws. It takes the buffer and repaints the
whole line — `\r`, prompt, buffer, `\033[K` — and no scattered `printf` attempts an
incremental correction" — holds at `components/keyer_console/src/console.c:41-56`,
with the call sites at `:90`, `:112`, `:138`, `:174`, `:185`, `:192` and the
prompt at `:65-68`. `echo_char()` is deleted from
`components/keyer_usb/src/usb_console.c`. The prompt string, previously in four
places, is in one.

Not closed by this PR, because #30 records it as out of scope: left/right arrows
are still unhandled, `s_line_pos` is still both length and cursor, and backspace
still only removes the last character.

## Definition of done

- Host tests: 202/202 plain, 202/202 with `-fsanitize=address,undefined`. **They do
  not exercise this change.** `console.c` is excluded from the host build
  (`test_host/CMakeLists.txt:76`, "requires commands.c"), as are `history.c`,
  `completion.c`, `test_history.c` and `test_completion.c`. The pass counts say
  this PR broke nothing else; they say nothing about the console.
  What I could verify without hardware: `console.c` and `completion.c` compile
  clean under `gcc -std=c11 -Wall -Wextra -Werror -Wconversion -Wsign-conversion
  -Wshadow -Wformat=2` on the host path (`ESP_PLATFORM` undefined) against
  generated config headers. `usb_console.c` I could not compile — it needs the
  TinyUSB headers, ESP-IDF is not installed on this machine, and CI does not build
  the firmware (#29). What I could not verify at all: what any of this looks like
  on a terminal. The three symptoms — backspace on an empty line, Tab completing
  to a shorter line, a keystroke refused by a full buffer — need the bench.
  Filed #46 for the missing host coverage, which is why #30 survived from the day
  the console was written until a hardware session found it.
- Reference test: n/a — no `keyer_cwnet/` or `keyer_iambic/` code is touched.
- RT path: untouched. All of this is Core 1: the console task and the TinyUSB RX
  callback. No Core 0 file is in the diff, and nothing here is reachable from
  `rt_task`.
- Blocking issues open on this work: none.

## Not done here

- Host coverage for the line editor — tracked in #46. It needs a decision (the
  registry needs an injection point, or the editor splits from the dispatcher),
  which is why it is an issue and not a commit.
- The out-of-scope items #30 records as a design limit, not a defect: mid-line
  editing, left/right arrows, `s_line_pos` as both length and cursor.
- `\r` and `\n` are still each treated as Enter, so a terminal sending CRLF gets
  two prompts. Pre-existing, untouched, and not part of #30.
