### PR TITLE
console: greet the operator with the stats overview on every attach

### DIFF
--- a/components/keyer_console/include/console.h
+++ b/components/keyer_console/include/console.h
@@ -147,6 +147,20 @@ bool console_push_char(char c);
  */
 void console_print_prompt(void);
 
+/**
+ * @brief Print the connection welcome message
+ *
+ * Banner + the full `stats` overview (uptime, heap, wifi, ssid, ip) + a hint
+ * naming the command that reproduces it, followed by the prompt.
+ *
+ * Printed every time an operator attaches to the console, not once at boot:
+ * the answer to "did it connect, and at which address" has to be there when
+ * the cable goes in, whenever that happens.
+ *
+ * Core 1 only - it formats and writes to the console transport.
+ */
+void console_print_welcome(void);
+
 /* ============================================================================
  * History
  * ============================================================================ */

--- a/components/keyer_console/src/commands.c
+++ b/components/keyer_console/src/commands.c
@@ -1232,7 +1232,7 @@ static const char USAGE_LOG[] =
     "  log TAG=L           Compact: set tag";
 
 static const char USAGE_STATS[] =
-    "  stats               Overview (uptime, heap, stream)\r\n"
+    "  stats               Overview (uptime, heap, stream, wifi, ssid, ip)\r\n"
     "  stats heap          Heap memory details\r\n"
     "  stats tasks         Task list by core\r\n"
     "  stats stream        Stream buffer status\r\n"

--- a/components/keyer_console/src/console.c
+++ b/components/keyer_console/src/console.c
@@ -55,6 +55,25 @@ void console_print_prompt(void) {
     fflush(stdout);
 }
 
+void console_print_welcome(void) {
+    printf("\r\nCW Keyer Console\r\n");
+
+    /* Carry the `stats` overview: uptime, heap, wifi, ssid, ip. Executed
+     * through the registry rather than duplicated, so the banner and the
+     * command can never drift apart. */
+    console_parsed_cmd_t stats_cmd = {
+        .command = "stats",
+        .args = { NULL, NULL, NULL },
+        .argc = 0,
+    };
+    (void)console_execute(&stats_cmd);
+
+    printf("\r\nFor keyer wifi stats, use 'stats'. Type 'help' for all commands.\r\n");
+    fflush(stdout);
+
+    console_print_prompt();
+}
+
 bool console_push_char(char c) {
     /* Handle escape sequences for arrow keys */
     if (s_escape_state == ESC_BRACKET_RECEIVED) {
@@ -206,9 +225,7 @@ bool console_process_char(char c) {
 void console_task(void *arg) {
     (void)arg;
 
-    printf("\r\nCW Keyer Console\r\n");
-    printf("Type 'help' for available commands\r\n");
-    console_print_prompt();
+    console_print_welcome();
 
     for (;;) {
         int c = getchar();

--- a/components/keyer_usb/src/usb_console.c
+++ b/components/keyer_usb/src/usb_console.c
@@ -79,6 +79,42 @@ static void console_rx_callback(int itf, cdcacm_event_t *event) {
     tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, 0);
 }
 
+/**
+ * @brief Previous DTR level on CDC0, for rising-edge detection
+ *
+ * tud_cdc_line_state_cb() fires on every SET_CONTROL_LINE_STATE request the
+ * host sends (tinyusb cdc_device.c:436), and a host may re-assert an already
+ * asserted DTR. Only the false->true transition is an attach.
+ *
+ * Written and read exclusively from the TinyUSB task, so no atomics needed.
+ */
+static bool s_dtr_prev = false;
+
+/**
+ * @brief Line-state callback for CDC0 - welcome the operator on attach
+ *
+ * TinyUSB treats DTR alone as "connected" (cdc_device.c:144-149), so the
+ * rising edge of DTR is the attach event. RTS is not required: some terminals
+ * assert DTR only.
+ *
+ * Runs in the TinyUSB task (Core 1 by default, CONFIG_TINYUSB_TASK_AFFINITY),
+ * the same context in which console_rx_callback() already runs whole console
+ * commands. Nothing here touches the Core 0 RT path.
+ */
+static void console_line_state_callback(int itf, cdcacm_event_t *event) {
+    if (itf != TINYUSB_CDC_ACM_0 || event == NULL) {
+        return;
+    }
+
+    const bool dtr = event->line_state_changed_data.dtr;
+    const bool rising = dtr && !s_dtr_prev;
+    s_dtr_prev = dtr;
+
+    if (rising) {
+        console_print_welcome();
+    }
+}
+
 esp_err_t usb_console_init(void) {
     ESP_LOGI(TAG, "Initializing USB console on CDC0");
 
@@ -87,6 +123,13 @@ esp_err_t usb_console_init(void) {
         TINYUSB_CDC_ACM_0,
         CDC_EVENT_RX,
         console_rx_callback
+    );
+
+    /* Register line-state callback: prints the welcome on every attach */
+    tinyusb_cdcacm_register_callback(
+        TINYUSB_CDC_ACM_0,
+        CDC_EVENT_LINE_STATE_CHANGED,
+        console_line_state_callback
     );
 
     return ESP_OK;


### PR DESCRIPTION
## What changes

Attaching a terminal to the USB console now prints a welcome — banner, the full `stats` overview (uptime, heap, stream, wifi, ssid, ip), and a line naming the command that reproduces it — on **every** attach, not once at boot.

**The open question in #31: is a line-state event available, or must `bg_task` poll?** It is available, and this PR is event-driven. Read from source:

- `esp_tinyusb` defines `CDC_EVENT_LINE_STATE_CHANGED` and delivers `{dtr, rts}` to a registered callback: `managed_components/espressif__esp_tinyusb/include/tusb_cdc_acm.h:47-79`, dispatched in `tusb_cdc_acm.c:50-81` (`tud_cdc_line_state_cb` → `acm->callback_line_state_changed`). Registration is the same `tinyusb_cdcacm_register_callback()` the console already uses for `CDC_EVENT_RX` (`tusb_cdc_acm.c:158-161`) — no wrapper had to be fought, and no `tud_*` symbol is overridden.
- The edge has to be tracked by us: TinyUSB invokes the callback on *every* `SET_CONTROL_LINE_STATE` request, including a repeat of an already-asserted DTR (`espressif__tinyusb/src/class/cdc/cdc_device.c:422-436`). Hence `s_dtr_prev` in `usb_console.c:91`.
- Keyed on **DTR alone**, not `dtr && rts`: TinyUSB's own definition of connected is bit 0 of the line state (`cdc_device.c:144-149`), and terminals that assert only DTR are common. Note esp_tinyusb's internal log line uses `dtr && rts` (`tusb_cdc_acm.c:53`) but does not gate the callback on it, so the choice is ours.

Rejected: polling `usb_cdc_connected()` for a rising edge in `bg_task`. It would not have worked as written — that function returns `tusb_cdc_acm_initialized()`, i.e. "the ACM object exists", not "a host is attached". Filed as #48.

The banner runs `stats` through the command registry (`console.c:64-69`) instead of reprinting its fields, so the welcome and the command cannot drift apart. `USAGE_STATS` was describing the overview as "uptime, heap, stream" while the code has printed wifi/ssid/ip since it was written; corrected on the spot.

## Closes

Closes #31. The condition under *What would make it right* — "on connecting to the console, print a welcome message carrying the `stats` output, plus a reminder along the lines of *For keyer wifi stats, use stats*" — holds at `components/keyer_usb/src/usb_console.c:104-116` (rising-DTR attach detection) calling `console_print_welcome()` at `components/keyer_console/src/console.c:58-75` (banner + `stats` + the reminder + prompt). The "printing it once at boot is not sufficient" clause is met by construction: the trigger is the DTR edge, so a second attach prints a second welcome.

The UART path's boot banner (`console.c:228`) now calls the same function, so the two paths cannot diverge.

## Definition of done

- Host tests: 202/202 plain, 202/202 ASan/UBSan (`-DCMAKE_C_FLAGS="-fsanitize=address,undefined"`), 0 failures 0 ignored in both. **This suite does not exercise this change** and cannot: `test_host/CMakeLists.txt:74-79` excludes `console.c` and `commands.c`, and `keyer_usb` is not in the host build at all. The pass counts say the change broke nothing, not that it works.
- Compile evidence instead, since #29 means CI does not build the firmware and the ESP-IDF Python venv is not installed on this machine (`idf.py` unavailable — `esp-idf/export.sh` reports the v6.0 py3.14 venv missing, and running the installer is not something to do inside a PR). All three touched translation units were compiled for the real target with the exact command line from the project's own `build/compile_commands.json` — `xtensa-esp32s3-elf-gcc`, IDF v6.0.2 headers, `-Wall -Wextra -Werror -Wconversion -Wshadow`, full codegen, not `-fsyntax-only`: `usb_console.c`, `console.c`, `commands.c`, rc=0 each, no diagnostics.
- Reference test: n/a — touches neither `keyer_cwnet/` nor `keyer_iambic/`.
- RT path: untouched. Nothing added on Core 0. The line-state callback runs in the TinyUSB task, which `esp_tinyusb` pins to CPU1 by default (`Kconfig:62-84`, `TINYUSB_TASK_AFFINITY_CPU1` when not `FREERTOS_UNICORE`; `tusb_tasks.c:59`), and this repo's `sdkconfig.defaults` does not override it. That is the same task and stack in which `console_rx_callback` already runs whole console commands including `stats tasks`, so the context is not new — no `ESP_LOGx`/`printf`/allocation was added anywhere reachable from `rt_task`.
- Blocking issues open on this work: none. No open issue carries the `blocking` label.

## What a device is still needed for

Everything about the wire. Verified here: it compiles for the target, and the logic is sound by inspection. Not verified, and not verifiable without hardware:

- the banner actually reaching a terminal on attach — the write happens inside the control-transfer ACK stage of `SET_CONTROL_LINE_STATE`, and whether a given host's tty layer keeps bytes queued that early is a property of the host, not of this code;
- that it fires **again** on re-attach, which is the whole point of #31 over the boot print;
- which terminals assert DTR without RTS on this device, i.e. whether the DTR-alone choice was the right one in practice;
- that the ~10-line burst is not truncated (`CONFIG_TINYUSB_CDC_TX_BUFSIZE=4096`, so it should not be, but should-not-be is not evidence).

## Not done here

- `stats wifi` still returns `E02: invalid value` (`commands.c:247`), noted in #31's *What is wrong*. The maintainer's decision under *What would make it right* is the welcome message; adding a subcommand is new command surface and was left out deliberately. #31 closes on the stated condition — say so if the subcommand was meant to be part of it and it can follow.
- `usb_cdc_connected()` lying about host presence, and `main.c:294-297`'s wait loop being a no-op because of it: #48. Deliberately untouched here — making that predicate truthful changes when `app_main` unblocks and when the UART logger dies, which needs a decision.
- #26 (LEDs) and #30 (line editor): out of scope, not touched.
