### PR TITLE
ci: build the firmware for esp32s3, so a link failure can't hide again

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -1,0 +1,60 @@
+name: Firmware build
+
+# host-tests.yml proves the logic; this proves the tree still produces a
+# linked esp32s3 binary. See issue #29 — a link failure went unnoticed for
+# four months because nothing in CI ran `idf.py build`. This job only
+# proves the tree compiles and links; whether it boots is a separate,
+# hardware-only question this workflow does not answer.
+
+on:
+  push:
+  pull_request:
+
+env:
+  # ESP-IDF Docker image tag. Keep this in step with .devcontainer/Dockerfile's
+  # DOCKER_TAG default (issue #16) by hand — both name the same release, but
+  # a Dockerfile FROM line and this workflow's `docker run` are two different
+  # places a build-arg can't bridge without a bigger restructuring than either
+  # issue asked for (see the PR body for #29/#16).
+  IDF_DOCKER_TAG: v6.0.3
+
+jobs:
+  firmware-build:
+    runs-on: ubuntu-latest
+    name: firmware-build (esp32s3)
+    steps:
+      - uses: actions/checkout@v4
+
+      # keyer_webui is a hard REQUIRES of main (main/CMakeLists.txt) and its
+      # CMakeLists unconditionally shells out to `npm install && npm run
+      # build` to produce the assets the firmware embeds
+      # (components/keyer_webui/CMakeLists.txt). There is no stubbed path:
+      # `idf.py build` cannot link without it, so the frontend build is not
+      # optional here.
+      #
+      # Run inside the image via `docker run` rather than the workflow
+      # `container:` field: GitHub Actions execs job steps into a
+      # `container:` with the image's own ENTRYPOINT bypassed, so the IDF
+      # toolchain (compilers, idf.py, the venv) never ends up on PATH — it is
+      # only put there by espressif/idf's entrypoint.sh, which a plain
+      # `docker run` (default entrypoint intact) does run. Verified locally
+      # with this exact image and command.
+      - name: Build firmware (esp32s3)
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            "espressif/idf:${IDF_DOCKER_TAG}" \
+            bash -euo pipefail -c '
+              apt-get update -qq
+              apt-get install -y --no-install-recommends nodejs npm
+              cd /workspace
+              idf.py build
+            '
+
+      - name: Upload firmware binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyer_c-esp32s3-${{ github.sha }}
+          path: build/keyer_c.bin
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## What changes

Adds `.github/workflows/firmware-build.yml`: a job that builds the firmware for `esp32s3` inside `espressif/idf:v6.0.3` and fails if `idf.py build` does not link. It uploads the resulting `keyer_c.bin` as a build artifact. The four open decisions the issue named, and the call made on each:

- **Image tag** — pinned `v6.0.3` (not `latest`, not the floating `release-v6.0`). Same exact tag as `.devcontainer/Dockerfile`'s new default (#16): both name the same release, chosen as the latest stable patch of the v6.0 line the project migrated to. Not force-merged into one file both read: a Dockerfile `FROM` line and this workflow's `docker run` argument are resolved at genuinely different times (image build vs. job run), and building a real shared source for the two would mean either teaching the Dockerfile to read a file before its `FROM` line (not really possible without another indirection) or splitting this workflow into a version-reading job plus a downstream job — both go beyond the two files these issues name. Missed opportunity, noted rather than forced.
- **Push vs PR-only** — both, matching `host-tests.yml`'s trigger shape (`on: push, pull_request`). The gap this issue closes is exactly "nothing proves every change still links"; restricting to PR-only would leave direct pushes to `main` unchecked, which is how the original four-month gap happened in the first place.
- **Frontend build** — not actually a discretionary choice: `keyer_webui` is a hard `REQUIRES` of `main` (`main/CMakeLists.txt`) and its `CMakeLists.txt` unconditionally shells out to `npm install && npm run build` before it can generate `assets.c` (`components/keyer_webui/CMakeLists.txt`). Stubbing it would mean `idf.py build` never touches the real link graph — the exact thing this issue exists to catch. So the job installs Node via `apt-get install nodejs npm` (Ubuntu 24.04 base in the image ships Node 18.19, confirmed sufficient — Vite 5 + Svelte 5 built cleanly against it) before calling `idf.py build`.
- **`.bin` as artifact** — yes, `retention-days: 14`. Cheap (a couple MB), and it is exactly what the issue's own reasoning names as the payoff: flashing a given commit without a local ESP-IDF install.

One implementation point worth calling out: the job runs the toolchain via a plain `docker run` inside a step, not the workflow's `container:` field. Verified by hand against `espressif/idf:v6.0.3`: a job-level `container:` execs steps into the running container with the image's own `ENTRYPOINT` bypassed, and `idf.py`/the compilers only land on `PATH` because `entrypoint.sh` sources `export.sh` — so `container:` would leave every step unable to find `idf.py`. `docker run` with the default entrypoint intact does source it. Confirmed with `docker inspect espressif/idf:v6.0.3` (image `PATH` has no toolchain in it) and by running the build both ways locally.

## Closes

Issue #29, "What would make it right": a CI job that builds the firmware for esp32s3 and fails the run when it does not link. That now holds at `.github/workflows/firmware-build.yml` — verified by an actual local run of the same image/command producing a linked `build/keyer_c.bin` (1,225,824 bytes, 42% partition free) for the current tree. The GitHub Actions run itself is unverified — see Definition of done.

## Definition of done

- Host tests: 202/202 plain, 202/202 ASan/UBSan (sanity check — this PR is CI-only and touches no host-tested code).
- Reference test: n/a.
- RT path: untouched.
- Blocking issues open on this work: none.

**On verification**: this environment cannot trigger a real GitHub Actions run, so the workflow is unverified in that specific sense. What was actually checked:
- `actionlint` (v1.7.12, with its bundled `shellcheck` pass over the embedded `run:` script) against `firmware-build.yml`, `host-tests.yml`, and `devcontainer-image.yml`: zero findings.
- Ruby's `YAML.load_file` parse of the new workflow: succeeds (the bareword `on:` key round-trips to Ruby's YAML-1.1 boolean `true`, which is the same well-known quirk `host-tests.yml` already relies on — GitHub's own parser special-cases it).
- The exact build the job runs — `docker run --rm -v <repo>:/workspace espressif/idf:v6.0.3 bash -c 'apt-get install -y nodejs npm; cd /workspace; idf.py build'` — was run locally (Apple Silicon host, `--platform` not needed since this step has no architecture-specific package installs) and produced a linked `esp32s3` binary end to end, including the frontend npm build.
- Not verified here: the actual GitHub Actions scheduling, runner disk/network behavior, and `actions/upload-artifact@v4` — those need a real Actions run.

## Not done here

Boot/behavior verification on real hardware — out of scope per the issue ("Not the same as testing on hardware"). No attempt to share the IDF version string with #16 through a single file; see the reasoning above.
