### PR TITLE
devcontainer: move to ESP-IDF v6.0.3, derive the python venv path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_TAG=v5.5.1
+ARG DOCKER_TAG=v6.0.3
 FROM espressif/idf:${DOCKER_TAG}
 
 ENV LC_ALL=C.UTF-8
@@ -72,8 +72,12 @@ RUN mkdir -p \
 	/home/${USERNAME}/.vscode-server/data/User \
 	/home/${USERNAME}/.vscode-server/data/Machine \
 	&& chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.vscode-server
-RUN /opt/esp/python_env/idf5.5_py3.12_env/bin/pip  install --no-cache-dir  jsonschema 
-RUN /opt/esp/python_env/idf5.5_py3.12_env/bin/pip  install --no-cache-dir  gcovr
+# The venv directory name embeds the IDF/Python version (e.g. idf6.0_py3.12_env)
+# and changes on every IDF or Python bump baked into the base image, so derive
+# it instead of hardcoding it.
+RUN idf_pip="$(ls -d /opt/esp/python_env/*/bin/pip)" \
+	&& "${idf_pip}" install --no-cache-dir jsonschema \
+	&& "${idf_pip}" install --no-cache-dir gcovr
 
 # Create docker group (for socket access) and add user
 RUN groupadd -f docker && usermod -aG docker ${USERNAME}


### PR DESCRIPTION
## What changes

`.devcontainer/Dockerfile`: `ARG DOCKER_TAG` default moves from `v5.5.1` to `v6.0.3` (latest stable patch of the v6.0 line the project migrated to — same tag `.github/workflows/firmware-build.yml` now uses, #29), and the two `pip install` lines stop hardcoding `/opt/esp/python_env/idf5.5_py3.12_env` in favor of `ls -d /opt/esp/python_env/*/bin/pip` — that directory name embeds the IDF/Python version and changes with the base image, so it's derived instead of written literally.

Not shared with #29 through one file: a Dockerfile `FROM ${ARG}` line and a workflow's `docker run` image reference resolve at genuinely different times, and building real single-sourcing between them would mean either teaching the `FROM` line to read a file before it runs (not really possible without another layer of indirection) or splitting the CI workflow into a version-reading job plus a downstream job — both go beyond the two files these issues name. Left as the same literal tag string in both places; noted here rather than forced. See PR #50 (issue #29) for the matching side of this.

## Closes

Issue #16, "What would make it right": move to an `espressif/idf:v6.x` tag and stop hardcoding the Python env directory, then actually build the image once to confirm. Both hold — `.devcontainer/Dockerfile:1-2` (tag) and `.devcontainer/Dockerfile:75-79` (derived path) — confirmed by an actual local `docker build`, not by inspection. See Definition of done for the two runs and what each showed.

## Definition of done

- Host tests: 202/202 plain, 202/202 ASan/UBSan. Sanity check only — this PR touches no C code, only the devcontainer Dockerfile.
- Reference test: n/a.
- RT path: untouched.
- Blocking issues open on this work: none.

**Docker build, actually run** (Docker was available in this environment):
- First attempt, native to this Mac (Apple Silicon / arm64): failed at the pre-existing PVS-Studio install step — `pvs-studio:amd64 : Depends: strace:amd64 but it is not installable`. Unrelated to this change: that `RUN` line is untouched by this diff, and PVS-Studio's apt repo has no arm64 packages. Real limitation of building this Dockerfile on an arm64 host, worth knowing about but out of scope here.
- Second attempt, `docker build --platform linux/amd64 .` (matching real CI runners and most contributors' hosts, via QEMU emulation): **succeeded end to end**, `[exited with code 0]`. Confirmed from the build log that both touched lines did what they're supposed to:
  - `FROM docker.io/espressif/idf:v6.0.3@sha256:54278f2c...` — the new tag resolved and pulled.
  - `RUN idf_pip="$(ls -d /opt/esp/python_env/*/bin/pip)" && ...` resolved to `/opt/esp/python_env/idf6.0_py3.12_env/...` and both `pip install` calls (`jsonschema`, `gcovr`) completed (`Successfully installed ...` for each).

## Not done here

Rebuilding a shared version-source between this Dockerfile and the CI workflow from #29 — see the reasoning above. No change to the rest of the Dockerfile (PVS-Studio, Node 18, uv, elan, Continuous-Claude clone) beyond the two lines the issue named.
