### PR TITLE
docs(solutions): the divergence count of a differential oracle is not a gradient

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -11,6 +11,9 @@ Il protocollo di rete del Remote CW Keyer di DL4YHF, che trasporta keying CW, au
 L'implementazione di riferimento — client e server DL4YHF in esecuzione — contro cui ogni comportamento che conta viene *dimostrato*, non *reso simile*. Il suo sorgente pubblicato dice cosa guardare, non cosa è vero: la verità sono i byte sul filo, non il codice né i suoi commenti.
 *Avoid:* riferimento (quando ambiguo).
 
+### Oracolo differenziale
+Un artefatto **eseguibile** derivato dal riferimento — un modulo suo ricompilato, o il suo firmware fatto girare in un emulatore — che riceve lo stesso stimolo del nostro codice perché le due uscite si possano confrontare. Non è il golden standard: è un candidato che si guadagna il posto dimostrando di riprodurre una cattura del riferimento vero. Quando risponde con un conteggio di divergenze invece che con un verdetto, quel conteggio è un cancello e non un gradiente.
+
 ## Keying
 
 ### MORSE keying stream

--- a/docs/solutions/architecture-patterns/differential-oracle-count-is-not-a-gradient.md
+++ b/docs/solutions/architecture-patterns/differential-oracle-count-is-not-a-gradient.md
@@ -1,0 +1,128 @@
+---
+title: "Il conteggio di un oracolo differenziale non è un gradiente"
+date: 2026-09-06
+category: architecture-patterns
+module: keyer_iambic
+problem_type: workflow_issue
+component: testing_framework
+severity: high
+applies_when:
+  - "Un oracolo differenziale restituisce un conteggio di divergenze invece di un verdetto binario"
+  - "Si sta per modificare una macchina a stati e rimisurare per decidere se tenere la modifica"
+  - "Lo sweep gira su una famiglia di stimoli campionata, non sul dominio esaustivo"
+tags:
+  - differential-testing
+  - oracle
+  - method
+  - k8
+  - keyer-iambic
+  - debugging
+---
+
+# Il conteggio di un oracolo differenziale non è un gradiente
+
+## Contesto
+
+Il banco differenziale del keyer (`tools/k8/bench/`) manda lo stesso stimolo di
+paddle al K1EL K8 emulato in gpsim e alla nostra FSM, poi confronta le sequenze
+di elementi. Su 436 casi a 25 WPM partiva da **124 divergenze**, con una
+diagnosi corretta della causa (issue #44) e una raccomandazione motivata su come
+correggerla.
+
+L'implementazione è stata misurata dopo ogni passo:
+
+| passo | divergenze |
+|---|---|
+| stato di partenza | 124 |
+| dopo il riordino delle decisioni | 225 |
+| dopo la correzione su `BOTH_ON` | 145 |
+
+Tre tentativi, tutti peggiori del punto di partenza, e il lavoro è stato
+abbandonato su un ramo `wip-` senza mai capire quale riga fosse sbagliata.
+
+Il banco era corretto. La diagnosi era in larga parte corretta. **A essere
+sbagliato è stato l'uso del numero.**
+
+## Guida
+
+**1. Il conteggio risponde a "va meglio", mai a "perché".** È un cancello, non
+un gradiente. Serve a decidere se una correzione è finita, non a scegliere quale
+correzione fare.
+
+**2. Prima di cambiare una riga, traccia UN caso divergente da un capo
+all'altro sui due lati.** Il nostro tick per tick, il riferimento istruzione per
+istruzione nell'emulatore. Il caso si sceglie dalla classe più numerosa, così la
+comprensione che ne esce copre la maggior parte delle divergenze.
+
+**3. Una modifica si giustifica con la traccia, non con il delta.** Se non sai
+dire in anticipo in che verso si muoverà il conteggio e all'incirca di quanto,
+non hai ancora capito la modifica che stai per fare.
+
+**4. Guarda sempre la composizione, non solo il totale.** Raggruppa le
+divergenze per coppia `(riferimento, nostro)` e conta ogni forma. Il totale
+nasconde esattamente l'informazione che serve.
+
+**5. Se abbandoni, conserva il tentativo con i suoi numeri e la diagnosi del
+metodo**, non solo del codice. Un ramo `wip-` con un messaggio di commit onesto
+costa niente e impedisce al tentativo successivo di rifare la stessa strada.
+
+## Perché conta
+
+Il pattern gemello, `reference-source-as-differential-oracle.md`, descrive un
+confronto **esaustivo** che restituisce una risposta binaria: zero scarti su
+tutto il dominio, oppure no. Quella forma non si presta a questo abuso.
+
+Uno sweep su una famiglia di stimoli campionata restituisce invece un
+**conteggio**, e un conteggio somiglia a un gradiente. Non lo è, per tre
+ragioni: i casi non sono indipendenti, una singola modifica può sistemare una
+classe e romperne due, e il totale non dice quale.
+
+Il caso concreto è istruttivo. Passare da 124 a 145 sembrava "quasi tornato al
+punto di partenza". Ma la composizione era cambiata del tutto: 141 delle 145
+erano ormai una forma sola, "perdiamo l'elemento finale", che non era il difetto
+originale. Il numero diceva "un po' peggio". La composizione diceva "bug
+diverso".
+
+## Quando applicarla
+
+Ogni volta che l'oracolo restituisce un conteggio invece di un verdetto. E in
+particolare nel momento in cui ti accorgi di star lanciando lo sweep per
+decidere se tenere una modifica: quello è il segnale che stai usando il numero
+come gradiente.
+
+## Esempi
+
+Il raggruppamento che avrebbe intercettato l'errore al primo giro, invece che al
+terzo:
+
+```python
+import collections
+c = collections.Counter()
+for key, ev in cases():
+    k = k8seq.run(ev)          # riferimento
+    o = ours(ev)               # nostro
+    if k != o:
+        c[(k, o)] += 1
+for (k, o), n in c.most_common(8):
+    print(f"{n:4d}x  rif={k!r:10s} noi={o!r:10s}")
+```
+
+Uscita al terzo tentativo, che rende evidente il cambio di natura del difetto:
+
+```
+  65x  rif='.-.'      noi='.-'
+  32x  rif='..-'      noi='.-'
+  20x  rif='....'     noi='...'
+  17x  rif='-.-'      noi='-.'
+```
+
+Quattro forme, tutte "manca l'ultimo elemento". Un totale di 145 non lo dice.
+
+## Related
+
+- `docs/solutions/architecture-patterns/reference-source-as-differential-oracle.md`
+  — il pattern di cui questo documenta un modo di fallire
+- `tools/k8/bench/` — il banco e `FINDINGS.md` con le tabelle complete
+- `tools/k8/README.md` — come far girare l'oracolo K8 in gpsim
+- Issue #44 (il difetto), #32 (la specifica verificata del riferimento)
+- Ramo `wip-k8-decision-order-attempt` — il tentativo abbandonato, da non mergiare

--- a/thoughts/shared/handoffs/general/2026-09-06_1245_k8-sampled-mode-diverge.md
+++ b/thoughts/shared/handoffs/general/2026-09-06_1245_k8-sampled-mode-diverge.md
@@ -1,0 +1,163 @@
+---
+artifact_contract: "ce-handoff/v1"
+created_at: "2026-09-06T12:45:54Z"
+title: "SQUEEZE_MODE_SAMPLED diverge dal K8, e tre tentativi di correzione sono falliti"
+summary: "Il banco differenziale mostra 124 divergenze su 436 casi; la diagnosi è scritta, la causa probabile è nota, ma tre implementazioni di seguito hanno peggiorato il conteggio e sono state abbandonate."
+keywords: ["k8", "k1el", "squeeze-mode-sampled", "issue-44", "oracolo-differenziale", "gpsim", "iambic", "inlast"]
+cwd: "/Users/sf/Developer/RemoteCWKeyer-esp32/.claude/worktrees/k8-oracolo-handoff-resume-6f0342"
+resume_focus: "Correggere SQUEEZE_MODE_SAMPLED contro il K8, tracciando un caso divergente da un capo all'altro prima di toccare una riga."
+repository: "iu3qez/RemoteCWKeyer-esp32"
+repo_root_sha: "f153e01ec202b2cae17102fa0f355d657bb641c7"
+branch: "docs-compound-oracle-gradient"
+head: "a8ccb10"
+worktree_path: "/Users/sf/Developer/RemoteCWKeyer-esp32/.claude/worktrees/k8-oracolo-handoff-resume-6f0342"
+---
+
+# Il modo campionato diverge dal K8
+
+Sessione del 6 settembre 2026, ripresa dall'handoff `2026-09-06_0112_k8-oracolo-eseguibile.md`.
+Ha prodotto sette PR mergiate e un difetto aperto che non è stato risolto. Questo
+documento serve soprattutto per quel difetto.
+
+## Obiettivo della prossima sessione
+
+Issue **#44**: `SQUEEZE_MODE_SAMPLED` perde elementi che il K8 manda. Il difetto è
+in codice mergiato oggi con #38, non è un debito ereditato.
+
+Decisione del maintainer, esplicita: **si segue lo standard K1EL**, non
+un'approssimazione. E: si resta sul K8 come unico riferimento, «una cosa sola,
+fatta bene» (Keyrama è parcheggiata in #37).
+
+## Il metodo, che è la parte che conta
+
+L'errore di questa sessione non è stato di conoscenza ma di metodo, ed è
+documentato in
+[docs/solutions/architecture-patterns/differential-oracle-count-is-not-a-gradient.md](../../../../docs/solutions/architecture-patterns/differential-oracle-count-is-not-a-gradient.md)
+(in PR #52, non ancora mergiata al momento della scrittura).
+
+**Leggilo prima di toccare `iambic.c`.** In sintesi: il conteggio delle
+divergenze è un cancello, non un gradiente. Traccia **un** caso divergente da un
+capo all'altro sui due lati, nostro tick per tick e riferimento istruzione per
+istruzione in gpsim, prima di cambiare una riga. Raggruppa sempre le divergenze
+per forma, mai leggere solo il totale.
+
+## Cosa sappiamo della causa
+
+Da leggere, in quest'ordine:
+
+- **#32**, commenti dal fondo verso l'alto: la specifica verificata del
+  campionamento K8, la regola del latch e le decisioni del maintainer.
+- **#44**: la diagnosi del difetto e le tabelle dello sweep.
+- `tools/k8/bench/FINDINGS.md`: le stesse tabelle in forma stabile.
+
+Il nocciolo. Il K8 campiona il livello delle leve su una griglia di un'unità e
+**si segna** quello che trova in `PROCLAT`. All'ultimo istante di un elemento fa
+tre cose in ordine: campiona, cancella il bit del tipo appena mandato
+(`morse8.asm:374` per un dit, `:409` per un dah), campiona di nuovo in `AUTOSP`
+(`:536`). Il secondo campione riarma lo stesso tipo se il contatto è ancora
+chiuso. La nostra implementazione fa solo la cancellazione e per il resto legge
+lo stato **live** delle leve alla decisione successiva. Un fatto registrato
+sopravvive al dito che si alza, una domanda posta dopo no.
+
+Un agente su opus ha stabilito, leggendo il sorgente, che `NSAMPLE` sui bit delle
+leve fa solo `BSF` e mai `BCF`, quindi **è idempotente**: i campioni di `AUTOSP` e
+`SERVLOOP` non sono due osservazioni distinte. Ne segue che modellare il confine
+come un campione solo è corretto, e che la domanda «uno o tre campioni» non aveva
+due alternative vere. Ha anche avvertito che, una volta che entrambi i bit
+possono essere accesi insieme, il tiebreak su `INLAST` diventa portante e noi non
+ce l'abbiamo. `INLAST` è quindi dentro #44, non un lavoro successivo.
+
+Il suo test di falsificazione, non ancora eseguito: se esiste un caso in cui la
+divergenza segue la **fase dentro la finestra di 30 µs**, spostando un fronte di
+dieci microsecondi e cambiando l'elemento emesso, allora la lettura
+sull'idempotenza è sbagliata e vince l'assembly.
+
+## Cosa è stato provato e ha fallito
+
+Ramo locale **`wip-k8-decision-order-attempt`** (`cba48c4`), non pushato, **da
+non mergiare**. Il messaggio di commit è scritto apposta per questo passaggio e
+va letto: separa quello che sembra corretto da quello che non lo è.
+
+| passo | divergenze su 436 |
+|---|---|
+| stato su `main` | 124 |
+| dopo il riordino delle decisioni | 225 |
+| dopo la correzione su `BOTH_ON` | 145 |
+
+Alla fine 141 delle 145 erano una forma sola, «perdiamo l'elemento finale», che
+non è il difetto originale. Il difetto residuo **non è stato identificato**: il
+sospetto è la gestione di `BOTH_ON` in modo A, che azzera un latch che il K8
+sembra tenere, ma è un sospetto e non una conclusione.
+
+Sembrano corretti, e valgono come punto di partenza: il campionatore riscritto
+sul modello di `NSAMPLE`, il campionamento a riposo (perché `SERVLOOP` campiona
+liberamente quando nessun elemento è in volo, `morse8.asm:776`), il campo
+`in_last_dit` distinto da `last_element`, e l'aver limitato l'ordine di decisione
+K8 al solo `SQUEEZE_MODE_SAMPLED` lasciando intatti i due modi a finestra.
+
+## Il banco
+
+Ramo **`k8-differential-bench`** (`fae2f57`), pushato, **senza PR**. Contiene
+`tools/k8/bench/` con `k8seq.py`, `sweep.py`, `ours_seq.c` e `FINDINGS.md`. Una
+corsa costa circa un decimo di secondo, quindi uno sweep di 436 casi è pratico.
+
+Vale da solo, indipendentemente dalla correzione: è quello che ha trovato il
+difetto. Aprire una PR è una scelta ancora da fare.
+
+## Stato machine-local, fragile
+
+Percorsi assoluti, fuori dal repository e gitignorati. Sopravvivono al riavvio ma
+non sono in git.
+
+- `/Users/sf/Developer/RemoteCWKeyer-esp32/tmp/k8/` — l'originale `morse8.asm`
+  (**non toccare**, sha256 `432df077a197…`), la copia patchata
+  `morse8_gpasm_tb40_nosleep.asm`, il suo `morse8_tb40_nosleep.hex`
+  (sha256 `e1764e099f7c…`), copie di `k8seq.py`, `sweep.py`, `ours_seq.c`, il
+  risultato del confronto di timing in `k8-timing-comparison-RESULT.md`, e in
+  `dj5il/` l'estrazione degli articoli DJ5IL con i PDF.
+- Lo scratchpad di sessione **evapora**: tutto ciò che serviva è stato copiato
+  sopra.
+
+Le tre patch necessarie per far girare l'oracolo sono documentate in
+`tools/k8/README.md`, quindi il hex è ricostruibile anche se si perde. La terza,
+la sostituzione dello `SLEEP` con `GOTO SERVLOOP`, è verificata: patchato e non
+patchato producono keying identico al ciclo.
+
+## Verifica fatta
+
+Suite host **202/202 verde**, variante piana e ASan/UBSan, su `main` e su ogni
+ramo consegnato. Il confronto di timing contro il K8 è stato eseguito a 25 WPM e
+a 15 WPM: ogni scarto sta dentro un tick del nostro loop, il peggiore è un
+decimo di tick a 25 WPM. La tolleranza che ne è uscita è scritta in
+`docs/k8-timing-tolerance.md`, mergiata.
+
+## Il resto della sessione, già chiuso
+
+Mergiate: #38 (il modo campionato, che è ciò che #44 corregge), #41, #42, #43,
+#45, #47, #50, #51. Aperte: **#52** (il documento sul metodo), più #2 e #3 di
+marzo, parcheggiate e non toccate.
+
+Issue aperte trovate strada facendo e non ancora affrontate: **#46** (il line
+editor non ha copertura host), **#48** (`usb_cdc_connected()` riporta
+l'inizializzazione, non la presenza dell'host, e il ciclo di attesa in `main.c`
+non attende), **#39** (arrotondamento al tick, fino al 2 % di velocità in meno,
+declassata da bloccante quando si è deciso di testare solo a velocità allineate).
+
+Nessuna issue `blocking` aperta.
+
+## Continuazioni plausibili
+
+La sola continuazione naturale è #44, e il primo passo non è scrivere codice: è
+scegliere un caso dalla classe più numerosa, per esempio quello riprodotto in
+`FINDINGS.md` (dit a 0, dah a 0,25u, dit rilasciato a 2,0u, entrambi a 2,5u, dove
+il K8 manda `..-` e noi `.-`), e tracciarlo sui due lati fino a sapere quale riga
+è sbagliata.
+
+Il maintainer ha indicato di farlo in una sessione nuova a contesto pulito,
+affiancata da un agente di review adversariale: quel pattern oggi ha funzionato
+in modo dimostrabile, perché l'agente su opus ha rifiutato la cornice sbagliata
+che gli era stata data.
+
+Nota per chi ripiega su un subagente: **in questa build non è possibile
+rimandare un messaggio a un subagente già avviato**. Un compito lungo ed
+esplorativo delegato in background non è pilotabile a metà strada.


### PR DESCRIPTION
## What changes

A solution doc recording how the K8 differential bench was misused, and a
`CONCEPTS.md` entry for the term it turns on.

The bench started at 124 divergences over 436 cases with a correct diagnosis in
hand. Three attempts measured 225, then 145, then were abandoned without ever
identifying the wrong line. The bench was right and the diagnosis was largely
right; using the count as feedback was not.

The decision the doc records: a sampled sweep's count is a **gate**, not a
gradient. Trace one divergent case end to end on both sides before changing a
line, group divergences by shape rather than reading the total, and keep an
abandoned attempt with its numbers so the next one does not repeat the road.

The rejected alternative was a second differential-oracle pattern doc.
`reference-source-as-differential-oracle.md` already covers the pattern; what it
does not cover is this failure mode, because it describes an *exhaustive*
comparison that returns a binary answer and so cannot be misused this way.

## Closes

None. It documents the method failure behind iu3qez/Esp32KeyerTest#1, which stays open — the defect
is unfixed and the branch `wip-k8-decision-order-attempt` holds the abandoned
attempt.

## Definition of done

- Host tests: n/a, docs only. Suite was 202/202 plain and ASan/UBSan at the time
  of writing, unchanged by this branch.
- Reference test: n/a, no code touched.
- RT path: untouched.
- Blocking issues open on this work: none.

## Not done here

The fix for iu3qez/Esp32KeyerTest#1 itself. The next attempt should start from the trace discipline
this doc records rather than from another sweep.
