### PR TITLE
CWNet TX: keying as MORSE 0x10 with the reference's stopwatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ From [STRATEGY.md](STRATEGY.md): behaviour that matters is proven against a real
 
 - No open `blocking` issue covers this work. See **A Blocking Issue Blocks** under Critical Constraints.
 - Host tests green in both CI variants. Never skip, disable or quarantine a failing test to get there.
-- A change touching CWNet (`keyer_cwnet/`) ships with a host test that pins the behaviour against the reference (DL4YHF client/server traces). The iambic FSM is the `Esp32KeyerTest` submodule: its behaviour is proven there, against the executed K8, under its own STRATEGY.md; here a change is a **pin bump**, and it ships with that repo's suite green at the new commit and `test_host/interface/sample.h` still identical to `keyer_core/include/sample.h` (CI checks both).
+- A change touching CWNet (`keyer_cwnet/`) ships with a host test that pins the behaviour against the reference (DL4YHF client/server traces). The iambic FSM is the `Esp32KeyerTest` submodule: its behaviour is proven there, against the executed K8, under its own STRATEGY.md; here a change is a **pin bump**, and it ships with that repo's suite green at the new commit and the submodule's `test_host/interface/sample.h`, past its five-line banner, still identical to `keyer_core/include/sample.h` (CI checks both).
 - Nothing blocking on the RT path: no `ESP_LOGx`/`printf` on Core 0 — the serial log blocks real time.
 
 A pull request answers these with evidence, not checkmarks, in the shape of [.github/pull_request_template.md](.github/pull_request_template.md): test counts, the test function that pins the reference, the issue condition it makes true and where. A line that cannot be filled honestly is a PR that is not done.

--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -20,8 +20,21 @@
  *   CONNECTING -> recv CONNECT echo -> READY
  *   READY -> recv PING_REQUEST -> send RESPONSE_1, sync timer
  *   READY -> recv PING_RESPONSE_2 -> update latency
- *   READY -> send_key_event() -> send CW_DOWN/CW_UP
+ *   READY -> send_key_event() -> send MORSE (7-bit keying stream)
+ *   READY -> poll() after 14 dot-times of key-up -> send the end of the over
  *   any state -> on_disconnected() -> DISCONNECTED
+ *
+ * Keying on the wire (reference: DL4YHF Remote CW Keyer, CwStreamEnc.c and
+ * KeyerThread.c, sw_MorseTxFifo):
+ *   Each key transition becomes one byte in a MORSE 0x10 frame: bit 7 is the
+ *   new key state, bits 6..0 the 7-bit encoded time to wait before applying
+ *   it, measured from the previous transition. The first transition of an
+ *   over waits 0. After each byte the sender's reference instant advances by
+ *   the *encoded* milliseconds, not the measured ones, so quantisation error
+ *   does not accumulate. A wait above CWSTREAM_MAX_WAIT_MS is split over
+ *   several bytes with the same key state. Once the key has been up for more
+ *   than 14 dot-times the sender emits a second key-up: that is how the
+ *   receiver learns the over has ended.
  */
 
 #pragma once
@@ -59,9 +72,13 @@ typedef enum {
     CWNET_CMD_CONNECT = 0x01,   /**< Client -> Server request; echoed back by the server to confirm */
     CWNET_CMD_DISCONNECT = 0x02,/**< Bidirectional: disconnect */
     CWNET_CMD_PING = 0x03,      /**< Bidirectional: time sync */
-    CWNET_CMD_CW_UP = 0x14,     /**< Key up event */
-    CWNET_CMD_CW_DOWN = 0x15,   /**< Key down event */
+    CWNET_CMD_MORSE = 0x10,     /**< Keying: 7-bit stream, bit 7 = key state, bits 6..0 = wait */
+    CWNET_CMD_CI_V = 0x14,      /**< A single CI-V packet (Icom rig control). Not keying. */
+    CWNET_CMD_SPECTRUM = 0x15,  /**< Spectrum data for the waterfall display. Not keying. */
 } cwnet_cmd_t;
+
+/** Longest MORSE payload this client sends in one frame (bytes = events) */
+#define CWNET_MORSE_MAX_EVENTS 8
 
 /** CONNECT payload field sizes */
 #define CWNET_CONNECT_USERNAME_LEN  44
@@ -139,19 +156,6 @@ typedef void (*cwnet_state_change_cb_t)(cwnet_client_state_t old_state,
                                          cwnet_client_state_t new_state,
                                          void *user_data);
 
-/**
- * @brief CW event received callback (optional)
- *
- * Called when a CW event is received from the server (another operator).
- *
- * @param key_down true if key down, false if key up
- * @param timestamp_ms Event timestamp (server time)
- * @param user_data User context pointer
- */
-typedef void (*cwnet_cw_event_cb_t)(bool key_down,
-                                     int32_t timestamp_ms,
-                                     void *user_data);
-
 /*===========================================================================*/
 /* Configuration                                                             */
 /*===========================================================================*/
@@ -170,7 +174,6 @@ typedef struct {
 
     /* Optional callbacks */
     cwnet_state_change_cb_t state_change_cb;  /**< State change notification */
-    cwnet_cw_event_cb_t cw_event_cb;          /**< Received CW event */
 
     void *user_data;                    /**< User context for callbacks */
 } cwnet_client_config_t;
@@ -194,7 +197,6 @@ typedef struct {
     cwnet_send_cb_t send_cb;
     cwnet_get_time_ms_cb_t get_time_ms_cb;
     cwnet_state_change_cb_t state_change_cb;
-    cwnet_cw_event_cb_t cw_event_cb;
     void *user_data;
 
     /* State */
@@ -208,6 +210,12 @@ typedef struct {
 
     /* Permissions granted by the server in its CONNECT echo */
     uint32_t permissions;
+
+    /* MORSE TX stopwatch: the reference's sw_MorseTxFifo, fFillingTxFifo and
+     * fMorseOutput_sent (KeyerThread.c). */
+    int32_t tx_ref_ms;   /**< Instant the next wait is measured from; advances by the encoded ms */
+    bool tx_filling;     /**< Inside an over: waits are measured, not forced to 0 */
+    bool tx_key_down;    /**< Last key state put on the wire */
 
     /* Frame parser for incoming data */
     cwnet_frame_parser_t parser;
@@ -308,15 +316,43 @@ void cwnet_client_on_data(cwnet_client_t *client,
 /*===========================================================================*/
 
 /**
- * @brief Send CW key event
+ * @brief Send a key transition as a MORSE frame
  *
- * Sends a key down or key up event to the server.
- * Only valid in READY state.
+ * Emits one MORSE 0x10 frame carrying the new key state and the 7-bit wait
+ * since the previous transition, as the reference client does (see the file
+ * header). A call that repeats the current key state sends nothing: the
+ * reference encodes only on a change of its keying output.
+ *
+ * Only valid in READY state, and only once the server granted TRANSMIT.
  *
  * @param client Client context
  * @param key_down true for key down, false for key up
- * @return CWNET_CLIENT_OK on success,
- *         CWNET_CLIENT_ERR_NOT_READY if not in READY state
+ * @param at_ms Instant of the transition, in milliseconds on a clock the
+ *              caller keeps monotonic across calls (only differences are
+ *              used; the first transition of an over is sent with wait 0).
+ *              Round to the millisecond, do not truncate: the reference
+ *              rounds its microsecond stopwatch.
+ * @return CWNET_CLIENT_OK on success (also when nothing had to be sent),
+ *         CWNET_CLIENT_ERR_NOT_READY if not in READY state,
+ *         CWNET_CLIENT_ERR_NOT_PERMITTED if the server did not grant TRANSMIT,
+ *         CWNET_CLIENT_ERR_SEND_FAILED if the send callback failed
  */
 cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
-                                                bool key_down);
+                                                bool key_down,
+                                                int32_t at_ms);
+
+/**
+ * @brief Close an over that has gone quiet
+ *
+ * Call periodically. When the key has been up for more than 14 dot-times
+ * since the last transition, sends the second key-up the reference uses to
+ * mark the end of an over, and stops measuring: the next transition starts
+ * a new over with wait 0.
+ *
+ * @param client Client context
+ * @param now_ms Current instant on the same clock as send_key_event()'s at_ms
+ * @param dot_ms Local dot time in milliseconds (1200 / WPM); the threshold
+ *               is 14 * dot_ms, as the reference's KeyerThread.c
+ * @return true if the end-of-over byte was sent by this call
+ */
+bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms);

--- a/components/keyer_cwnet/include/cwnet_socket.h
+++ b/components/keyer_cwnet/include/cwnet_socket.h
@@ -47,7 +47,10 @@ void cwnet_socket_init(void);
 void cwnet_socket_process(void);
 
 /**
- * @brief Send CW key event
+ * @brief Send a key transition as a MORSE frame
+ *
+ * Stamps the transition with the current time; the end of a quiet over is
+ * sent by cwnet_socket_process().
  *
  * @param key_down true for key down, false for key up
  * @return true if sent successfully

--- a/components/keyer_cwnet/include/cwnet_timestamp.h
+++ b/components/keyer_cwnet/include/cwnet_timestamp.h
@@ -15,6 +15,15 @@
 #include <stdint.h>
 
 /**
+ * @brief Longest wait one 7-bit timestamp can carry, in milliseconds
+ *
+ * A longer wait is sent as several consecutive bytes with the same key
+ * state (CwStreamEnc.c, "pulses or gaps longer than 1165 milliseconds
+ * may be sent as subsequent bytes").
+ */
+#define CWSTREAM_MAX_WAIT_MS 1165
+
+/**
  * @brief Encode milliseconds to 7-bit CW timestamp
  *
  * @param ms Duration in milliseconds (negative clamps to 0, >1165 clamps to max)

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -4,6 +4,7 @@
  */
 
 #include "cwnet_client.h"
+#include "cwnet_timestamp.h"
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>
@@ -146,36 +147,53 @@ static cwnet_client_err_t send_ping_response(cwnet_client_t *client,
 }
 
 /**
- * @brief Build and send CW event frame
+ * @brief Build and send one MORSE frame for a key transition
  *
- * CW event frame format (short payload with timestamp):
- *   - cmd byte: (CW_DOWN/CW_UP << 2) | CAT_SHORT
- *   - length: 4 (32-bit timestamp)
- *   - payload: 4-byte little-endian synced timestamp
+ * MORSE frame format (short payload):
+ *   - cmd byte: 0x50 = (CAT_SHORT << 6) | MORSE
+ *   - length: number of keying bytes
+ *   - payload: keying bytes, bit 7 = key state, bits 6..0 = 7-bit wait
+ *
+ * A wait above CWSTREAM_MAX_WAIT_MS becomes several bytes with the same key
+ * state, exactly as CwStream_EncodeKeyUpDownEvent() splits it: full bytes of
+ * 1165 ms, then the remainder. The reference queues them in its FIFO and the
+ * network poll drains the whole FIFO into one frame, so they travel together.
+ *
+ * @param encoded_ms Out: sum of the decoded waits actually put on the wire.
+ *                   This is what the sender's stopwatch advances by.
  */
-static cwnet_client_err_t send_cw_event(cwnet_client_t *client, bool key_down) {
-    /* Get synced timestamp */
-    int32_t local_time = get_local_time(client);
-    int32_t timestamp = cwnet_timer_read_synced_ms(&client->timer, local_time);
+static cwnet_client_err_t send_morse(cwnet_client_t *client,
+                                     bool key_down,
+                                     int32_t wait_ms,
+                                     int32_t *encoded_ms) {
+    uint8_t frame[2 + CWNET_MORSE_MAX_EVENTS];
+    size_t n = 0;
+    int32_t remaining = wait_ms > 0 ? wait_ms : 0;
+    int32_t total = 0;
 
-    /* Frame: cmd(1) + len(1) + timestamp(4) */
-    uint8_t frame[6];
-    cwnet_cmd_t cmd = key_down ? CWNET_CMD_CW_DOWN : CWNET_CMD_CW_UP;
-    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, cmd);
-    frame[1] = 4;  /* 4-byte timestamp */
+    /* The reference's do-while: always at least one byte, even for wait 0 */
+    do {
+        int32_t chunk = remaining > CWSTREAM_MAX_WAIT_MS ? CWSTREAM_MAX_WAIT_MS : remaining;
+        uint8_t b = cwstream_encode_timestamp((int)chunk);
+        if (key_down) {
+            b |= 0x80u;
+        }
+        frame[2 + n] = b;
+        n++;
+        total += cwstream_decode_timestamp(b);
+        remaining -= chunk;
+    } while (remaining > 0 && n < CWNET_MORSE_MAX_EVENTS);
 
-    /* Little-endian timestamp */
-    uint32_t ts = (uint32_t)timestamp;
-    frame[2] = (uint8_t)(ts & 0xFF);
-    frame[3] = (uint8_t)((ts >> 8) & 0xFF);
-    frame[4] = (uint8_t)((ts >> 16) & 0xFF);
-    frame[5] = (uint8_t)((ts >> 24) & 0xFF);
+    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_MORSE);
+    frame[1] = (uint8_t)n;
 
-    int sent = send_frame(client, frame, sizeof(frame));
-    if (sent < 0 || (size_t)sent != sizeof(frame)) {
+    size_t frame_len = 2 + n;
+    int sent = send_frame(client, frame, frame_len);
+    if (sent < 0 || (size_t)sent != frame_len) {
         return CWNET_CLIENT_ERR_SEND_FAILED;
     }
 
+    *encoded_ms = total;
     return CWNET_CLIENT_OK;
 }
 
@@ -256,30 +274,10 @@ static void handle_ping(cwnet_client_t *client,
 }
 
 /**
- * @brief Handle CW event frame (received from server/other operators)
- */
-static void handle_cw_event(cwnet_client_t *client,
-                            bool key_down,
-                            const uint8_t *payload,
-                            size_t len) {
-    if (client->cw_event_cb == NULL) {
-        return;  /* No callback registered */
-    }
-
-    /* Decode little-endian 32-bit timestamp */
-    int32_t timestamp = 0;
-    if (len >= 4) {
-        timestamp = (int32_t)((uint32_t)payload[0] |
-                              ((uint32_t)payload[1] << 8) |
-                              ((uint32_t)payload[2] << 16) |
-                              ((uint32_t)payload[3] << 24));
-    }
-
-    client->cw_event_cb(key_down, timestamp, client->user_data);
-}
-
-/**
  * @brief Process a complete frame from parse result
+ *
+ * Keying from other operators arrives as MORSE 0x10 and is not decoded yet.
+ * CI_V 0x14 and SPECTRUM 0x15 are rig control and display data, never keying.
  */
 static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *result) {
     uint8_t cmd = result->command;
@@ -295,16 +293,8 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
             handle_ping(client, payload, payload_len);
             break;
 
-        case CWNET_CMD_CW_DOWN:
-            handle_cw_event(client, true, payload, payload_len);
-            break;
-
-        case CWNET_CMD_CW_UP:
-            handle_cw_event(client, false, payload, payload_len);
-            break;
-
         default:
-            /* Unknown command, ignore */
+            /* Not handled, ignore */
             break;
     }
 }
@@ -353,7 +343,6 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     client->send_cb = config->send_cb;
     client->get_time_ms_cb = config->get_time_ms_cb;
     client->state_change_cb = config->state_change_cb;
-    client->cw_event_cb = config->cw_event_cb;
     client->user_data = config->user_data;
 
     /* Initialize state */
@@ -409,6 +398,11 @@ void cwnet_client_on_connected(cwnet_client_t *client) {
 
     /* Reset parser for new connection */
     cwnet_frame_parser_reset(&client->parser);
+
+    /* A new session starts a new over: first transition waits 0 */
+    client->tx_ref_ms = 0;
+    client->tx_filling = false;
+    client->tx_key_down = false;
 
     /* Transition to CONNECTING */
     set_state(client, CWNET_STATE_CONNECTING);
@@ -471,7 +465,8 @@ void cwnet_client_on_data(cwnet_client_t *client,
 }
 
 cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
-                                                bool key_down) {
+                                                bool key_down,
+                                                int32_t at_ms) {
     if (client == NULL) {
         return CWNET_CLIENT_ERR_INVALID_ARG;
     }
@@ -487,5 +482,57 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
         return CWNET_CLIENT_ERR_NOT_PERMITTED;
     }
 
-    return send_cw_event(client, key_down);
+    /* KeyerThread.c encodes only when fMorseOutput differs from what was sent */
+    if (key_down == client->tx_key_down) {
+        return CWNET_CLIENT_OK;
+    }
+
+    /* Wait since the previous transition. At the start of an over there is
+     * no previous transition: the wait is 0 and the stopwatch starts here. */
+    bool opening = !client->tx_filling;
+    int32_t wait_ms = opening ? 0 : at_ms - client->tx_ref_ms;
+
+    int32_t encoded_ms = 0;
+    cwnet_client_err_t err = send_morse(client, key_down, wait_ms, &encoded_ms);
+    if (err != CWNET_CLIENT_OK) {
+        return err;
+    }
+
+    /* Advance by what the receiver will actually wait, not by what we
+     * measured: the quantisation residual carries into the next interval
+     * (TIM_AdjustStopwatch_ms in KeyerThread.c). The reference never resets
+     * this state on reconnect; we do, in on_connected(), so a session cannot
+     * open with a stale wait. */
+    if (opening) {
+        client->tx_ref_ms = at_ms;
+        client->tx_filling = true;
+    }
+    client->tx_ref_ms += encoded_ms;
+    client->tx_key_down = key_down;
+    return CWNET_CLIENT_OK;
+}
+
+bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms) {
+    if (client == NULL || client->state != CWNET_STATE_READY) {
+        return false;
+    }
+    if (!client->tx_filling || client->tx_key_down) {
+        return false;
+    }
+
+    /* KeyerThread.c: t_us > 14000 * iDotTime_ms. Which 16 ms bucket the
+     * elapsed time falls in depends on the poll instant there too. */
+    int32_t elapsed_ms = now_ms - client->tx_ref_ms;
+    if (elapsed_ms <= 14 * dot_ms) {
+        return false;
+    }
+
+    int32_t encoded_ms = 0;
+    if (send_morse(client, false, elapsed_ms, &encoded_ms) != CWNET_CLIENT_OK) {
+        return false;
+    }
+
+    client->tx_ref_ms += encoded_ms;
+    client->tx_filling = false;  /* the next transition opens a new over with wait 0 */
+    return true;
 }

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -274,7 +274,6 @@ void cwnet_socket_init(void) {
         .send_cb = socket_send_cb,
         .get_time_ms_cb = get_time_ms_cb,
         .state_change_cb = state_change_cb,
-        .cw_event_cb = NULL,  /* TODO: handle received CW events */
         .user_data = NULL
     };
 
@@ -328,6 +327,18 @@ void cwnet_socket_process(void) {
             if (cwnet_client_get_state(&s_ctx.client) == CWNET_STATE_READY) {
                 s_ctx.state = CWNET_SOCK_READY;
             }
+
+            /* Close a quiet over: the reference sends a second key-up after
+             * 14 dot-times of silence, and that is how the server learns the
+             * over ended. Same clock as the key events below. */
+            {
+                uint32_t wpm = (uint32_t)CONFIG_GET_WPM();
+                int32_t dot_ms = wpm > 0 ? (int32_t)(1200u / wpm) : 0;
+                if (dot_ms > 0 &&
+                    cwnet_client_poll(&s_ctx.client, get_time_ms_cb(NULL), dot_ms)) {
+                    RT_DEBUG(&g_bg_log_stream, now_us, "CWNet TX: end of over");
+                }
+            }
             break;
 
         case CWNET_SOCK_ERROR:
@@ -345,7 +356,11 @@ bool cwnet_socket_send_key_event(bool key_down) {
         return false;
     }
 
-    cwnet_client_err_t err = cwnet_client_send_key_event(&s_ctx.client, key_down);
+    /* Stamped when the caller got to the event, not when the edge happened
+     * on Core 0: the 7-bit wait inherits the bg loop's jitter. Feeding the
+     * client from a stream consumer with stream time is separate work. */
+    cwnet_client_err_t err = cwnet_client_send_key_event(&s_ctx.client, key_down,
+                                                         get_time_ms_cb(NULL));
     if (err == CWNET_CLIENT_OK) {
         int64_t now_us = esp_timer_get_time();
         RT_DEBUG(&g_bg_log_stream, now_us, "CWNet TX: %s", key_down ? "DOWN" : "UP");

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -75,6 +75,40 @@ static void feed_connect_echo(void) {
     cwnet_client_on_data(&client, ref_connect_echo, sizeof(ref_connect_echo));
 }
 
+/* Everything the client sends, in order: mock_send keeps only the last frame. */
+static uint8_t mock_tx_all[512];
+static size_t mock_tx_all_len;
+
+static int mock_send_accumulate(const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    if (mock_tx_all_len + len > sizeof(mock_tx_all)) {
+        return -1;
+    }
+    memcpy(mock_tx_all + mock_tx_all_len, data, len);
+    mock_tx_all_len += len;
+    return (int)len;
+}
+
+/* A client at READY with TRANSMIT granted, capturing every byte it sends
+ * from here on (the CONNECT it sent is dropped). */
+static void ready_client_accumulating(void) {
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "TEST",
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+
+    test_setup();
+    mock_tx_all_len = 0;
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+    feed_connect_echo();
+    mock_tx_all_len = 0;
+}
+
 /*===========================================================================*/
 /* Initialization Tests                                                      */
 /*===========================================================================*/
@@ -301,7 +335,7 @@ void test_client_refuses_to_key_without_transmit_permission(void) {
     TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
 
     TEST_ASSERT_EQUAL(CWNET_CLIENT_ERR_NOT_PERMITTED,
-                      cwnet_client_send_key_event(&client, true));
+                      cwnet_client_send_key_event(&client, true, 1000));
 }
 
 /*===========================================================================*/
@@ -427,57 +461,194 @@ void test_client_updates_latency_on_ping_response2(void) {
 /* CW Event Tests                                                            */
 /*===========================================================================*/
 
-void test_client_sends_key_down_event(void) {
-    cwnet_client_config_t config = {
-        .server_host = "test.server.com",
-        .server_port = 7373,
-        .username = "TEST",
-        .send_cb = mock_send,
-        .get_time_ms_cb = mock_get_time_ms,
-        .user_data = NULL
-    };
+/*
+ * Keying goes out as MORSE 0x10: one byte per transition, bit 7 the new key
+ * state, bits 6..0 the 7-bit wait since the previous transition. Reference:
+ * DL4YHF CwStreamEnc.c and KeyerThread.c (sw_MorseTxFifo); the synthetic
+ * expectations below were produced by tools/cwnet/keyer_sim.c, which runs
+ * that algorithm on the reference's own encoder.
+ */
 
-    cwnet_client_init(&client, &config);
-    cwnet_client_on_connected(&client);
+void test_client_tx_first_transition_of_an_over_waits_zero(void) {
+    ready_client_accumulating();
 
-    feed_connect_echo();
-    mock_tx_len = 0;
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true, 5000));
 
-    /* Send key down event */
-    mock_time_ms = 2000;
-    cwnet_client_err_t err = cwnet_client_send_key_event(&client, true);
-    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, err);
-    TEST_ASSERT_GREATER_THAN(0, mock_tx_len);
-
-    /* Verify it's a CW_DOWN command with timestamp */
-    /* CMD_CW_DOWN = 0x15 with category 1: (1 << 6) | 0x15 = 0x55 */
-    TEST_ASSERT_EQUAL(0x55, mock_tx_buffer[0]);
+    /* 0x50 = short block | MORSE; one byte: key down, wait 0 */
+    static const uint8_t expected[] = {0x50, 0x01, 0x80};
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
 }
 
-void test_client_sends_key_up_event(void) {
-    cwnet_client_config_t config = {
-        .server_host = "test.server.com",
-        .server_port = 7373,
-        .username = "TEST",
-        .send_cb = mock_send,
-        .get_time_ms_cb = mock_get_time_ms,
-        .user_data = NULL
+void test_client_tx_wait_is_measured_from_previous_transition(void) {
+    ready_client_accumulating();
+
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true, 5000));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 5048));
+
+    /* 48 ms is in the 4 ms range: 0x20 + (48 - 32) / 4 = 0x24, key up */
+    static const uint8_t expected[] = {0x50, 0x01, 0x80, 0x50, 0x01, 0x24};
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
+
+/*
+ * Client-to-server bytes 238..278 of session 12 of the 2026-09-05 capture of
+ * the official DL4YHF client: its first over, the letter A at 25 WPM (dot
+ * 48 ms) and then silence. Five MORSE frames, with the two rigctld set_ptt
+ * frames the reference interleaves around an over (PTT is #13; we do not
+ * send it, so the comparison is on the MORSE frames alone).
+ */
+static const uint8_t ref_first_over[] = {
+    0x50, 0x01, 0x80,                                     /* key down, wait 0      */
+    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
+    0x20, 0x31, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 1"   */
+    0x50, 0x01, 0x24,                                     /* key up   after  48 ms */
+    0x50, 0x01, 0xA4,                                     /* key down after  48 ms */
+    0x50, 0x01, 0x3C,                                     /* key up   after 144 ms */
+    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
+    0x20, 0x30, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 0"   */
+    0x50, 0x01, 0x60,                                     /* end of over, 669 ms   */
+};
+
+void test_client_tx_first_over_matches_reference_capture(void) {
+    ready_client_accumulating();
+
+    /* The edges the reference client saw, reconstructed from its own bytes */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1000));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1048));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1096));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1240));
+    /* 14 dot-times = 672 ms: not at exactly 672, sent at the first poll past it */
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 1240 + 672, 48));
+    TEST_ASSERT_TRUE(cwnet_client_poll(&client, 1240 + 673, 48));
+
+    /* Expected: the raw bytes of every MORSE frame in the capture, in order */
+    uint8_t expected[sizeof(ref_first_over)];
+    size_t expected_len = 0;
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+    size_t off = 0;
+    while (off < sizeof(ref_first_over)) {
+        cwnet_parse_result_t r = cwnet_frame_parse(&parser, ref_first_over + off,
+                                                   sizeof(ref_first_over) - off);
+        TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r.status);
+        if (r.command == CWNET_CMD_MORSE) {
+            memcpy(expected + expected_len, ref_first_over + off, r.bytes_consumed);
+            expected_len += r.bytes_consumed;
+        }
+        off += r.bytes_consumed;
+    }
+    TEST_ASSERT_EQUAL(15, expected_len);  /* five frames of three bytes */
+
+    TEST_ASSERT_EQUAL(expected_len, mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, expected_len);
+}
+
+void test_client_tx_advances_by_encoded_not_measured_ms(void) {
+    ready_client_accumulating();
+
+    /* 33 ms edges: 33 encodes as 32 (0x20). The reference advances its
+     * stopwatch by the encoded 32, so the next interval measures 34, then
+     * 35, then 36, which finally encodes as 0x21. Advancing by the measured
+     * 33 would send 0x20 forever and let the receiver drift 1 ms per edge. */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 33));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  66));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 99));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  132));
+
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x20,
+        0x50, 0x01, 0xA0,
+        0x50, 0x01, 0x20,
+        0x50, 0x01, 0xA1,
     };
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
 
-    cwnet_client_init(&client, &config);
-    cwnet_client_on_connected(&client);
+void test_client_tx_splits_wait_above_1165_ms(void) {
+    ready_client_accumulating();
 
-    feed_connect_echo();
-    mock_tx_len = 0;
+    /* A 2000 ms gap inside an over (below the end-of-over threshold at slow
+     * speed): 1165 ms as 0x7F, then 835 ms as 0x6A, both key down, in one
+     * frame. The stopwatch advances by 1165 + 829 = 1994, so the next
+     * interval measures 30 + 6 = 36 ms. */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 20));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  2020));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 2050));
 
-    /* Send key up event */
-    mock_time_ms = 2100;
-    cwnet_client_err_t err = cwnet_client_send_key_event(&client, false);
-    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, err);
-    TEST_ASSERT_GREATER_THAN(0, mock_tx_len);
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x14,
+        0x50, 0x02, 0xFF, 0xEA,
+        0x50, 0x01, 0x21,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
 
-    /* CMD_CW_UP = 0x14 with category 1: (1 << 6) | 0x14 = 0x54 */
-    TEST_ASSERT_EQUAL(0x54, mock_tx_buffer[0]);
+void test_client_tx_end_of_over_after_14_dot_times(void) {
+    ready_client_accumulating();
+
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    /* Key still down: nothing to close, whatever the elapsed time */
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 5000, 48));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 48));
+
+    /* Strictly more than 14 dot-times */
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 48 + 672, 48));
+    TEST_ASSERT_TRUE(cwnet_client_poll(&client, 48 + 673, 48));
+    /* Once: the over is closed until the next transition */
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 48 + 2000, 48));
+    /* The next transition opens a new over with wait 0 */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true, 5000));
+
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x24,
+        0x50, 0x01, 0x60,   /* 673 ms in the 16 ms range: 0x40 + (673 - 157) / 16 */
+        0x50, 0x01, 0x80,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
+
+void test_client_tx_end_of_over_splits_at_slow_speed(void) {
+    ready_client_accumulating();
+
+    /* At 12 WPM (dot 100 ms) 14 dot-times are 1400 ms, more than one byte
+     * can carry: the end of the over is 1165 + 236 ms, two key-up bytes in
+     * one frame, three consecutive key-ups in the stream. */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 100));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 100 + 1400, 100));
+    TEST_ASSERT_TRUE(cwnet_client_poll(&client, 100 + 1401, 100));
+
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x31,
+        0x50, 0x02, 0x7F, 0x44,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
+
+void test_client_tx_ignores_repeated_key_state(void) {
+    ready_client_accumulating();
+
+    /* The reference encodes only on a change of its keying output */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  10));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 48));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 60));
+
+    static const uint8_t expected[] = {0x50, 0x01, 0x80, 0x50, 0x01, 0x24};
+    TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
 }
 
 void test_client_rejects_events_when_not_ready(void) {
@@ -493,7 +664,7 @@ void test_client_rejects_events_when_not_ready(void) {
     cwnet_client_init(&client, &config);
     /* Don't connect - stay in DISCONNECTED state */
 
-    cwnet_client_err_t err = cwnet_client_send_key_event(&client, true);
+    cwnet_client_err_t err = cwnet_client_send_key_event(&client, true, 1000);
     TEST_ASSERT_EQUAL(CWNET_CLIENT_ERR_NOT_READY, err);
 }
 
@@ -544,7 +715,7 @@ void test_client_handles_disconnect_during_operation(void) {
     TEST_ASSERT_EQUAL(CWNET_STATE_DISCONNECTED, cwnet_client_get_state(&client));
 
     /* Verify can't send events after disconnect */
-    cwnet_client_err_t err = cwnet_client_send_key_event(&client, true);
+    cwnet_client_err_t err = cwnet_client_send_key_event(&client, true, 1000);
     TEST_ASSERT_EQUAL(CWNET_CLIENT_ERR_NOT_READY, err);
 }
 
@@ -638,8 +809,14 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_updates_latency_on_ping_response2);
 
     /* CW Events */
-    RUN_TEST(test_client_sends_key_down_event);
-    RUN_TEST(test_client_sends_key_up_event);
+    RUN_TEST(test_client_tx_first_transition_of_an_over_waits_zero);
+    RUN_TEST(test_client_tx_wait_is_measured_from_previous_transition);
+    RUN_TEST(test_client_tx_first_over_matches_reference_capture);
+    RUN_TEST(test_client_tx_advances_by_encoded_not_measured_ms);
+    RUN_TEST(test_client_tx_splits_wait_above_1165_ms);
+    RUN_TEST(test_client_tx_end_of_over_after_14_dot_times);
+    RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
+    RUN_TEST(test_client_tx_ignores_repeated_key_state);
     RUN_TEST(test_client_rejects_events_when_not_ready);
 
     /* Error Handling */

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -222,8 +222,14 @@ void test_client_refuses_to_key_without_transmit_permission(void);
 void test_client_responds_to_ping_request(void);
 void test_client_syncs_timer_on_ping_request(void);
 void test_client_updates_latency_on_ping_response2(void);
-void test_client_sends_key_down_event(void);
-void test_client_sends_key_up_event(void);
+void test_client_tx_first_transition_of_an_over_waits_zero(void);
+void test_client_tx_wait_is_measured_from_previous_transition(void);
+void test_client_tx_first_over_matches_reference_capture(void);
+void test_client_tx_advances_by_encoded_not_measured_ms(void);
+void test_client_tx_splits_wait_above_1165_ms(void);
+void test_client_tx_end_of_over_after_14_dot_times(void);
+void test_client_tx_end_of_over_splits_at_slow_speed(void);
+void test_client_tx_ignores_repeated_key_state(void);
 void test_client_rejects_events_when_not_ready(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
@@ -501,9 +507,15 @@ int main(void) {
     RUN_TEST(test_client_responds_to_ping_request);
     RUN_TEST(test_client_syncs_timer_on_ping_request);
     RUN_TEST(test_client_updates_latency_on_ping_response2);
-    /* CW Events */
-    RUN_TEST(test_client_sends_key_down_event);
-    RUN_TEST(test_client_sends_key_up_event);
+    /* Keying TX: MORSE 0x10 against the DL4YHF reference */
+    RUN_TEST(test_client_tx_first_transition_of_an_over_waits_zero);
+    RUN_TEST(test_client_tx_wait_is_measured_from_previous_transition);
+    RUN_TEST(test_client_tx_first_over_matches_reference_capture);
+    RUN_TEST(test_client_tx_advances_by_encoded_not_measured_ms);
+    RUN_TEST(test_client_tx_splits_wait_above_1165_ms);
+    RUN_TEST(test_client_tx_end_of_over_after_14_dot_times);
+    RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
+    RUN_TEST(test_client_tx_ignores_repeated_key_state);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);

--- a/tools/cwnet/README.md
+++ b/tools/cwnet/README.md
@@ -16,6 +16,7 @@ compilano con clang/gcc. In particolare `pcap_to_stream.py` sostituisce
 | `cwnet_dump.c` | Decodifica un flusso grezzo: parser di frame **nostro** + codec del keying **di DL4YHF**. Diagnostico, non asserisce. |
 | `diff_main.c` | Confronto esaustivo del nostro `cwnet_timestamp.c` contro `CwStreamEnc.c` di DL4YHF, tutto il dominio di ingresso. |
 | `gen_synth.c` | Genera uno stream MORSE sintetico con l'encoder DL4YHF, per collaudare il decodificatore. |
+| `keyer_sim.c` | Simula il `KeyerThread` di DL4YHF (transizioni, cronometro aggiustato dei ms codificati, fine over a 14 dot-time) sull'encoder DL4YHF. Provenienza degli attesi sintetici di `test_cwnet_client.c`; il caso A riproduce i byte del primo over della sessione 12. |
 | `shim/yhf_type.h` | I quattro typedef (`BYTE`/`WORD`/`DWORD`/`BOOL`) che l'archivio pubblicato di DL4YHF non include. Scritto da noi. |
 | `shim/Elbug.h` | Stub: `CwStreamEnc.c` include `Elbug.h` ma non usa alcun simbolo di Elbug, solo i typedef. Lo stub evita di dover scaricare `Elbug.{c,h}`. Scritto da noi. |
 
@@ -50,6 +51,9 @@ clang -O1 -fsanitize=undefined -I shim -I "$REF" -I "$OUR/include" \
 # decodifica di una cattura
 clang -O1 -Wall -Wextra -fsanitize=address,undefined -I shim -I "$REF" -I "$OUR/include" \
       cwnet_dump.c "$REF/CwStreamEnc.c" "$OUR/src/cwnet_frame.c" -o cwnet_dump
+
+# byte attesi dal KeyerThread di riferimento per una lista di edge
+clang -O1 -Wall -fsanitize=undefined -I shim -I "$REF" keyer_sim.c "$REF/CwStreamEnc.c" -o keyer_sim && ./keyer_sim
 
 # tap dal vivo: client -> tap -> server, un file per direzione
 python3 cwnet_tap.py --listen 0.0.0.0:7355 --server <ip-server>:7355 --out sess

--- a/tools/cwnet/keyer_sim.c
+++ b/tools/cwnet/keyer_sim.c
@@ -1,0 +1,64 @@
+/* keyer_sim - il KeyerThread di DL4YHF (KeyerThread.c:2707-2762) simulato
+ * sull'encoder di riferimento CwStreamEnc.c, con un cronometro ideale in µs.
+ * Produce i byte MORSE che il client ufficiale accoderebbe per una lista di
+ * edge: e' la provenienza degli attesi sintetici in test_cwnet_client.c.
+ * Il caso A riproduce il primo over della sessione 12 del 2026-09-05. */
+#include "yhf_type.h"
+#include <stdio.h>
+#include <string.h>
+#include "CwStreamEnc.h"
+
+static T_CW_KEYING_FIFO fifo;
+static long sw_start_us;     /* istante di partenza del cronometro, aggiustato */
+static int  filling, sent;   /* fFillingTxFifo, fMorseOutput_sent */
+
+static void reset(void){ memset(&fifo,0,sizeof fifo); sw_start_us=0; filling=0; sent=0; }
+
+/* KeyerThread.c:2717-2741 (transizione) e :2743-2761 (fine over) */
+static void tick(long now_us, int key, int dot_ms){
+  long t_us; int enc;
+  if(key != sent){
+    t_us = now_us - sw_start_us;
+    if(!filling){ t_us = 0; sw_start_us = now_us; filling = 1; }
+    enc = CwStream_EncodeKeyUpDownEvent(&fifo, key, (int)((t_us + 500) / 1000));
+    sw_start_us += (long)enc * 1000;          /* TIM_AdjustStopwatch_ms */
+    sent = key;
+  } else {
+    t_us = now_us - sw_start_us;
+    if(!key && t_us > 14000L * dot_ms && filling){
+      enc = CwStream_EncodeKeyUpDownEvent(&fifo, key, (int)((t_us + 500) / 1000));
+      sw_start_us += (long)enc * 1000;
+      filling = 0;
+    }
+  }
+}
+static void dump(const char *tag){
+  int i = fifo.iTailIndex; printf("%-28s", tag);
+  while(i != fifo.iHeadIndex){ printf(" %02X", fifo.elem[i].bCmd); i=(i+1)&(CW_KEYING_FIFO_SIZE-1); }
+  fifo.iTailIndex = fifo.iHeadIndex; printf("   (cronometro ora a %ld us)\n", sw_start_us);
+}
+typedef struct { long t; int k; } edge_t;
+/* edge[] = {istante_us, stato}; poll ogni period_us fino a t_end */
+static void run(const char *tag, const edge_t *e, int n, int dot_ms, long period_us, long t_end){
+  int i=0; long t; int key=0; reset();
+  for(t=0; t<=t_end; t+=period_us){
+    while(i<n && e[i].t <= t){ key=e[i].k; tick(e[i].t, key, dot_ms); i++; }
+    tick(t, key, dot_ms);
+  }
+  dump(tag);
+}
+int main(void){
+  edge_t A[]={{0,1},{48000,0},{96000,1},{240000,0}};
+  run("A primo over, dot 48", A, 4, 48, 2000, 1500000);        /* -> 80 24 A4 3C 60 */
+  edge_t B[]={{0,1},{33000,0},{66000,1},{99000,0},{132000,1}};
+  run("B edge a 33 ms", B, 5, 48, 2000, 132000);                /* -> 80 20 A0 20 A1 */
+  edge_t C[]={{0,1},{20000,0},{2020000,1},{2050000,0}};
+  run("C gap 2000 ms spezzato", C, 4, 240, 2000, 2050000);      /* -> 80 14 FF EA 21 */
+  edge_t D[]={{0,1},{31600,0},{63200,1}};
+  run("D arrotondamento 31.6 ms", D, 3, 48, 2000, 64000);       /* -> 80 20 9F */
+  edge_t E[]={{0,1},{48000,0}};
+  run("E fine over, poll 1 ms", E, 2, 48, 1000, 800000);        /* -> 80 24 60 */
+  edge_t F[]={{0,1},{100000,0}};
+  run("F fine over a 12 WPM (dot 100)", F, 2, 100, 1000, 2000000); /* -> 80 31 7F 44: soglia 1400 > 1165 */
+  return 0;
+}


### PR DESCRIPTION
## What changes

Keying leaves the box as `MORSE 0x10` frames carrying the 7-bit stream, with the reference client's stopwatch rule: the first transition of an over waits 0, each later wait is measured from a reference instant that advances by the *encoded* milliseconds, a wait above 1165 ms is split over bytes of the same key state, and after 14 dot-times of key-up a second key-up closes the over. That last part is not in #10's text; it is what the reference emits for every over (`KeyerThread.c:2747`) and without it the server never learns the over ended. The RX cases that read CI-V (0x14) and SPECTRUM (0x15) as keying are gone, with their callback; MORSE RX is #11. The socket layer stamps events with its own clock and polls the end of over from `cwnet_socket_process()`.

Decision taken: TX state resets on connect. The reference never clears `fFillingTxFifo` on reconnect and can open a session with a stale wait; that is a defect there, not behaviour to reproduce. Alternative rejected: keeping `get_time_ms_cb` as the only time source. The API takes the transition instant explicitly so #55 can feed stream time without touching the client again.

## Closes

#10. Condition: the TX path emits `MORSE 0x10` frames whose payload is the 7-bit stream from `cwstream_encode_timestamp()`, and the sender advances its stopwatch by the encoded milliseconds. Holds in `components/keyer_cwnet/src/cwnet_client.c`, `send_morse()` and `cwnet_client_send_key_event()`.

## Definition of done

- Host tests: 182/182 plain, 182/182 ASan/UBSan. Was 176: the two tests that asserted `0x55`/`0x54` are replaced by eight.
- Reference test: `test_client_tx_first_over_matches_reference_capture` compares our frames byte for byte with the MORSE frames of the first over of session 12 of the 2026-09-05 capture of the official DL4YHF client (client→server bytes 238..278, embedded with provenance; the interleaved `set_ptt` frames are #13 and filtered). The synthetic cases (`_advances_by_encoded_not_measured_ms`, `_splits_wait_above_1165_ms`, `_end_of_over_splits_at_slow_speed`) take their bytes from `tools/cwnet/keyer_sim.c`: the reference's `KeyerThread.c:2707-2762` run on the reference's own `CwStreamEnc.c`; its case A reproduces the capture. An adversarial review of that reading against the source confirmed every claim the implementation rests on and pinned the reference's loop period at 2 ms.
- RT path: untouched. Everything here runs on Core 1.
- Blocking issues open on this work: none.

## Not done here

- Stream-time stamping and a CWNet-owned stream consumer, so keying is sent without a browser attached: #55.
- MORSE RX: #11. Its body assumes an RX consumer exists; there is none (comment on the issue).
- `set_ptt` rigctld frames around an over: #13.
- Firmware build checked by CI only (`firmware-build`): no ESP-IDF on this machine, and not run on hardware.
