### PR TITLE
CWNet keys from the keying stream, on stream time

### DIFF
--- a/.claude/code-quality.md
+++ b/.claude/code-quality.md
@@ -11,7 +11,8 @@
 
 ## Da sistemare
 - `.devcontainer/Dockerfile`: `ARG DOCKER_TAG=v5.5.1` e path `idf5.5_py3.12_env` hardcoded — non aggiornati dopo la migrazione a IDF v6. Da verificare su un'immagine `espressif/idf:v6.x` prima di cambiare.
-- `test_host/CLAUDE.md` e `components/keyer_core/CLAUDE.md` (blocchi `treecode` auto) nominano ancora `keyer_iambic` come dipendenza in-tree: dal 2026-09-06 è il submodule `Esp32KeyerTest`. Si risincronizzano con `map-tree`, non a mano.
+- `test_host/CLAUDE.md` e `components/keyer_core/CLAUDE.md` (blocchi `treecode` auto) nominano ancora `keyer_iambic` come dipendenza in-tree: dal 2026-09-06 è il submodule `Esp32KeyerTest`. `components/keyer_cwnet/CLAUDE.md` dice ancora che è `bg_task` a passare gli eventi di keying: dal 2026-09-07 il modulo consuma lo stream da sé (`cwnet_feed`, #55). Si risincronizzano con `map-tree`, non a mano.
+- `sample_silence()` clampa il marker a `UINT16_MAX`: oltre 65,5 s di stream immutato i tick in eccesso spariscono dal marker e il tempo di stream ricostruito da un consumer (`cwnet_feed`) resta indietro. Innocuo finché il fine over chiude l'over; il rimedio è che `stream_push` scarichi il marker quando `idle_ticks` arriva a `UINT16_MAX` (RT path, un confronto per tick, test host possibile).
 - Ramo remoto `k8-differential-bench` (`fae2f57`), senza PR: lo scheletro del banco è migrato in Esp32KeyerTest, `FINDINGS.md` (numeri superati) vive solo lì. Da cancellare quando nessuno lo cita più.
 
 

--- a/.claude/feature-status.md
+++ b/.claude/feature-status.md
@@ -30,7 +30,7 @@
 |---------|-------------|
 | Keyer page (testo, memory M1-M8) | Completa end-to-end (8 API, NVS, UI) |
 | WiFi status API | Implementata (stato, IP, CWNet latency) |
-| CWNet TX (locale→remoto) | Funzionante via `cwnet_socket_send_key_event()` |
+| CWNet TX (locale→remoto) | MORSE 0x10 dal keying stream via `cwnet_feed` (#10, #55); non provato su hardware |
 | wireguard-vpn | Mergiato su main (commit `2678037`) — componente, console, WebUI, config |
 | ESP-IDF v6 migration | Completata — cJSON via component manager, esp_wireguard vendorato in `components/`, deps strict-check, GPIO iomux rename |
 

--- a/components/keyer_cwnet/CMakeLists.txt
+++ b/components/keyer_cwnet/CMakeLists.txt
@@ -9,9 +9,11 @@ idf_component_register(
         "src/cwnet_frame.c"
         "src/cwnet_ping.c"
         "src/cwnet_client.c"
+        "src/cwnet_feed.c"
         "src/cwnet_socket.c"
     INCLUDE_DIRS "include"
     REQUIRES
+        keyer_core
         keyer_config
         keyer_logging
         esp_timer

--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -77,8 +77,13 @@ typedef enum {
     CWNET_CMD_SPECTRUM = 0x15,  /**< Spectrum data for the waterfall display. Not keying. */
 } cwnet_cmd_t;
 
-/** Longest MORSE payload this client sends in one frame (bytes = events) */
-#define CWNET_MORSE_MAX_EVENTS 8
+/**
+ * Longest MORSE payload this client sends in one frame (bytes = events).
+ * The reference's keying FIFO holds 128 (CW_KEYING_FIFO_SIZE): 149 s of wait.
+ * A longer wait is truncated on the wire and the stopwatch re-based on the
+ * edge, so only that one wait is short.
+ */
+#define CWNET_MORSE_MAX_EVENTS 128
 
 /** CONNECT payload field sizes */
 #define CWNET_CONNECT_USERNAME_LEN  44
@@ -213,7 +218,7 @@ typedef struct {
 
     /* MORSE TX stopwatch: the reference's sw_MorseTxFifo, fFillingTxFifo and
      * fMorseOutput_sent (KeyerThread.c). */
-    int32_t tx_ref_ms;   /**< Instant the next wait is measured from; advances by the encoded ms */
+    uint32_t tx_ref_ms;  /**< Instant the next wait is measured from; advances by the encoded ms (wraps) */
     bool tx_filling;     /**< Inside an over: waits are measured, not forced to 0 */
     bool tx_key_down;    /**< Last key state put on the wire */
 
@@ -356,3 +361,35 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
  * @return true if the end-of-over byte was sent by this call
  */
 bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms);
+
+/**
+ * @brief Close the over on the wire now, timing unknown
+ *
+ * For when the caller has lost track of time (a stream overrun) or of the
+ * wire (a send failed): sends a key-up with wait 0 if the key is down on the
+ * wire, then the second key-up that marks the end of the over, and forgets
+ * the stopwatch. The next transition opens a new over with wait 0. Silence
+ * beats corrupted timing.
+ *
+ * @param client Client context
+ * @return true if the wire is clean now (or there was no session to clean);
+ *         false if a send failed and the key is still down or the over still
+ *         open on the wire: call again
+ */
+bool cwnet_client_abort_over(cwnet_client_t *client);
+
+/**
+ * @brief Key state last put on the wire
+ *
+ * @param client Client context
+ * @return true if the server has been told the key is down
+ */
+bool cwnet_client_key_on_wire(const cwnet_client_t *client);
+
+/**
+ * @brief Whether an over is open on the wire
+ *
+ * @param client Client context
+ * @return true between the first transition of an over and its end
+ */
+bool cwnet_client_over_open(const cwnet_client_t *client);

--- a/components/keyer_cwnet/include/cwnet_feed.h
+++ b/components/keyer_cwnet/include/cwnet_feed.h
@@ -1,0 +1,90 @@
+/**
+ * @file cwnet_feed.h
+ * @brief Feeds the CWNet client from the keying stream
+ *
+ * A best-effort consumer on the keying stream that turns local_key edges
+ * into cwnet_client_send_key_event() calls stamped with *stream time*: the
+ * tick the edge happened on Core 0, reconstructed by counting one tick per
+ * sample and the tick count of every silence marker. The 7-bit waits on the
+ * wire are then tick distances, whatever the background loop's jitter and
+ * however many samples one drain finds waiting.
+ *
+ * The stream carries no entry while nothing changes, so stream time stands
+ * still on an idle key. The end of an over is judged on stream time aged by
+ * the caller's clock since the last tick consumed. With the clock sampled
+ * right before the call, the entries consumed were produced before it, so
+ * the aged value never runs ahead of stream time and the end of the over
+ * fires at most one drain period late, inside the 16 ms bucket the
+ * reference itself encodes it in.
+ *
+ * When the ticks are no longer trustworthy (a stream overrun) or the wire
+ * may disagree with the client (a send failed), corrupted timing is worse
+ * than silence (ARCHITECTURE.md 8.1): the over on the wire is closed at
+ * once and the next edge opens a fresh one with wait 0.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stream.h"
+#include "consumer.h"
+#include "cwnet_client.h"
+
+/** Edges sent in one pass at most; the rest of a backlog waits for the next */
+#define CWNET_FEED_MAX_EDGES_PER_PASS 64
+
+typedef struct {
+    best_effort_consumer_t consumer;
+    uint32_t stream_ms;     /**< Ticks consumed: stream time of the last entry seen */
+    int64_t aged_at_us;     /**< Caller clock when stream_ms last advanced */
+    size_t dropped_seen;    /**< consumer.dropped at the last check */
+    uint8_t key;            /**< local_key of the last sample seen */
+    bool wire_stuck;        /**< The over on the wire could not be closed yet */
+} cwnet_feed_t;
+
+/** What one cwnet_feed_process() call put on the wire, for logging */
+typedef struct {
+    uint16_t edges;         /**< Key transitions sent */
+    bool end_of_over;       /**< The quiet-over second key-up was sent */
+    bool aborted;           /**< The over on the wire was closed by force */
+    bool stuck;             /**< It had to be and could not: retried next pass */
+} cwnet_feed_result_t;
+
+/**
+ * @brief Start consuming at the stream's current position
+ *
+ * @param feed Feed context
+ * @param stream Keying stream (producer: rt_task on Core 0)
+ * @param now_us Caller clock, same one later passed to process()
+ */
+void cwnet_feed_init(cwnet_feed_t *feed, const keying_stream_t *stream, int64_t now_us);
+
+/**
+ * @brief Drain the stream into the client, then close a quiet over
+ *
+ * Call periodically from the background loop, in every socket state: the
+ * stream is drained whether or not the client can send, so a client that
+ * becomes READY does not replay stale edges. When it cannot send, edges are
+ * consumed and dropped.
+ *
+ * @param feed Feed context
+ * @param client CWNet client
+ * @param now_us Caller clock (esp_timer on target), sampled immediately
+ *               before this call; used only to age stream time while the
+ *               stream is idle
+ * @param dot_ms Local dot time; the end of an over is 14 dot-times of key-up.
+ *               0 or less disables the end-of-over check.
+ * @return What was sent
+ */
+cwnet_feed_result_t cwnet_feed_process(cwnet_feed_t *feed,
+                                       cwnet_client_t *client,
+                                       int64_t now_us,
+                                       int32_t dot_ms);
+
+/**
+ * @brief Stream time of the last entry consumed, in ticks (ms)
+ */
+static inline uint32_t cwnet_feed_stream_ms(const cwnet_feed_t *feed) {
+    return feed->stream_ms;
+}

--- a/components/keyer_cwnet/include/cwnet_socket.h
+++ b/components/keyer_cwnet/include/cwnet_socket.h
@@ -8,13 +8,16 @@
  * Usage:
  *   1. cwnet_socket_init() - once at startup
  *   2. cwnet_socket_process() - call periodically from bg_task (100Hz)
- *   3. cwnet_socket_send_key_event() - send CW events
+ *
+ * Keying is not pushed in: this layer consumes the keying stream itself
+ * (cwnet_feed) and stamps each edge with the tick it happened on.
  */
 
 #pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "stream.h"
 #include "cwnet_client.h"
 
 /**
@@ -35,8 +38,10 @@ typedef enum {
  *
  * Reads configuration from NVS (remote family).
  * Does nothing if remote.enabled is false.
+ *
+ * @param keying_stream The stream this layer keys from (rt_task's output)
  */
-void cwnet_socket_init(void);
+void cwnet_socket_init(const keying_stream_t *keying_stream);
 
 /**
  * @brief Process CWNet socket
@@ -45,17 +50,6 @@ void cwnet_socket_init(void);
  * Handles connection, reconnection, sending/receiving.
  */
 void cwnet_socket_process(void);
-
-/**
- * @brief Send a key transition as a MORSE frame
- *
- * Stamps the transition with the current time; the end of a quiet over is
- * sent by cwnet_socket_process().
- *
- * @param key_down true for key down, false for key up
- * @return true if sent successfully
- */
-bool cwnet_socket_send_key_event(bool key_down);
 
 /**
  * @brief Get current socket state

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -490,7 +490,7 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
     /* Wait since the previous transition. At the start of an over there is
      * no previous transition: the wait is 0 and the stopwatch starts here. */
     bool opening = !client->tx_filling;
-    int32_t wait_ms = opening ? 0 : at_ms - client->tx_ref_ms;
+    int32_t wait_ms = opening ? 0 : (int32_t)((uint32_t)at_ms - client->tx_ref_ms);
 
     int32_t encoded_ms = 0;
     cwnet_client_err_t err = send_morse(client, key_down, wait_ms, &encoded_ms);
@@ -504,12 +504,58 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
      * this state on reconnect; we do, in on_connected(), so a session cannot
      * open with a stale wait. */
     if (opening) {
-        client->tx_ref_ms = at_ms;
+        client->tx_ref_ms = (uint32_t)at_ms;
         client->tx_filling = true;
     }
-    client->tx_ref_ms += encoded_ms;
+    if (wait_ms > CWNET_MORSE_MAX_EVENTS * CWSTREAM_MAX_WAIT_MS) {
+        /* One frame could not carry the whole wait: that wait is short on
+         * the wire. Re-base on this edge so the next one is not late by
+         * the part that was lost. */
+        client->tx_ref_ms = (uint32_t)at_ms;
+    } else {
+        client->tx_ref_ms += (uint32_t)encoded_ms;
+    }
     client->tx_key_down = key_down;
     return CWNET_CLIENT_OK;
+}
+
+bool cwnet_client_abort_over(cwnet_client_t *client) {
+    if (client == NULL) {
+        return false;
+    }
+
+    if (client->state == CWNET_STATE_READY) {
+        int32_t encoded_ms = 0;
+        if (client->tx_key_down) {
+            /* Key up, now. If it does not go out the key is still down on
+             * the wire: say so, the caller comes back. */
+            if (send_morse(client, false, 0, &encoded_ms) != CWNET_CLIENT_OK) {
+                return false;
+            }
+            client->tx_key_down = false;
+        }
+        if (client->tx_filling) {
+            /* Second key-up: the end of the over */
+            if (send_morse(client, false, 0, &encoded_ms) != CWNET_CLIENT_OK) {
+                return false;
+            }
+            client->tx_filling = false;
+        }
+    }
+    /* Not READY: there is no session, so nothing is on the wire */
+
+    client->tx_ref_ms = 0;
+    client->tx_filling = false;
+    client->tx_key_down = false;
+    return true;
+}
+
+bool cwnet_client_key_on_wire(const cwnet_client_t *client) {
+    return client != NULL && client->tx_key_down;
+}
+
+bool cwnet_client_over_open(const cwnet_client_t *client) {
+    return client != NULL && client->tx_filling;
 }
 
 bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms) {
@@ -522,7 +568,7 @@ bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms) {
 
     /* KeyerThread.c: t_us > 14000 * iDotTime_ms. Which 16 ms bucket the
      * elapsed time falls in depends on the poll instant there too. */
-    int32_t elapsed_ms = now_ms - client->tx_ref_ms;
+    int32_t elapsed_ms = (int32_t)((uint32_t)now_ms - client->tx_ref_ms);
     if (elapsed_ms <= 14 * dot_ms) {
         return false;
     }
@@ -532,7 +578,7 @@ bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms) {
         return false;
     }
 
-    client->tx_ref_ms += encoded_ms;
+    client->tx_ref_ms += (uint32_t)encoded_ms;
     client->tx_filling = false;  /* the next transition opens a new over with wait 0 */
     return true;
 }

--- a/components/keyer_cwnet/src/cwnet_feed.c
+++ b/components/keyer_cwnet/src/cwnet_feed.c
@@ -1,0 +1,136 @@
+/**
+ * @file cwnet_feed.c
+ * @brief Feeds the CWNet client from the keying stream
+ */
+
+#include "cwnet_feed.h"
+#include <string.h>
+
+void cwnet_feed_init(cwnet_feed_t *feed, const keying_stream_t *stream, int64_t now_us) {
+    if (feed == NULL) {
+        return;
+    }
+    memset(feed, 0, sizeof(*feed));
+    if (stream == NULL) {
+        return;  /* consumer.stream stays NULL: process() does nothing */
+    }
+    /* skip_threshold 0: skip only on a real overrun, never on mere lag */
+    best_effort_consumer_init(&feed->consumer, stream, 0);
+    feed->aged_at_us = now_us;
+}
+
+/**
+ * @brief Close whatever is on the wire, now
+ *
+ * If the client cannot (send failed) the wire stays marked stuck and every
+ * later pass retries before anything else goes out.
+ */
+static void close_wire(cwnet_feed_t *feed, cwnet_client_t *client, cwnet_feed_result_t *result) {
+    bool open = cwnet_client_key_on_wire(client) || cwnet_client_over_open(client);
+    if (cwnet_client_abort_over(client)) {
+        feed->wire_stuck = false;
+        if (open) {
+            result->aborted = true;
+        }
+    } else {
+        feed->wire_stuck = true;
+        result->stuck = true;
+    }
+}
+
+/**
+ * @brief React to the consumer having skipped entries
+ *
+ * The ticks in between are lost: the wait of anything sent from here would
+ * be wrong, so the over is closed on the wire. The wire is key-up after
+ * that; if the key is still down, the next sample that carries state opens
+ * a new over with wait 0.
+ */
+static void note_skip(cwnet_feed_t *feed, cwnet_client_t *client, cwnet_feed_result_t *result) {
+    if (feed->consumer.dropped != feed->dropped_seen) {
+        feed->dropped_seen = feed->consumer.dropped;
+        close_wire(feed, client, result);
+        feed->key = 0;
+    }
+}
+
+static void send_edge(cwnet_feed_t *feed, cwnet_client_t *client, uint8_t key,
+                      cwnet_feed_result_t *result) {
+    /* The client answers OK also when the wire already shows this state (a
+     * key-up at the start of a session): count only what changed. */
+    bool before = cwnet_client_key_on_wire(client);
+    cwnet_client_err_t err = cwnet_client_send_key_event(client, key != 0,
+                                                         (int32_t)feed->stream_ms);
+    if (err == CWNET_CLIENT_OK) {
+        if (cwnet_client_key_on_wire(client) != before) {
+            result->edges++;
+        }
+    } else if (err == CWNET_CLIENT_ERR_SEND_FAILED) {
+        /* The wire may hold a key-down that will never get its key-up:
+         * close the over rather than key on from a state the server does
+         * not share. */
+        close_wire(feed, client, result);
+    }
+    /* NOT_READY / NOT_PERMITTED: no session to key; the edge is consumed,
+     * not queued, so nothing stale is replayed later. */
+}
+
+cwnet_feed_result_t cwnet_feed_process(cwnet_feed_t *feed,
+                                       cwnet_client_t *client,
+                                       int64_t now_us,
+                                       int32_t dot_ms) {
+    cwnet_feed_result_t result = {0};
+    if (feed == NULL || client == NULL || feed->consumer.stream == NULL) {
+        return result;
+    }
+
+    /* A previous pass could not close the over on the wire: nothing else
+     * goes out before it is closed. */
+    if (feed->wire_stuck) {
+        close_wire(feed, client, &result);
+    }
+
+    stream_sample_t sample;
+    bool advanced = false;
+
+    /* Bounded per pass: after a stall, the backlog goes out over several
+     * passes rather than as one burst that fills the socket. Stream time is
+     * exact either way. */
+    while (result.edges < CWNET_FEED_MAX_EDGES_PER_PASS &&
+           best_effort_consumer_tick(&feed->consumer, &sample)) {
+        note_skip(feed, client, &result);
+
+        if (sample_is_silence(&sample)) {
+            feed->stream_ms += sample_silence_ticks(&sample);
+        } else {
+            feed->stream_ms += 1;
+            if (sample.local_key != feed->key) {
+                feed->key = sample.local_key;
+                if (!feed->wire_stuck) {
+                    send_edge(feed, client, sample.local_key, &result);
+                }
+            }
+        }
+        advanced = true;
+    }
+    /* The consumer also skips, without returning an entry, when the slot it
+     * was about to read has been overwritten. */
+    note_skip(feed, client, &result);
+
+    if (advanced) {
+        feed->aged_at_us = now_us;
+    }
+
+    if (dot_ms > 0 && !feed->wire_stuck) {
+        /* Stream time stands still on an idle key; age it by the caller's
+         * clock since the last tick consumed. */
+        int64_t idle_us = now_us - feed->aged_at_us;
+        uint32_t idle_ms = idle_us > 0 ? (uint32_t)(idle_us / 1000) : 0u;
+        int32_t now_ms = (int32_t)(feed->stream_ms + idle_ms);
+        if (cwnet_client_poll(client, now_ms, dot_ms)) {
+            result.end_of_over = true;
+        }
+    }
+
+    return result;
+}

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -4,6 +4,7 @@
  */
 
 #include "cwnet_socket.h"
+#include "cwnet_feed.h"
 #include "config.h"
 #include "rt_log.h"
 
@@ -38,6 +39,7 @@ extern keyer_config_t g_config;
 static struct {
     cwnet_socket_state_t state;
     cwnet_client_t client;
+    cwnet_feed_t feed;
     int sock;
     int64_t last_attempt_us;
     int64_t connect_start_us;
@@ -45,6 +47,7 @@ static struct {
     uint16_t port;
     char username[CWNET_MAX_USERNAME_LEN];
     bool enabled;
+    bool send_failed;   /**< A send() in this pass did not go out whole */
 } s_ctx;
 
 /*===========================================================================*/
@@ -57,6 +60,13 @@ static int socket_send_cb(const uint8_t *data, size_t len, void *user_data) {
         return -1;
     }
     ssize_t sent = send(s_ctx.sock, data, len, 0);
+    if (sent != (ssize_t)len) {
+        /* Non-blocking socket, buffer full or worse. A frame that did not go
+         * out whole leaves the server a truncated frame or a key state we
+         * will never correct: the session is over. Handled after the pass,
+         * not here, so the client is not re-entered from its own send. */
+        s_ctx.send_failed = true;
+    }
     return (int)sent;
 }
 
@@ -240,7 +250,7 @@ static void process_recv(void) {
 /* Public API                                                                */
 /*===========================================================================*/
 
-void cwnet_socket_init(void) {
+void cwnet_socket_init(const keying_stream_t *keying_stream) {
     memset(&s_ctx, 0, sizeof(s_ctx));
     s_ctx.sock = -1;
     s_ctx.state = CWNET_SOCK_DISABLED;
@@ -286,6 +296,8 @@ void cwnet_socket_init(void) {
     }
 
     int64_t now_us = esp_timer_get_time();
+    cwnet_feed_init(&s_ctx.feed, keying_stream, now_us);
+
     RT_INFO(&g_bg_log_stream, now_us, "CWNet: initialized, server=%s:%u user=%s",
             s_ctx.host, s_ctx.port, s_ctx.username);
 
@@ -327,18 +339,6 @@ void cwnet_socket_process(void) {
             if (cwnet_client_get_state(&s_ctx.client) == CWNET_STATE_READY) {
                 s_ctx.state = CWNET_SOCK_READY;
             }
-
-            /* Close a quiet over: the reference sends a second key-up after
-             * 14 dot-times of silence, and that is how the server learns the
-             * over ended. Same clock as the key events below. */
-            {
-                uint32_t wpm = (uint32_t)CONFIG_GET_WPM();
-                int32_t dot_ms = wpm > 0 ? (int32_t)(1200u / wpm) : 0;
-                if (dot_ms > 0 &&
-                    cwnet_client_poll(&s_ctx.client, get_time_ms_cb(NULL), dot_ms)) {
-                    RT_DEBUG(&g_bg_log_stream, now_us, "CWNet TX: end of over");
-                }
-            }
             break;
 
         case CWNET_SOCK_ERROR:
@@ -349,24 +349,42 @@ void cwnet_socket_process(void) {
             }
             break;
     }
-}
 
-bool cwnet_socket_send_key_event(bool key_down) {
-    if (s_ctx.state != CWNET_SOCK_READY) {
-        return false;
+    /* Keying: drained from the stream in every state, sent when READY, with
+     * the end of a quiet over after 14 dot-times (the reference's rule).
+     * The clock is sampled here, not at the top of the pass: the feed ages
+     * stream time by it, and a stale value would run ahead of the stream. */
+    {
+        uint32_t wpm = (uint32_t)CONFIG_GET_WPM();
+        int32_t dot_ms = wpm > 0 ? (int32_t)(1200u / wpm) : 0;
+        int64_t feed_now_us = esp_timer_get_time();
+        cwnet_feed_result_t r = cwnet_feed_process(&s_ctx.feed, &s_ctx.client, feed_now_us, dot_ms);
+        if (r.aborted) {
+            RT_WARN(&g_bg_log_stream, feed_now_us, "CWNet TX: over closed by force");
+        }
+        if (r.stuck) {
+            RT_ERROR(&g_bg_log_stream, feed_now_us, "CWNet TX: could not close the over on the wire");
+        }
+        if (r.edges > 0) {
+            RT_DEBUG(&g_bg_log_stream, feed_now_us, "CWNet TX: %u edge(s)", (unsigned)r.edges);
+        }
+        if (r.end_of_over) {
+            RT_DEBUG(&g_bg_log_stream, feed_now_us, "CWNet TX: end of over");
+        }
     }
 
-    /* Stamped when the caller got to the event, not when the edge happened
-     * on Core 0: the 7-bit wait inherits the bg loop's jitter. Feeding the
-     * client from a stream consumer with stream time is separate work. */
-    cwnet_client_err_t err = cwnet_client_send_key_event(&s_ctx.client, key_down,
-                                                         get_time_ms_cb(NULL));
-    if (err == CWNET_CLIENT_OK) {
-        int64_t now_us = esp_timer_get_time();
-        RT_DEBUG(&g_bg_log_stream, now_us, "CWNet TX: %s", key_down ? "DOWN" : "UP");
-        return true;
+    /* A send that did not go out whole: the session is over, silence beats
+     * a wire the server and we read differently. Reconnect after the delay. */
+    if (s_ctx.send_failed) {
+        s_ctx.send_failed = false;
+        if (s_ctx.sock >= 0) {
+            int64_t fail_us = esp_timer_get_time();
+            RT_ERROR(&g_bg_log_stream, fail_us, "CWNet: send failed, dropping the session");
+            close_socket();
+            s_ctx.state = CWNET_SOCK_ERROR;
+            s_ctx.last_attempt_us = fail_us;
+        }
     }
-    return false;
 }
 
 cwnet_socket_state_t cwnet_socket_get_state(void) {

--- a/main/bg_task.c
+++ b/main/bg_task.c
@@ -79,7 +79,7 @@ void bg_task(void *arg) {
     s_timeline_initialized = true;
 
     /* Initialize CWNet client (reads config, connects if enabled) */
-    cwnet_socket_init();
+    cwnet_socket_init(&g_keying_stream);
 
     /* Log startup */
     int64_t now_us = esp_timer_get_time();
@@ -217,9 +217,6 @@ void bg_task(void *arg) {
                         (long long)(now_us / 1000),
                         sample.local_key ? 1 : 0);
                     webui_timeline_push("keying", json);
-
-                    /* Forward key event to CWNet */
-                    cwnet_socket_send_key_event(sample.local_key != 0);
                 }
 
                 /* Update previous state */

--- a/test_host/CMakeLists.txt
+++ b/test_host/CMakeLists.txt
@@ -90,6 +90,7 @@ set(CWNET_SOURCES
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_frame.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_ping.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_client.c
+    ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_feed.c
 )
 
 # Test sources
@@ -110,6 +111,7 @@ set(TEST_SOURCES
     test_cwnet_frame_parser.c
     test_cwnet_ping.c
     test_cwnet_client.c
+    test_cwnet_feed.c
     stubs/esp_stubs.c
 )
 

--- a/test_host/cwnet_fixtures.h
+++ b/test_host/cwnet_fixtures.h
@@ -1,0 +1,81 @@
+/**
+ * @file cwnet_fixtures.h
+ * @brief Bytes from the 2026-09-05 capture of the official DL4YHF client and
+ *        server, shared by the CWNet host suites
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include "cwnet_frame.h"
+#include "cwnet_client.h"
+
+/*
+ * The reference protocol has no WELCOME: 0x00 is CWNET_CMD_NONE, "dummy command
+ * to send HTTP instead of our binary protocol" (CwNet.h). A real server confirms
+ * a connection by echoing the 92-byte CONNECT record back with the permissions
+ * field filled in, then sending a PRINT with the greeting.
+ *
+ * These are the first 94 bytes of the server-to-client direction of session 10
+ * of the 2026-09-05 capture of the official DL4YHF client and server: the
+ * CONNECT echo, user "Moritz", permissions 0x07 where the client had sent 0.
+ */
+static const uint8_t ref_connect_echo[] = {
+    0x41, 0x5C, 0x4D, 0x6F, 0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x6F,
+    0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+};
+
+
+/*
+ * Client-to-server bytes 238..278 of session 12 of the 2026-09-05 capture of
+ * the official DL4YHF client: its first over, the letter A at 25 WPM (dot
+ * 48 ms) and then silence. Five MORSE frames, with the two rigctld set_ptt
+ * frames the reference interleaves around an over (PTT is #13; we do not
+ * send it, so the comparison is on the MORSE frames alone).
+ */
+static const uint8_t ref_first_over[] = {
+    0x50, 0x01, 0x80,                                     /* key down, wait 0      */
+    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
+    0x20, 0x31, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 1"   */
+    0x50, 0x01, 0x24,                                     /* key up   after  48 ms */
+    0x50, 0x01, 0xA4,                                     /* key down after  48 ms */
+    0x50, 0x01, 0x3C,                                     /* key up   after 144 ms */
+    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
+    0x20, 0x30, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 0"   */
+    0x50, 0x01, 0x60,                                     /* end of over, 669 ms   */
+};
+
+/**
+ * @brief Copy the raw bytes of every MORSE frame of a capture slice, in order
+ *
+ * @return false on a parse error
+ */
+static inline bool ref_morse_frames(const uint8_t *in, size_t in_len,
+                                    uint8_t *out, size_t *out_len) {
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+    size_t off = 0;
+    size_t n = 0;
+    while (off < in_len) {
+        cwnet_parse_result_t r = cwnet_frame_parse(&parser, in + off, in_len - off);
+        if (r.status != CWNET_PARSE_OK) {
+            return false;
+        }
+        if (r.command == CWNET_CMD_MORSE) {
+            memcpy(out + n, in + off, r.bytes_consumed);
+            n += r.bytes_consumed;
+        }
+        off += r.bytes_consumed;
+    }
+    *out_len = n;
+    return true;
+}

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -7,6 +7,7 @@
  */
 
 #include "unity.h"
+#include "cwnet_fixtures.h"
 #include "cwnet_client.h"
 #include "cwnet_frame.h"
 #include "cwnet_ping.h"
@@ -48,27 +49,6 @@ static void test_setup(void) {
     mock_connected = false;
     mock_time_ms = 1000;
 }
-
-/*
- * The reference protocol has no WELCOME: 0x00 is CWNET_CMD_NONE, "dummy command
- * to send HTTP instead of our binary protocol" (CwNet.h). A real server confirms
- * a connection by echoing the 92-byte CONNECT record back with the permissions
- * field filled in, then sending a PRINT with the greeting.
- *
- * These are the first 94 bytes of the server-to-client direction of session 10
- * of the 2026-09-05 capture of the official DL4YHF client and server: the
- * CONNECT echo, user "Moritz", permissions 0x07 where the client had sent 0.
- */
-static const uint8_t ref_connect_echo[] = {
-    0x41, 0x5C, 0x4D, 0x6F, 0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x6F,
-    0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
-};
 
 /* Drive the client to READY the way a real server does. */
 static void feed_connect_echo(void) {
@@ -492,25 +472,6 @@ void test_client_tx_wait_is_measured_from_previous_transition(void) {
     TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
 }
 
-/*
- * Client-to-server bytes 238..278 of session 12 of the 2026-09-05 capture of
- * the official DL4YHF client: its first over, the letter A at 25 WPM (dot
- * 48 ms) and then silence. Five MORSE frames, with the two rigctld set_ptt
- * frames the reference interleaves around an over (PTT is #13; we do not
- * send it, so the comparison is on the MORSE frames alone).
- */
-static const uint8_t ref_first_over[] = {
-    0x50, 0x01, 0x80,                                     /* key down, wait 0      */
-    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
-    0x20, 0x31, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 1"   */
-    0x50, 0x01, 0x24,                                     /* key up   after  48 ms */
-    0x50, 0x01, 0xA4,                                     /* key down after  48 ms */
-    0x50, 0x01, 0x3C,                                     /* key up   after 144 ms */
-    0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74,
-    0x20, 0x30, 0x0A, 0x00,                               /* RIGCTLD "set_ptt 0"   */
-    0x50, 0x01, 0x60,                                     /* end of over, 669 ms   */
-};
-
 void test_client_tx_first_over_matches_reference_capture(void) {
     ready_client_accumulating();
 
@@ -526,19 +487,8 @@ void test_client_tx_first_over_matches_reference_capture(void) {
     /* Expected: the raw bytes of every MORSE frame in the capture, in order */
     uint8_t expected[sizeof(ref_first_over)];
     size_t expected_len = 0;
-    cwnet_frame_parser_t parser;
-    cwnet_frame_parser_init(&parser);
-    size_t off = 0;
-    while (off < sizeof(ref_first_over)) {
-        cwnet_parse_result_t r = cwnet_frame_parse(&parser, ref_first_over + off,
-                                                   sizeof(ref_first_over) - off);
-        TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r.status);
-        if (r.command == CWNET_CMD_MORSE) {
-            memcpy(expected + expected_len, ref_first_over + off, r.bytes_consumed);
-            expected_len += r.bytes_consumed;
-        }
-        off += r.bytes_consumed;
-    }
+    TEST_ASSERT_TRUE(ref_morse_frames(ref_first_over, sizeof(ref_first_over),
+                                      expected, &expected_len));
     TEST_ASSERT_EQUAL(15, expected_len);  /* five frames of three bytes */
 
     TEST_ASSERT_EQUAL(expected_len, mock_tx_all_len);
@@ -635,6 +585,28 @@ void test_client_tx_end_of_over_splits_at_slow_speed(void) {
     };
     TEST_ASSERT_EQUAL(sizeof(expected), mock_tx_all_len);
     TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, sizeof(expected));
+}
+
+void test_client_tx_wait_beyond_one_frame_rebases_on_the_edge(void) {
+    ready_client_accumulating();
+
+    /* 200 s of key-down: more than 128 bytes of 1165 ms can carry. The wire
+     * gets the 128, and the next wait is measured from this edge, so the
+     * element that follows is not late by the 50 s that were lost. */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 200000));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  200100));
+
+    uint8_t expected[3 + 2 + 128 + 3];
+    size_t n = 0;
+    expected[n++] = 0x50; expected[n++] = 0x01; expected[n++] = 0x80;
+    expected[n++] = 0x50; expected[n++] = 128;
+    for (int i = 0; i < 128; i++) {
+        expected[n++] = 0x7F;
+    }
+    expected[n++] = 0x50; expected[n++] = 0x01; expected[n++] = 0xB1;  /* 100 ms */
+    TEST_ASSERT_EQUAL(n, mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, n);
 }
 
 void test_client_tx_ignores_repeated_key_state(void) {
@@ -817,6 +789,7 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_tx_end_of_over_after_14_dot_times);
     RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
     RUN_TEST(test_client_tx_ignores_repeated_key_state);
+    RUN_TEST(test_client_tx_wait_beyond_one_frame_rebases_on_the_edge);
     RUN_TEST(test_client_rejects_events_when_not_ready);
 
     /* Error Handling */

--- a/test_host/test_cwnet_feed.c
+++ b/test_host/test_cwnet_feed.c
@@ -1,0 +1,426 @@
+/**
+ * @file test_cwnet_feed.c
+ * @brief The CWNet feed: from the keying stream to MORSE frames, on stream time
+ *
+ * Driven only through the stream, the way rt_task drives it: one sample per
+ * 1 ms tick, unchanged samples compressed into silence markers.
+ */
+
+#include "unity.h"
+#include "cwnet_fixtures.h"
+#include "cwnet_feed.h"
+#include "stream.h"
+#include "sample.h"
+#include "consumer.h"
+#include <string.h>
+
+#define FEED_STREAM_CAPACITY 256
+static stream_sample_t s_buf[FEED_STREAM_CAPACITY];
+static keying_stream_t s_stream;
+static cwnet_client_t s_client;
+static cwnet_feed_t s_feed;
+
+/* Everything the client sends, in order */
+static uint8_t s_tx[512];
+static size_t s_tx_len;
+static int s_fail_sends;   /* the next N sends fail, like a full socket */
+
+static int send_accumulate(const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    if (s_fail_sends > 0) {
+        s_fail_sends--;
+        return -1;
+    }
+    if (s_tx_len + len > sizeof(s_tx)) {
+        return -1;
+    }
+    memcpy(s_tx + s_tx_len, data, len);
+    s_tx_len += len;
+    return (int)len;
+}
+
+/* PING only; keying never reads this clock */
+static int32_t time_cb(void *user_data) {
+    (void)user_data;
+    return 0;
+}
+
+static void setup_stream(void) {
+    stream_init(&s_stream, s_buf, FEED_STREAM_CAPACITY);
+}
+
+static void make_ready(void) {
+    cwnet_client_on_connected(&s_client);
+    cwnet_client_on_data(&s_client, ref_connect_echo, sizeof(ref_connect_echo));
+    TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&s_client));
+    s_tx_len = 0;  /* drop the CONNECT */
+}
+
+/* A client on the accumulating sink; READY with TRANSMIT granted if asked */
+static void setup_client(bool ready) {
+    cwnet_client_config_t cfg = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "TEST",
+        .send_cb = send_accumulate,
+        .get_time_ms_cb = time_cb,
+        .user_data = NULL
+    };
+    memset(&s_client, 0, sizeof(s_client));
+    s_tx_len = 0;
+    s_fail_sends = 0;
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_init(&s_client, &cfg));
+    if (ready) {
+        make_ready();
+    }
+}
+
+/* rt_task pushes one sample per tick; the stream compresses the unchanged ones */
+static void key_for_ticks(uint8_t key, uint32_t ticks) {
+    stream_sample_t s = STREAM_SAMPLE_EMPTY;
+    s.local_key = key;
+    for (uint32_t i = 0; i < ticks; i++) {
+        TEST_ASSERT_TRUE(stream_push(&s_stream, s));
+    }
+}
+
+/* The letter A at 25 WPM (dot 48 ms), then the key-up edge */
+static void key_letter_a(void) {
+    key_for_ticks(1, 48);
+    key_for_ticks(0, 48);
+    key_for_ticks(1, 144);
+    key_for_ticks(0, 1);
+}
+
+static const uint8_t frames_letter_a[] = {
+    0x50, 0x01, 0x80,   /* down, wait 0 */
+    0x50, 0x01, 0x24,   /* up after 48 */
+    0x50, 0x01, 0xA4,   /* down after 48 */
+    0x50, 0x01, 0x3C,   /* up after 144 */
+};
+
+void test_feed_waits_are_tick_distances_whatever_the_drain(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(0, 500);  /* idle before the over: no entry until something changes */
+    key_letter_a();
+
+    /* One drain for the whole over. Stamped at drain time, every wait here
+     * would be 0; on stream time they are the tick distances. */
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(4, r.edges);
+    TEST_ASSERT_FALSE(r.end_of_over);
+    TEST_ASSERT_FALSE(r.aborted);
+
+    TEST_ASSERT_EQUAL(sizeof(frames_letter_a), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(frames_letter_a, s_tx, sizeof(frames_letter_a));
+    TEST_ASSERT_EQUAL_UINT32(500 + 48 + 48 + 144 + 1, cwnet_feed_stream_ms(&s_feed));
+}
+
+void test_feed_first_over_from_stream_matches_reference_capture(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(0, 100);
+    key_letter_a();
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(4, r.edges);
+
+    /* Nothing else happens on the key: 673 ms later on the caller's clock
+     * the over is closed, on stream time aged by that clock. */
+    r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 673000, 48);
+    TEST_ASSERT_TRUE(r.end_of_over);
+
+    uint8_t expected[sizeof(ref_first_over)];
+    size_t expected_len = 0;
+    TEST_ASSERT_TRUE(ref_morse_frames(ref_first_over, sizeof(ref_first_over),
+                                      expected, &expected_len));
+    TEST_ASSERT_EQUAL(expected_len, s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, expected_len);
+}
+
+void test_feed_idle_stream_ages_on_the_caller_clock(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(1, 48);
+    key_for_ticks(0, 1);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(2, r.edges);
+    TEST_ASSERT_EQUAL_UINT32(49, cwnet_feed_stream_ms(&s_feed));
+
+    /* rt_task keeps pushing the unchanged sample every tick, and the stream
+     * writes no entry for it: the caller's clock ages stream time */
+    key_for_ticks(0, 672);
+    r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 672000, 48);
+    TEST_ASSERT_FALSE(r.end_of_over);
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 673000, 48);
+    TEST_ASSERT_TRUE(r.end_of_over);
+    r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 5000000, 48);
+    TEST_ASSERT_FALSE(r.end_of_over);
+    /* Ageing is not stream time: nothing was consumed */
+    TEST_ASSERT_EQUAL_UINT32(49, cwnet_feed_stream_ms(&s_feed));
+
+    /* The next edge opens a new over with wait 0 */
+    key_for_ticks(1, 10);
+    r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 6000000, 48);
+    TEST_ASSERT_EQUAL(1, r.edges);
+
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x24,
+        0x50, 0x01, 0x60,
+        0x50, 0x01, 0x80,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+}
+
+void test_feed_drains_while_client_not_ready_and_does_not_replay(void) {
+    setup_stream();
+    setup_client(false);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    /* Keying while disconnected is consumed and dropped, not queued */
+    key_letter_a();
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(0, r.edges);
+    TEST_ASSERT_EQUAL(0, s_tx_len);
+    TEST_ASSERT_EQUAL_UINT32(48 + 48 + 144 + 1, cwnet_feed_stream_ms(&s_feed));
+
+    /* Key down when the session comes up: its key-up is not a transition on
+     * the wire and sends nothing; the next key-down opens the first over. */
+    key_for_ticks(1, 20);
+    r = cwnet_feed_process(&s_feed, &s_client, 1100000, 48);
+    TEST_ASSERT_EQUAL(0, r.edges);
+    make_ready();
+    key_for_ticks(0, 100);
+    r = cwnet_feed_process(&s_feed, &s_client, 1200000, 48);
+    TEST_ASSERT_EQUAL(0, r.edges);
+    TEST_ASSERT_EQUAL(0, s_tx_len);
+
+    key_for_ticks(1, 30);
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1300000, 48);
+    TEST_ASSERT_EQUAL(2, r.edges);
+
+    static const uint8_t expected[] = {0x50, 0x01, 0x80, 0x50, 0x01, 0x1E};
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+}
+
+void test_feed_overrun_closes_the_over_on_the_wire(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(0, 10);
+    key_for_ticks(1, 20);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(1, r.edges);
+    TEST_ASSERT_EQUAL(3, s_tx_len);  /* 0x80: key down on the wire */
+    s_tx_len = 0;
+
+    /* The background loop stalls while the stream keeps writing: more
+     * entries than the buffer holds, key still down. An entry per tick is
+     * forced through audio_level, which the producer does not write today;
+     * on the box the same overrun takes a buffer's worth of transitions. */
+    for (uint32_t i = 0; i < FEED_STREAM_CAPACITY + 50; i++) {
+        stream_sample_t s = STREAM_SAMPLE_EMPTY;
+        s.local_key = 1;
+        s.audio_level = (i & 1u) ? 100 : 0;
+        TEST_ASSERT_TRUE(stream_push(&s_stream, s));
+    }
+
+    /* Time is lost: the over is closed now (key up, then the end-of-over
+     * mark), and since the key is still down a fresh over opens at once. */
+    r = cwnet_feed_process(&s_feed, &s_client, 2000000, 48);
+    TEST_ASSERT_TRUE(r.aborted);
+    TEST_ASSERT_GREATER_THAN(0, best_effort_consumer_dropped(&s_feed.consumer));
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x00,   /* key up, now */
+        0x50, 0x01, 0x00,   /* end of over */
+        0x50, 0x01, 0x80,   /* the key is down: new over, wait 0 */
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+
+    /* The new over is timed from its own first edge */
+    s_tx_len = 0;
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 2100000, 48);
+    TEST_ASSERT_EQUAL(1, r.edges);
+    TEST_ASSERT_FALSE(r.aborted);
+    TEST_ASSERT_EQUAL(3, s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, s_tx[2] & 0x80);  /* key up, a small wait */
+}
+
+void test_feed_no_dot_time_no_end_of_over(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(1, 48);
+    key_for_ticks(0, 1);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 0);
+    TEST_ASSERT_EQUAL(2, r.edges);
+    r = cwnet_feed_process(&s_feed, &s_client, 6000000, 0);
+    TEST_ASSERT_FALSE(r.end_of_over);
+    TEST_ASSERT_EQUAL(6, s_tx_len);
+
+    /* With a dot time the same idle closes it: 5000 ms of key-up, split as
+     * the reference splits a wait above 1165 ms, four full bytes and 340 */
+    r = cwnet_feed_process(&s_feed, &s_client, 6000000, 48);
+    TEST_ASSERT_TRUE(r.end_of_over);
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x24,
+        0x50, 0x05, 0x7F, 0x7F, 0x7F, 0x7F, 0x4B,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+}
+
+void test_feed_drain_granularity_does_not_change_the_bytes(void) {
+    /* Tick by tick: a process() after every single push */
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+    static const struct { uint8_t key; uint32_t ticks; } over[] = {
+        {0, 100}, {1, 48}, {0, 48}, {1, 144}, {0, 1},
+    };
+    int64_t tick = 0;
+    for (size_t i = 0; i < sizeof(over) / sizeof(over[0]); i++) {
+        for (uint32_t t = 0; t < over[i].ticks; t++) {
+            key_for_ticks(over[i].key, 1);
+            tick++;
+            cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, tick * 1000, 48);
+            TEST_ASSERT_FALSE(r.end_of_over);
+        }
+    }
+    uint8_t fine[64];
+    size_t fine_len = s_tx_len;
+    TEST_ASSERT_LESS_OR_EQUAL(sizeof(fine), fine_len);
+    memcpy(fine, s_tx, fine_len);
+
+    /* All at once */
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+    key_for_ticks(0, 100);
+    key_letter_a();
+    cwnet_feed_process(&s_feed, &s_client, tick * 1000, 48);
+
+    TEST_ASSERT_EQUAL(sizeof(frames_letter_a), fine_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(frames_letter_a, fine, fine_len);
+    TEST_ASSERT_EQUAL(fine_len, s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(fine, s_tx, fine_len);
+}
+
+void test_feed_send_failure_closes_the_over_and_retries(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(1, 20);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(1, r.edges);
+    TEST_ASSERT_TRUE(cwnet_client_key_on_wire(&s_client));
+    s_tx_len = 0;
+
+    /* The socket is full: the key-up does not go out, nor does the key-up
+     * of the first attempt to close the over. The wire still says down. */
+    s_fail_sends = 2;
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1020000, 48);
+    TEST_ASSERT_EQUAL(0, r.edges);
+    TEST_ASSERT_TRUE(r.stuck);
+    TEST_ASSERT_FALSE(r.aborted);
+    TEST_ASSERT_EQUAL(0, s_tx_len);
+    TEST_ASSERT_TRUE(cwnet_client_key_on_wire(&s_client));
+
+    /* Next pass, socket drained: the over is closed before anything else */
+    r = cwnet_feed_process(&s_feed, &s_client, 1030000, 48);
+    TEST_ASSERT_TRUE(r.aborted);
+    TEST_ASSERT_FALSE(r.stuck);
+    TEST_ASSERT_FALSE(cwnet_client_key_on_wire(&s_client));
+    TEST_ASSERT_FALSE(cwnet_client_over_open(&s_client));
+
+    /* And keying goes on from a clean wire */
+    key_for_ticks(1, 30);
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1100000, 48);
+    TEST_ASSERT_EQUAL(2, r.edges);
+
+    static const uint8_t expected[] = {
+        0x50, 0x01, 0x00,   /* key up, now */
+        0x50, 0x01, 0x00,   /* end of over */
+        0x50, 0x01, 0x80,
+        0x50, 0x01, 0x1E,
+    };
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+}
+
+void test_feed_disconnect_mid_over_then_reconnect(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    key_for_ticks(1, 20);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(1, r.edges);
+
+    /* The server goes away with our key down on its side */
+    cwnet_client_on_disconnected(&s_client);
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1020000, 48);
+    TEST_ASSERT_EQUAL(0, r.edges);
+    TEST_ASSERT_FALSE(r.end_of_over);
+
+    /* New session: it opens with the next key-down, wait 0 */
+    make_ready();
+    key_for_ticks(0, 50);
+    key_for_ticks(1, 10);
+    key_for_ticks(0, 1);
+    r = cwnet_feed_process(&s_feed, &s_client, 1100000, 48);
+    TEST_ASSERT_EQUAL(2, r.edges);
+
+    static const uint8_t expected[] = {0x50, 0x01, 0x80, 0x50, 0x01, 0x0A};
+    TEST_ASSERT_EQUAL(sizeof(expected), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, sizeof(expected));
+}
+
+void test_feed_long_key_down_is_sent_in_full(void) {
+    setup_stream();
+    setup_client(true);
+    cwnet_feed_init(&s_feed, &s_stream, 0);
+
+    /* A 60 s key-down (tuning up): one frame of 51 full bytes and the
+     * remainder, then the next element timed from the key-up, not from
+     * where a shorter frame would have left the stopwatch. */
+    key_for_ticks(1, 60000);
+    key_for_ticks(0, 100);
+    key_for_ticks(1, 1);
+    cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
+    TEST_ASSERT_EQUAL(3, r.edges);
+
+    uint8_t expected[3 + 2 + 52 + 3];
+    size_t n = 0;
+    expected[n++] = 0x50; expected[n++] = 0x01; expected[n++] = 0x80;
+    expected[n++] = 0x50; expected[n++] = 52;
+    for (int i = 0; i < 51; i++) {
+        expected[n++] = 0x7F;                  /* 1165 ms each, key up */
+    }
+    expected[n++] = 0x5A;                      /* 60000 - 51 * 1165 = 585 ms, 573 on the wire */
+    /* The 12 ms the 16 ms bucket could not carry are owed to the next wait:
+     * 100 + 12 = 112 ms, as the reference's adjusted stopwatch does */
+    expected[n++] = 0x50; expected[n++] = 0x01; expected[n++] = 0xB4;
+    TEST_ASSERT_EQUAL(n, s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, n);
+}

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -230,11 +230,24 @@ void test_client_tx_splits_wait_above_1165_ms(void);
 void test_client_tx_end_of_over_after_14_dot_times(void);
 void test_client_tx_end_of_over_splits_at_slow_speed(void);
 void test_client_tx_ignores_repeated_key_state(void);
+void test_client_tx_wait_beyond_one_frame_rebases_on_the_edge(void);
 void test_client_rejects_events_when_not_ready(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
 void test_client_handles_fragmented_frame(void);
 void test_client_handles_ping_in_fragments(void);
+
+/* CWNet feed (stream -> client) */
+void test_feed_waits_are_tick_distances_whatever_the_drain(void);
+void test_feed_first_over_from_stream_matches_reference_capture(void);
+void test_feed_idle_stream_ages_on_the_caller_clock(void);
+void test_feed_drains_while_client_not_ready_and_does_not_replay(void);
+void test_feed_overrun_closes_the_over_on_the_wire(void);
+void test_feed_no_dot_time_no_end_of_over(void);
+void test_feed_drain_granularity_does_not_change_the_bytes(void);
+void test_feed_send_failure_closes_the_over_and_retries(void);
+void test_feed_disconnect_mid_over_then_reconnect(void);
+void test_feed_long_key_down_is_sent_in_full(void);
 
 void setUp(void) {
     /* Called before each test */
@@ -516,6 +529,7 @@ int main(void) {
     RUN_TEST(test_client_tx_end_of_over_after_14_dot_times);
     RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
     RUN_TEST(test_client_tx_ignores_repeated_key_state);
+    RUN_TEST(test_client_tx_wait_beyond_one_frame_rebases_on_the_edge);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);
@@ -523,6 +537,19 @@ int main(void) {
     /* Fragmentation */
     RUN_TEST(test_client_handles_fragmented_frame);
     RUN_TEST(test_client_handles_ping_in_fragments);
+
+    /* CWNet feed: from the keying stream to the wire, on stream time */
+    printf("\n=== CWNet Feed Tests ===\n");
+    RUN_TEST(test_feed_waits_are_tick_distances_whatever_the_drain);
+    RUN_TEST(test_feed_first_over_from_stream_matches_reference_capture);
+    RUN_TEST(test_feed_idle_stream_ages_on_the_caller_clock);
+    RUN_TEST(test_feed_drains_while_client_not_ready_and_does_not_replay);
+    RUN_TEST(test_feed_overrun_closes_the_over_on_the_wire);
+    RUN_TEST(test_feed_no_dot_time_no_end_of_over);
+    RUN_TEST(test_feed_drain_granularity_does_not_change_the_bytes);
+    RUN_TEST(test_feed_send_failure_closes_the_over_and_retries);
+    RUN_TEST(test_feed_disconnect_mid_over_then_reconnect);
+    RUN_TEST(test_feed_long_key_down_is_sent_in_full);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## What changes

CWNet keys from the keying stream itself. A new best-effort consumer, `cwnet_feed`, drains the stream every background pass, reconstructs stream time by counting one tick per sample and the tick count of each silence marker, and hands every `local_key` edge to the client stamped with the tick it happened on Core 0. The 7-bit waits on the wire are now tick distances, whatever the background loop's jitter and however many samples one drain finds. The WebSocket gate is gone with the forwarding in `bg_task`: the box keys the server with no browser attached.

Decisions the diff does not show. The stream carries no entry while nothing changes, so stream time stands still on an idle key: the end of an over is judged on stream time aged by a clock sampled right before the drain, which fires it at most one drain period late and never feeds a wait. The alternative rejected, periodic silence markers from `rt_task`, touches the RT path and every consumer for the benefit of one. When the ticks are no longer trustworthy (a stream overrun, including the consumer's silent resync path) or the wire may disagree with the client (a `send()` that did not go out whole), the over is closed on the wire at once, key-up then end-of-over mark, and retried until it goes out; a failed send also drops the session, since a truncated frame cannot be repaired. Silence over corrupted timing. A frame carries up to 128 keying bytes, the reference FIFO's size, and a wait beyond that re-bases the stopwatch on the edge so only that wait is short; a backlog goes out at most 64 edges per pass.

The feed drains in every socket state and lets the client refuse, so a session coming up does not replay stale edges.

## Closes

#55. Condition: CWNet owns a stream consumer independent of the WebUI, edges reach the client with stream time, the end-of-over poll runs on the same clock, and a host test feeds a recorded stream through the consumer and finds the waits equal to the tick distances. Holds in `components/keyer_cwnet/src/cwnet_feed.c` and `test_host/test_cwnet_feed.c`.

## Definition of done

- Host tests: 193/193 plain, 193/193 ASan/UBSan. Was 182: ten feed tests and one client test added, all driven through `stream_push()` or the client's byte sink.
- Reference test: `test_feed_first_over_from_stream_matches_reference_capture` pushes the letter A at 25 WPM into a real `keying_stream_t` one tick at a time, drains it in one pass, ages the idle on the caller's clock, and compares the bytes with the MORSE frames of the first over of session 12 of the 2026-09-05 DL4YHF capture, now shared in `test_host/cwnet_fixtures.h`. `test_feed_drain_granularity_does_not_change_the_bytes` is the condition of #55 itself: the same over drained tick by tick and in one pass gives identical bytes. An adversarial review of the first cut found the send-failure hole, the 8-byte truncation, the early-running aged clock and the silent resync path; each has a test now.
- RT path: untouched. One more read index on the SPMC stream; `stream_push()` and Core 0 do not change. The review also found a pre-existing cross-core race in the stream itself (producer publishes `write_idx` before storing the slot; `stream_read` accepts `behind == capacity`): #57, not fixed here, affects every Core 1 consumer.
- Blocking issues open on this work: none.

## Not done here

- #57 above. MORSE RX: #11. PTT frames: #13.
- `sample_silence()` clamps at 65.5 s of unchanged stream; noted in `.claude/code-quality.md`, harmless while the end of over closes overs.
- The `keyer_cwnet` CLAUDE.md treecode block still says `bg_task` hands events in: `map-tree`, noted in `.claude/code-quality.md`.
- Firmware build checked by CI only; not run on hardware.
