### PR TITLE
CWNet RX: MORSE frames into keying events, and the reference's latency peak-hold

### DIFF
--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -22,6 +22,7 @@
  *   READY -> recv PING_RESPONSE_2 -> update latency
  *   READY -> send_key_event() -> send MORSE (7-bit keying stream)
  *   READY -> poll() after 14 dot-times of key-up -> send the end of the over
+ *   any state -> recv MORSE -> keying events queued for rx_pop()
  *   any state -> on_disconnected() -> DISCONNECTED
  *
  * Keying on the wire (reference: DL4YHF Remote CW Keyer, CwStreamEnc.c and
@@ -96,6 +97,37 @@ typedef enum {
 #define CWNET_PERMISSION_TRANSMIT  0x02u  /**< May transmit (CW) */
 #define CWNET_PERMISSION_CTRL_RIG  0x04u  /**< May control the remote rig */
 #define CWNET_PERMISSION_ADMIN     0x08u  /**< Is the server administrator */
+
+/*===========================================================================*/
+/* Received keying                                                           */
+/*===========================================================================*/
+
+/** The reference's CW_KEYING_FIFO_SIZE */
+#define CWNET_RX_FIFO_SIZE 128
+
+/**
+ * @brief One received keying event, decoded from a MORSE byte
+ */
+typedef struct {
+    bool key_down;            /**< New key state (bit 7 of the byte) */
+    int32_t wait_ms;          /**< Decoded 7-bit wait before applying it */
+    int32_t received_at_ms;   /**< Local clock (get_time_ms_cb) when the byte arrived */
+} cwnet_rx_event_t;
+
+/**
+ * @brief FIFO of received keying bytes, decoded on the way out
+ *
+ * Kept as raw bytes like the reference's MorseRxFifo, so the buffered time
+ * and the end-of-over check are computed on the bytes exactly as
+ * CwStream_GetNumMillisecondsBufferedInFifo() and
+ * CwStream_CheckForAnyEndOfTransmissionInFifo() do.
+ */
+typedef struct {
+    uint8_t cmd[CWNET_RX_FIFO_SIZE];
+    int32_t received_at_ms[CWNET_RX_FIFO_SIZE];
+    uint16_t tail;            /**< Oldest entry */
+    uint16_t count;           /**< Entries held */
+} cwnet_rx_fifo_t;
 
 /*===========================================================================*/
 /* Client State                                                              */
@@ -211,10 +243,15 @@ typedef struct {
     cwnet_timer_t timer;
 
     /* Latency measurement */
-    int32_t latency_ms;  /**< Last measured RTT, -1 if unknown */
+    int32_t latency_ms;       /**< Last measured RTT, -1 if unknown */
+    int32_t latency_peak_ms;  /**< The reference's peak-hold of it, -1 if unknown */
 
     /* Permissions granted by the server in its CONNECT echo */
     uint32_t permissions;
+
+    /* Keying received in MORSE frames, oldest first */
+    cwnet_rx_fifo_t rx;
+    uint32_t rx_dropped;      /**< Bytes that found the FIFO full */
 
     /* MORSE TX stopwatch: the reference's sw_MorseTxFifo, fFillingTxFifo and
      * fMorseOutput_sent (KeyerThread.c). */
@@ -266,6 +303,60 @@ int32_t cwnet_client_get_synced_time(const cwnet_client_t *client);
  * @return RTT in ms, or -1 if unknown/not measured
  */
 int32_t cwnet_client_get_latency_ms(const cwnet_client_t *client);
+
+/**
+ * @brief Get the latency as the reference filters it
+ *
+ * Asymmetric peak-hold, exactly as CwNet.c does on every PING RESPONSE_2:
+ * a measurement at or above the held value replaces it; a lower one lets
+ * it drop by one tenth of the gap, in integer arithmetic, so once the gap
+ * is below 10 ms it stops descending. This is the number the reference
+ * displays as "pk" and sizes its keying buffer with.
+ *
+ * @param client Client context
+ * @return Filtered RTT in ms, or -1 until the first measurement
+ */
+int32_t cwnet_client_get_latency_peak_ms(const cwnet_client_t *client);
+
+/*===========================================================================*/
+/* Received keying                                                           */
+/*===========================================================================*/
+
+/**
+ * @brief Take the oldest received keying event
+ *
+ * Every byte of every MORSE frame lands in the FIFO in order, with the
+ * local time it arrived; a frame carries as many events as the sender had
+ * queued. A byte that finds the FIFO full is dropped and counted.
+ *
+ * @param client Client context
+ * @param out Event, written when true is returned
+ * @return true if an event was taken, false if the FIFO is empty
+ */
+bool cwnet_client_rx_pop(cwnet_client_t *client, cwnet_rx_event_t *out);
+
+/** @return Events waiting in the FIFO */
+size_t cwnet_client_rx_count(const cwnet_client_t *client);
+
+/**
+ * @brief Milliseconds of keying waiting in the FIFO
+ *
+ * The sum of the decoded waits of every byte held, as the reference's
+ * CwStream_GetNumMillisecondsBufferedInFifo(): what its latency control
+ * compares with the measured latency before it starts playing.
+ */
+int32_t cwnet_client_rx_buffered_ms(const cwnet_client_t *client);
+
+/**
+ * @brief Whether the FIFO holds the end of an over
+ *
+ * Two consecutive key-up bytes, whatever their waits, as the reference's
+ * CwStream_CheckForAnyEndOfTransmissionInFifo().
+ */
+bool cwnet_client_rx_has_end_of_over(const cwnet_client_t *client);
+
+/** @return Received keying bytes dropped because the FIFO was full */
+uint32_t cwnet_client_rx_dropped(const cwnet_client_t *client);
 
 /*===========================================================================*/
 /* Connection Events (called by socket layer)                                */

--- a/components/keyer_cwnet/include/cwnet_socket.h
+++ b/components/keyer_cwnet/include/cwnet_socket.h
@@ -69,6 +69,13 @@ bool cwnet_socket_is_ready(void);
 int32_t cwnet_socket_get_latency_ms(void);
 
 /**
+ * @brief Get the latency filtered the reference's way (peak-hold, "pk")
+ *
+ * @return ms, or -1 until the first measurement
+ */
+int32_t cwnet_socket_get_latency_peak_ms(void);
+
+/**
  * @brief Get state as string (for logging)
  */
 const char *cwnet_socket_state_str(cwnet_socket_state_t state);

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -261,7 +261,17 @@ static void handle_ping(cwnet_client_t *client,
                 int32_t latency = cwnet_ping_calc_latency(&ping);
                 if (latency >= 0) {
                     client->latency_ms = latency;
-                    RT_DEBUG(&g_bg_log_stream, now_us, "RTT=%" PRId32 "ms", latency);
+                    /* CwNet.c:1442-1447: jump to a new peak, otherwise drop
+                     * by a tenth of the gap. Integer division: a gap under
+                     * 10 ms no longer descends, and that is what the
+                     * reference shows. */
+                    if (client->latency_peak_ms < 0 || latency >= client->latency_peak_ms) {
+                        client->latency_peak_ms = latency;
+                    } else {
+                        client->latency_peak_ms -= (client->latency_peak_ms - latency) / 10;
+                    }
+                    RT_DEBUG(&g_bg_log_stream, now_us, "RTT=%" PRId32 "ms pk=%" PRId32 "ms",
+                             latency, client->latency_peak_ms);
                 }
             }
             break;
@@ -274,9 +284,30 @@ static void handle_ping(cwnet_client_t *client,
 }
 
 /**
+ * @brief Queue every byte of a MORSE frame as a received keying event
+ *
+ * The reference does this per byte as it parses (CwNet.c:2875-2902,
+ * MorseRxFifo), stamping each with its time of reception for the latency
+ * control that plays it back. A full FIFO drops the byte and counts it;
+ * the reference overwrites silently.
+ */
+static void handle_morse(cwnet_client_t *client, const uint8_t *payload, size_t len) {
+    int32_t now_ms = get_local_time(client);
+    for (size_t i = 0; i < len; i++) {
+        if (client->rx.count >= CWNET_RX_FIFO_SIZE) {
+            client->rx_dropped++;
+            continue;
+        }
+        uint16_t head = (uint16_t)((client->rx.tail + client->rx.count) % CWNET_RX_FIFO_SIZE);
+        client->rx.cmd[head] = payload[i];
+        client->rx.received_at_ms[head] = now_ms;
+        client->rx.count++;
+    }
+}
+
+/**
  * @brief Process a complete frame from parse result
  *
- * Keying from other operators arrives as MORSE 0x10 and is not decoded yet.
  * CI_V 0x14 and SPECTRUM 0x15 are rig control and display data, never keying.
  */
 static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *result) {
@@ -291,6 +322,10 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
 
         case CWNET_CMD_PING:
             handle_ping(client, payload, payload_len);
+            break;
+
+        case CWNET_CMD_MORSE:
+            handle_morse(client, payload, payload_len);
             break;
 
         default:
@@ -348,6 +383,7 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     /* Initialize state */
     client->state = CWNET_STATE_DISCONNECTED;
     client->latency_ms = -1;
+    client->latency_peak_ms = -1;
 
     /* Initialize timer */
     cwnet_timer_init(&client->timer);
@@ -403,6 +439,13 @@ void cwnet_client_on_connected(cwnet_client_t *client) {
     client->tx_ref_ms = 0;
     client->tx_filling = false;
     client->tx_key_down = false;
+
+    /* Nothing received yet, and no latency known: the reference keeps both
+     * across a reconnect, which is stale data with a fresh server. */
+    memset(&client->rx, 0, sizeof(client->rx));
+    client->rx_dropped = 0;
+    client->latency_ms = -1;
+    client->latency_peak_ms = -1;
 
     /* Transition to CONNECTING */
     set_state(client, CWNET_STATE_CONNECTING);
@@ -552,6 +595,66 @@ bool cwnet_client_abort_over(cwnet_client_t *client) {
 
 bool cwnet_client_key_on_wire(const cwnet_client_t *client) {
     return client != NULL && client->tx_key_down;
+}
+
+int32_t cwnet_client_get_latency_peak_ms(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return -1;
+    }
+    return client->latency_peak_ms;
+}
+
+/*===========================================================================*/
+/* Received keying                                                           */
+/*===========================================================================*/
+
+bool cwnet_client_rx_pop(cwnet_client_t *client, cwnet_rx_event_t *out) {
+    if (client == NULL || out == NULL || client->rx.count == 0) {
+        return false;
+    }
+    uint8_t b = client->rx.cmd[client->rx.tail];
+    out->key_down = (b & 0x80u) != 0;
+    out->wait_ms = cwstream_decode_timestamp(b);
+    out->received_at_ms = client->rx.received_at_ms[client->rx.tail];
+    client->rx.tail = (uint16_t)((client->rx.tail + 1) % CWNET_RX_FIFO_SIZE);
+    client->rx.count--;
+    return true;
+}
+
+size_t cwnet_client_rx_count(const cwnet_client_t *client) {
+    return client == NULL ? 0 : client->rx.count;
+}
+
+int32_t cwnet_client_rx_buffered_ms(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return 0;
+    }
+    int32_t total = 0;
+    for (uint16_t i = 0; i < client->rx.count; i++) {
+        uint16_t idx = (uint16_t)((client->rx.tail + i) % CWNET_RX_FIFO_SIZE);
+        total += cwstream_decode_timestamp(client->rx.cmd[idx]);
+    }
+    return total;
+}
+
+bool cwnet_client_rx_has_end_of_over(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return false;
+    }
+    /* CwStreamEnc.c: two consecutive key-up commands, regardless of the
+     * seven-bit time, indicate END-OF-TRANSMISSION */
+    for (uint16_t i = 1; i < client->rx.count; i++) {
+        uint16_t prev = (uint16_t)((client->rx.tail + i - 1) % CWNET_RX_FIFO_SIZE);
+        uint16_t cur = (uint16_t)((client->rx.tail + i) % CWNET_RX_FIFO_SIZE);
+        if ((client->rx.cmd[prev] & 0x80u) == 0 && (client->rx.cmd[cur] & 0x80u) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+uint32_t cwnet_client_rx_dropped(const cwnet_client_t *client) {
+    return client == NULL ? 0 : client->rx_dropped;
 }
 
 bool cwnet_client_over_open(const cwnet_client_t *client) {

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -399,6 +399,10 @@ int32_t cwnet_socket_get_latency_ms(void) {
     return cwnet_client_get_latency_ms(&s_ctx.client);
 }
 
+int32_t cwnet_socket_get_latency_peak_ms(void) {
+    return cwnet_client_get_latency_peak_ms(&s_ctx.client);
+}
+
 const char *cwnet_socket_state_str(cwnet_socket_state_t state) {
     switch (state) {
         case CWNET_SOCK_DISABLED:     return "DISABLED";

--- a/components/keyer_webui/src/api_system.c
+++ b/components/keyer_webui/src/api_system.c
@@ -46,6 +46,7 @@ esp_err_t api_status_handler(httpd_req_t *req) {
     cwnet_socket_state_t cwnet_state = cwnet_socket_get_state();
     cJSON_AddStringToObject(cwnet, "state", cwnet_socket_state_str(cwnet_state));
     cJSON_AddNumberToObject(cwnet, "latency_ms", cwnet_socket_get_latency_ms());
+    cJSON_AddNumberToObject(cwnet, "latency_peak_ms", cwnet_socket_get_latency_peak_ms());
     cJSON_AddItemToObject(root, "cwnet", cwnet);
 
     char *json_str = cJSON_PrintUnformatted(root);

--- a/test_host/cwnet_fixtures.h
+++ b/test_host/cwnet_fixtures.h
@@ -79,3 +79,24 @@ static inline bool ref_morse_frames(const uint8_t *in, size_t in_len,
     *out_len = n;
     return true;
 }
+
+/*
+ * Client-to-server bytes 6982..6989 of session 12 of the 2026-09-05 capture:
+ * frames 524 and 525, from the fast part of the session (dot about 20 ms),
+ * two keying events each, the shape a server receives at speed.
+ */
+static const uint8_t ref_two_event_frames[] = {
+    0x50, 0x02, 0x96, 0x12,   /* down after 22 ms, up after 18 ms */
+    0x50, 0x02, 0x96, 0x12,
+};
+
+/*
+ * One MORSE frame of 17 events written by tools/cwnet/gen_synth.c with the
+ * DL4YHF encoder (synth_morse.bin): 'S' 'O' 'S' at inputs of 60 and 180 ms,
+ * a 500 ms gap, then the end-of-over key-up.
+ */
+static const uint8_t synth_morse_frame[] = {
+    0x50, 0x11,
+    0x80, 0x41, 0xA7, 0x27, 0xC1, 0x27, 0xA7, 0x41, 0xC1, 0x27, 0xC1, 0x27,
+    0xA7, 0x27, 0xC1, 0x55, 0x00,
+};

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -640,6 +640,166 @@ void test_client_rejects_events_when_not_ready(void) {
     TEST_ASSERT_EQUAL(CWNET_CLIENT_ERR_NOT_READY, err);
 }
 
+
+/*===========================================================================*/
+/* Received keying: MORSE frames into events                                */
+/*===========================================================================*/
+
+void test_client_rx_decodes_every_event_of_a_morse_frame(void) {
+    ready_client_accumulating();
+
+    cwnet_client_on_data(&client, ref_two_event_frames, sizeof(ref_two_event_frames));
+
+    TEST_ASSERT_EQUAL(4, cwnet_client_rx_count(&client));
+    TEST_ASSERT_EQUAL(22 + 18 + 22 + 18, cwnet_client_rx_buffered_ms(&client));
+    TEST_ASSERT_FALSE(cwnet_client_rx_has_end_of_over(&client));
+
+    static const bool keys[] = {true, false, true, false};
+    static const int32_t waits[] = {22, 18, 22, 18};
+    for (size_t i = 0; i < 4; i++) {
+        cwnet_rx_event_t ev;
+        TEST_ASSERT_TRUE(cwnet_client_rx_pop(&client, &ev));
+        TEST_ASSERT_EQUAL(keys[i], ev.key_down);
+        TEST_ASSERT_EQUAL(waits[i], ev.wait_ms);
+    }
+    cwnet_rx_event_t none;
+    TEST_ASSERT_FALSE(cwnet_client_rx_pop(&client, &none));
+    TEST_ASSERT_EQUAL(0, cwnet_client_rx_buffered_ms(&client));
+}
+
+void test_client_rx_synthetic_frame_from_reference_encoder(void) {
+    ready_client_accumulating();
+
+    cwnet_client_on_data(&client, synth_morse_frame, sizeof(synth_morse_frame));
+    TEST_ASSERT_EQUAL(17, cwnet_client_rx_count(&client));
+
+    /* 180 ms inputs come back as 173 (16 ms steps), 500 as 493 */
+    static const bool keys[17] = {
+        true, false, true, false, true, false, true, false,
+        true, false, true, false, true, false, true, false, false,
+    };
+    static const int32_t waits[17] = {
+        0, 173, 60, 60, 173, 60, 60, 173,
+        173, 60, 173, 60, 60, 60, 173, 493, 0,
+    };
+    TEST_ASSERT_EQUAL(2011, cwnet_client_rx_buffered_ms(&client));
+    /* Two consecutive key-ups at the end: the over is complete */
+    TEST_ASSERT_TRUE(cwnet_client_rx_has_end_of_over(&client));
+
+    for (size_t i = 0; i < 17; i++) {
+        /* The end-of-over is in the FIFO while both key-ups are */
+        TEST_ASSERT_EQUAL(i <= 15, cwnet_client_rx_has_end_of_over(&client));
+        cwnet_rx_event_t ev;
+        TEST_ASSERT_TRUE(cwnet_client_rx_pop(&client, &ev));
+        TEST_ASSERT_EQUAL(keys[i], ev.key_down);
+        TEST_ASSERT_EQUAL(waits[i], ev.wait_ms);
+    }
+    TEST_ASSERT_EQUAL(0, cwnet_client_rx_count(&client));
+}
+
+void test_client_rx_frame_in_fragments(void) {
+    ready_client_accumulating();
+
+    for (size_t i = 0; i < sizeof(ref_two_event_frames); i++) {
+        cwnet_client_on_data(&client, ref_two_event_frames + i, 1);
+    }
+    TEST_ASSERT_EQUAL(4, cwnet_client_rx_count(&client));
+}
+
+void test_client_rx_event_carries_reception_time(void) {
+    ready_client_accumulating();
+
+    mock_time_ms = 7000;
+    static const uint8_t frame[] = {0x50, 0x01, 0x80};
+    cwnet_client_on_data(&client, frame, sizeof(frame));
+
+    cwnet_rx_event_t ev;
+    TEST_ASSERT_TRUE(cwnet_client_rx_pop(&client, &ev));
+    TEST_ASSERT_EQUAL(7000, ev.received_at_ms);
+}
+
+void test_client_rx_fifo_full_drops_and_counts(void) {
+    ready_client_accumulating();
+
+    static const uint8_t frame[] = {0x50, 0x01, 0x80};
+    for (int i = 0; i < CWNET_RX_FIFO_SIZE + 2; i++) {
+        cwnet_client_on_data(&client, frame, sizeof(frame));
+    }
+    TEST_ASSERT_EQUAL(CWNET_RX_FIFO_SIZE, cwnet_client_rx_count(&client));
+    TEST_ASSERT_EQUAL(2, cwnet_client_rx_dropped(&client));
+
+    /* A new session starts empty */
+    cwnet_client_on_connected(&client);
+    TEST_ASSERT_EQUAL(0, cwnet_client_rx_count(&client));
+    TEST_ASSERT_EQUAL(0, cwnet_client_rx_dropped(&client));
+}
+
+void test_client_rx_ignores_ci_v_and_spectrum(void) {
+    ready_client_accumulating();
+
+    /* 0x14 and 0x15 with a key-down-looking payload: rig data, not keying */
+    static const uint8_t civ[] = {0x54, 0x01, 0x80};
+    static const uint8_t spectrum[] = {0x55, 0x01, 0x80};
+    cwnet_client_on_data(&client, civ, sizeof(civ));
+    cwnet_client_on_data(&client, spectrum, sizeof(spectrum));
+    TEST_ASSERT_EQUAL(0, cwnet_client_rx_count(&client));
+}
+
+/*===========================================================================*/
+/* Latency peak-hold                                                         */
+/*===========================================================================*/
+
+/* A PING RESPONSE_2 whose t2 - t0 is the given round trip */
+static void feed_rtt(int32_t rtt_ms) {
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE] = {
+        0x43, 0x10,
+        0x02, 0x01, 0x00, 0x00,   /* RESPONSE_2, id 1 */
+        0xE8, 0x03, 0x00, 0x00,   /* t0 = 1000 */
+        0xE8, 0x03, 0x00, 0x00,   /* t1 = 1000 */
+        0x00, 0x00, 0x00, 0x00,   /* t2, filled below */
+    };
+    uint32_t t2 = 1000u + (uint32_t)rtt_ms;
+    frame[14] = (uint8_t)(t2 & 0xFFu);
+    frame[15] = (uint8_t)((t2 >> 8) & 0xFFu);
+    frame[16] = (uint8_t)((t2 >> 16) & 0xFFu);
+    frame[17] = (uint8_t)((t2 >> 24) & 0xFFu);
+    cwnet_client_on_data(&client, frame, sizeof(frame));
+}
+
+void test_client_latency_peak_holds_and_decays_like_the_reference(void) {
+    ready_client_accumulating();
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_peak_ms(&client));
+
+    /* CwNet.c:1442-1447 walked sample by sample: one spike, then a steady
+     * 30 ms. The held value drops by a tenth of the gap, in integers, and
+     * stops at 39: a gap under 10 ms decays by 0. */
+    static const int32_t rtt[] = {50, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30};
+    static const int32_t pk[]  = {50, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 39, 39};
+    for (size_t i = 0; i < sizeof(rtt) / sizeof(rtt[0]); i++) {
+        feed_rtt(rtt[i]);
+        TEST_ASSERT_EQUAL(rtt[i], cwnet_client_get_latency_ms(&client));
+        TEST_ASSERT_EQUAL(pk[i], cwnet_client_get_latency_peak_ms(&client));
+    }
+
+    /* A new peak is taken at once, the old one forgotten */
+    feed_rtt(100);
+    TEST_ASSERT_EQUAL(100, cwnet_client_get_latency_peak_ms(&client));
+    feed_rtt(90);
+    TEST_ASSERT_EQUAL(99, cwnet_client_get_latency_peak_ms(&client));
+    feed_rtt(90);
+    TEST_ASSERT_EQUAL(99, cwnet_client_get_latency_peak_ms(&client));
+
+    /* The floor the issue observed on loopback: pk 7 while the instant
+     * value sits at 1-5, for as long as you like */
+    cwnet_client_on_connected(&client);
+    feed_connect_echo();
+    static const int32_t loopback[] = {7, 3, 1, 5, 2, 4, 1};
+    for (size_t i = 0; i < sizeof(loopback) / sizeof(loopback[0]); i++) {
+        feed_rtt(loopback[i]);
+        TEST_ASSERT_EQUAL(7, cwnet_client_get_latency_peak_ms(&client));
+    }
+}
+
 /*===========================================================================*/
 /* Error Handling Tests                                                      */
 /*===========================================================================*/
@@ -790,6 +950,13 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
     RUN_TEST(test_client_tx_ignores_repeated_key_state);
     RUN_TEST(test_client_tx_wait_beyond_one_frame_rebases_on_the_edge);
+    RUN_TEST(test_client_rx_decodes_every_event_of_a_morse_frame);
+    RUN_TEST(test_client_rx_synthetic_frame_from_reference_encoder);
+    RUN_TEST(test_client_rx_frame_in_fragments);
+    RUN_TEST(test_client_rx_event_carries_reception_time);
+    RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
+    RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
+    RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
     RUN_TEST(test_client_rejects_events_when_not_ready);
 
     /* Error Handling */

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -231,6 +231,13 @@ void test_client_tx_end_of_over_after_14_dot_times(void);
 void test_client_tx_end_of_over_splits_at_slow_speed(void);
 void test_client_tx_ignores_repeated_key_state(void);
 void test_client_tx_wait_beyond_one_frame_rebases_on_the_edge(void);
+void test_client_rx_decodes_every_event_of_a_morse_frame(void);
+void test_client_rx_synthetic_frame_from_reference_encoder(void);
+void test_client_rx_frame_in_fragments(void);
+void test_client_rx_event_carries_reception_time(void);
+void test_client_rx_fifo_full_drops_and_counts(void);
+void test_client_rx_ignores_ci_v_and_spectrum(void);
+void test_client_latency_peak_holds_and_decays_like_the_reference(void);
 void test_client_rejects_events_when_not_ready(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
@@ -530,6 +537,14 @@ int main(void) {
     RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
     RUN_TEST(test_client_tx_ignores_repeated_key_state);
     RUN_TEST(test_client_tx_wait_beyond_one_frame_rebases_on_the_edge);
+    /* Received keying and latency */
+    RUN_TEST(test_client_rx_decodes_every_event_of_a_morse_frame);
+    RUN_TEST(test_client_rx_synthetic_frame_from_reference_encoder);
+    RUN_TEST(test_client_rx_frame_in_fragments);
+    RUN_TEST(test_client_rx_event_carries_reception_time);
+    RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
+    RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
+    RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);


### PR DESCRIPTION
## What changes

Every byte of a received `MORSE 0x10` frame becomes a keying event in a FIFO of 128 (the reference's `CW_KEYING_FIFO_SIZE`), kept as raw bytes and decoded on the way out, each with the local time of arrival: `cwnet_client_rx_pop()`, plus the two queries the reference's latency control runs on that FIFO, buffered milliseconds and end-of-over, two consecutive key-ups whatever their waits. Nothing plays it yet: in the reference a *client* discards MORSE (the receive path at `CwNet.c:2875` sits inside the server branch) and the server never sends any (H6), so this is the receive half of the determinism loop (#14, R7) and of a server role. A full FIFO drops the byte and counts it where the reference overwrites silently.

The latency the reference shows as "pk" is now computed beside the instantaneous one: jump to any new maximum, otherwise drop by a tenth of the gap in integer arithmetic (`CwNet.c:1442-1447`), so below a 10 ms gap it stops descending. Decision, written in #12's body: reproduce that exactly, floor included, because it is the number the reference displays and sizes its keying buffer with, and the bench compares ours with its GUI log; `latency_ms` stays exposed beside it. Both, and the FIFO, reset on a new session; the reference keeps stale values across a reconnect. The WebUI status JSON gains `latency_peak_ms`.

## Closes

#11: every event of a MORSE payload is decoded and exposed, pinned against a multi-event fixture. Holds in `components/keyer_cwnet/src/cwnet_client.c`, `handle_morse()` and `cwnet_client_rx_pop()`.
#12: the peak-hold filter, walked sample by sample in `test_client_latency_peak_holds_and_decays_like_the_reference`; the floor decision is in the issue body.

## Definition of done

- Host tests: 200/200 plain, 200/200 ASan/UBSan. Was 193: seven added.
- Reference test: `test_client_rx_decodes_every_event_of_a_morse_frame` feeds frames 524 and 525 of session 12 of the 2026-09-05 capture, two events each (client→server bytes 6982..6989, now in `test_host/cwnet_fixtures.h`); `test_client_rx_synthetic_frame_from_reference_encoder` feeds the 17-event frame `tools/cwnet/gen_synth.c` wrote with the DL4YHF encoder and checks every decoded wait and where the end-of-over is. The peak-hold expectations are the reference's integer arithmetic run on three sequences, including the loopback floor the issue reports (pk 7 over 1–5 ms).
- RT path: untouched.
- Blocking issues open on this work: none.

## Not done here

- Playing received keying (latency control, sidetone): needs a consumer that does not exist yet; the echo server is #14.
- PTT strings around an over: #13, logic and timing read from the source and reported in chat.
- The frontend does not show `latency_peak_ms` yet; the JSON carries it.
- Firmware build checked by CI only.
