### PR TITLE
Bench: a CWNet echo server for the determinism loop

### DIFF
--- a/.claude/code-quality.md
+++ b/.claude/code-quality.md
@@ -16,6 +16,10 @@
 - Ramo remoto `k8-differential-bench` (`fae2f57`), senza PR: lo scheletro del banco è migrato in Esp32KeyerTest, `FINDINGS.md` (numeri superati) vive solo lì. Da cancellare quando nessuno lo cita più.
 
 
+## Contesto: PING CWNet, cosa c'e' nei tre timestamp
+
+Il client DL4YHF risponde alla REQUEST copiando i tre timestamp del suo array (`CwNet.c:1478`): slot 0 = `t0` del server, slot 1 = il suo orologio locale grezzo (`:1403`), slot 2 = il `t2` del giro precedente, mai azzerato. Il nostro mette nello slot 1 l'ora sincronizzata e 0 nello slot 2. Il server copia lo slot 1 nella RESPONSE_2 e sovrascrive lo slot 2; nessuno legge lo slot 1 dall'altra parte. Byte diversi, nessun effetto. Osservato costruendo `cwnet_echo.py` (#14).
+
 ## Cleanup Items
 
 ### Vendored esp_wireguard — GCC 15 / ESP-IDF v6 patches

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -746,6 +746,35 @@ void test_client_rx_ignores_ci_v_and_spectrum(void) {
 }
 
 /*===========================================================================*/
+/* Determinism: what we send comes back as what we sent                     */
+/*===========================================================================*/
+
+void test_client_round_trip_returns_the_edges_sent(void) {
+    ready_client_accumulating();
+
+    /* The letter A at 25 WPM and the end of the over, as the feed sends it */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1000));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1048));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1096));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1240));
+    TEST_ASSERT_TRUE(cwnet_client_poll(&client, 1240 + 673, 48));
+
+    /* An echo server sends the frames straight back (tools/cwnet/cwnet_echo.py) */
+    cwnet_client_on_data(&client, mock_tx_all, mock_tx_all_len);
+
+    static const bool keys[] = {true, false, true, false, false};
+    static const int32_t waits[] = {0, 48, 48, 144, 669};
+    TEST_ASSERT_EQUAL(5, cwnet_client_rx_count(&client));
+    TEST_ASSERT_TRUE(cwnet_client_rx_has_end_of_over(&client));
+    for (size_t i = 0; i < 5; i++) {
+        cwnet_rx_event_t ev;
+        TEST_ASSERT_TRUE(cwnet_client_rx_pop(&client, &ev));
+        TEST_ASSERT_EQUAL(keys[i], ev.key_down);
+        TEST_ASSERT_EQUAL(waits[i], ev.wait_ms);
+    }
+}
+
+/*===========================================================================*/
 /* Latency peak-hold                                                         */
 /*===========================================================================*/
 
@@ -957,6 +986,7 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
     RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
     RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
+    RUN_TEST(test_client_round_trip_returns_the_edges_sent);
     RUN_TEST(test_client_rejects_events_when_not_ready);
 
     /* Error Handling */

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -238,6 +238,7 @@ void test_client_rx_event_carries_reception_time(void);
 void test_client_rx_fifo_full_drops_and_counts(void);
 void test_client_rx_ignores_ci_v_and_spectrum(void);
 void test_client_latency_peak_holds_and_decays_like_the_reference(void);
+void test_client_round_trip_returns_the_edges_sent(void);
 void test_client_rejects_events_when_not_ready(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
@@ -545,6 +546,7 @@ int main(void) {
     RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
     RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
     RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
+    RUN_TEST(test_client_round_trip_returns_the_edges_sent);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);

--- a/tools/cwnet/README.md
+++ b/tools/cwnet/README.md
@@ -11,6 +11,7 @@ compilano con clang/gcc. In particolare `pcap_to_stream.py` sostituisce
 
 | File | Cosa fa |
 |---|---|
+| `cwnet_echo.py` | Server CWNet minimo per il loop di determinismo (R7, #14): eco del CONNECT con i permessi, PING come richiedente ogni 2 s, `RPRT 0` alle stringhe 0x06, `TX_INFO` con la chiave presa al primo byte MORSE e rilasciata dopo 1 s, ed eco byte per byte di ogni frame MORSE al mittente. Il server DL4YHF non rimanda mai MORSE (H6). Registra i due versi come il tap. |
 | `cwnet_tap.py` | Relay TCP trasparente: il client CWNet punta al tap, il tap inoltra al server e registra i due versi come byte grezzi. Cattura il loopback quando Wireshark/Npcap non lo intercetta. |
 | `pcap_to_stream.py` | Estrae i flussi TCP da un pcap/pcapng e li scrive come byte grezzi, una direzione per file (solo stdlib, gestisce Ethernet/loopback/SLL/raw). |
 | `cwnet_dump.c` | Decodifica un flusso grezzo: parser di frame **nostro** + codec del keying **di DL4YHF**. Diagnostico, non asserisce. |
@@ -54,6 +55,10 @@ clang -O1 -Wall -Wextra -fsanitize=address,undefined -I shim -I "$REF" -I "$OUR/
 
 # byte attesi dal KeyerThread di riferimento per una lista di edge
 clang -O1 -Wall -fsanitize=undefined -I shim -I "$REF" keyer_sim.c "$REF/CwStreamEnc.c" -o keyer_sim && ./keyer_sim
+
+# loop di determinismo: la scatola punta all'echo server, che le rimanda il suo keying
+python3 cwnet_echo.py --listen 0.0.0.0:7355 --permissions 7 --verbose --record echo
+./cwnet_dump echo_1_client_to_server.bin; ./cwnet_dump echo_1_server_to_client.bin   # stessi frame MORSE nei due versi
 
 # tap dal vivo: client -> tap -> server, un file per direzione
 python3 cwnet_tap.py --listen 0.0.0.0:7355 --server <ip-server>:7355 --out sess

--- a/tools/cwnet/cwnet_echo.py
+++ b/tools/cwnet/cwnet_echo.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Server CWNet minimo che rimanda al mittente il keying che riceve.
+
+Il server DL4YHF non rimanda mai MORSE ai client (H6, smentita il 2026-09-05):
+il loop di determinismo del banco, R7, ha bisogno di un capo RX nostro. Quello
+che la scatola manda deve tornarle identico, e il confronto e' sul suo percorso
+di decodifica. Questo processo fa solo cio' che serve a un client per
+connettersi e trasmettere, con i byte del server vero dove il client li guarda:
+
+  * eco del CONNECT con i permessi scelti, PRINT di benvenuto, TX_INFO
+  * ciclo PING come richiedente, ogni 2 s come il riferimento, e RESPONSE_2
+  * "RPRT 0" a ogni stringa di controllo radio (blocco 0x06)
+  * TX_INFO quando un client prende la chiave con il primo byte MORSE, e
+    "-- nobody --" dopo un secondo di silenzio, come il timer del server vero
+  * eco byte per byte di ogni frame MORSE al client che l'ha mandato
+
+Con --record scrive i due versi come byte grezzi, nello stesso formato del tap,
+cosi' cwnet_dump li decodifica. Con --delay-ms ritarda ogni risposta, per
+simulare una latenza.
+
+  python3 cwnet_echo.py --listen 0.0.0.0:7355 --permissions 7 --record sess
+"""
+import argparse, asyncio, sys, time
+
+CMD_CONNECT, CMD_DISCONNECT, CMD_PING, CMD_PRINT, CMD_TX_INFO, CMD_RIG, CMD_MORSE = 1, 2, 3, 4, 5, 6, 0x10
+NAMES = {1: "CONNECT", 2: "DISCONNECT", 3: "PING", 4: "PRINT", 5: "TX_INFO", 6: "RIG", 0x10: "MORSE",
+         0x14: "CI_V", 0x15: "SPECTRUM", 0x16: "FREQ_REPORT"}
+NOBODY = b"-- nobody --\0"
+
+
+def hostport(s):
+    h, _, p = s.rpartition(":")
+    return h, int(p)
+
+
+def now_ms():
+    return int(time.monotonic() * 1000) & 0x7FFFFFFF
+
+
+def le32(v):
+    return (v & 0xFFFFFFFF).to_bytes(4, "little")
+
+
+def frame(code, payload=b""):
+    """Un frame CWNet: comando con la categoria nei bit 7-6, lunghezza, payload."""
+    if not payload:
+        return bytes([code & 0x3F])
+    if len(payload) <= 255:
+        return bytes([0x40 | (code & 0x3F), len(payload)]) + payload
+    return bytes([0x80 | (code & 0x3F), len(payload) & 0xFF, len(payload) >> 8]) + payload
+
+
+def decode7(b):
+    """Attesa in ms dai 7 bit bassi, come CwStreamEnc_7BitTimestampToMilliseconds."""
+    v = b & 0x7F
+    if v <= 0x1F:
+        return v
+    if v <= 0x3F:
+        return 32 + 4 * (v - 0x20)
+    return 157 + 16 * (v - 0x40)
+
+
+class FrameParser:
+    """Parser a flusso: restituisce (comando, payload) man mano che i frame sono completi."""
+
+    def __init__(self):
+        self.buf = bytearray()
+
+    def feed(self, data):
+        self.buf += data
+        out = []
+        while self.buf:
+            cmd = self.buf[0]
+            cat, code = cmd >> 6, cmd & 0x3F
+            if cat == 0:
+                out.append((code, b""))
+                del self.buf[:1]
+                continue
+            if cat == 3:
+                raise ValueError(f"categoria riservata nel comando 0x{cmd:02X}")
+            hdr = 2 if cat == 1 else 3
+            if len(self.buf) < hdr:
+                break
+            n = self.buf[1] if cat == 1 else self.buf[1] | (self.buf[2] << 8)
+            if len(self.buf) < hdr + n:
+                break
+            out.append((code, bytes(self.buf[hdr:hdr + n])))
+            del self.buf[:hdr + n]
+        return out
+
+
+class Hub:
+    """Stato condiviso fra i client: chi ha la chiave, e l'annuncio a tutti."""
+
+    def __init__(self, key_hold_ms):
+        self.clients = {}
+        self.next_index = 1
+        self.holder = None
+        self.last_key_ms = 0
+        self.key_hold_ms = key_hold_ms
+
+    def tx_info(self):
+        if self.holder is None or self.holder not in self.clients:
+            return frame(CMD_TX_INFO, b"\xff" + NOBODY)
+        c = self.clients[self.holder]
+        return frame(CMD_TX_INFO, bytes([self.holder]) + c.username.encode() + b"\0")
+
+    async def announce(self):
+        f = self.tx_info()
+        for c in list(self.clients.values()):
+            await c.send(f, note="TX_INFO")
+
+    async def take_key(self, index):
+        """Il server vero da' la chiave al primo byte MORSE se nessuno la tiene."""
+        self.last_key_ms = now_ms()
+        if self.holder is None:
+            self.holder = index
+            await self.announce()
+        return self.holder == index
+
+    async def release_loop(self):
+        while True:
+            await asyncio.sleep(0.1)
+            if self.holder is not None and now_ms() - self.last_key_ms > self.key_hold_ms:
+                self.holder = None
+                await self.announce()
+
+
+class Client:
+    def __init__(self, hub, index, reader, writer, cfg):
+        self.hub, self.index, self.reader, self.writer, self.cfg = hub, index, reader, writer, cfg
+        self.username = "?"
+        self.parser = FrameParser()
+        self.ping_task = None
+        self.ping_id = 0
+        self.ping_t0 = {}
+        self.rec_c2s = self.rec_s2c = None
+        if cfg.record:
+            self.rec_c2s = open(f"{cfg.record}_{index}_client_to_server.bin", "wb")
+            self.rec_s2c = open(f"{cfg.record}_{index}_server_to_client.bin", "wb")
+
+    def log(self, msg):
+        print(f"[{time.strftime('%H:%M:%S')}] c{self.index} {msg}", flush=True)
+
+    async def send(self, data, note=""):
+        if self.cfg.delay_ms:
+            await asyncio.sleep(self.cfg.delay_ms / 1000)
+        if self.rec_s2c:
+            self.rec_s2c.write(data)
+            self.rec_s2c.flush()
+        self.writer.write(data)
+        await self.writer.drain()
+        if note and self.cfg.verbose:
+            self.log(f"<- {note}")
+
+    async def ping_loop(self):
+        while True:
+            self.ping_id = self.ping_id % 255 + 1
+            t0 = now_ms()
+            self.ping_t0[self.ping_id] = t0
+            await self.send(frame(CMD_PING, bytes([0, self.ping_id, 0, 0]) + le32(t0) + bytes(8)),
+                            note=f"PING request id={self.ping_id}")
+            await asyncio.sleep(self.cfg.ping_interval)
+
+    async def on_frame(self, code, payload):
+        if code == CMD_CONNECT and len(payload) == 92:
+            self.username = payload[:44].split(b"\0", 1)[0].decode("ascii", "replace")
+            self.log(f"CONNECT user={self.username!r}, permessi 0x{self.cfg.permissions:02X}")
+            await self.send(frame(CMD_CONNECT, payload[:88] + le32(self.cfg.permissions)), note="CONNECT echo")
+            greeting = f"Welcome {self.username}. This is the echo server: what you key comes back.".encode() + b"\0"
+            await self.send(frame(CMD_PRINT, greeting), note="PRINT")
+            await self.send(self.hub.tx_info(), note="TX_INFO")
+            if self.ping_task is None:
+                self.ping_task = asyncio.create_task(self.ping_loop())
+        elif code == CMD_PING and len(payload) == 16:
+            kind, pid = payload[0], payload[1]
+            if kind == 1:
+                t0 = self.ping_t0.pop(pid, None)
+                t2 = now_ms()
+                await self.send(frame(CMD_PING, bytes([2, pid, 0, 0]) + payload[4:8] + payload[8:12] + le32(t2)),
+                                note=f"PING response 2 id={pid}")
+                if t0 is not None:
+                    self.log(f"PING id={pid}: RTT {t2 - t0} ms")
+            else:
+                self.log(f"PING tipo {kind} inatteso da un client")
+        elif code == CMD_MORSE:
+            mine = await self.hub.take_key(self.index)
+            if self.cfg.verbose:
+                ev = " ".join(f"{'D' if b & 0x80 else 'u'}{decode7(b)}" for b in payload)
+                self.log(f"-> MORSE {len(payload)} byte: {ev}" + ("" if mine else "  (chiave altrui: il server vero lo scarterebbe)"))
+            await self.send(frame(CMD_MORSE, payload), note=f"MORSE echo {len(payload)} byte")
+        elif code == CMD_RIG:
+            text = payload.split(b"\0", 1)[0].decode("ascii", "replace").strip()
+            self.log(f"-> 0x06 {text!r}")
+            await self.send(frame(CMD_RIG, b"RPRT 0\n\0"), note="RPRT 0")
+        elif code == CMD_DISCONNECT:
+            self.log("DISCONNECT")
+            self.writer.close()
+        else:
+            self.log(f"-> 0x{code:02X} {NAMES.get(code, '?')} {len(payload)} byte, ignorato")
+
+    async def run(self):
+        peer = self.writer.get_extra_info("peername")
+        self.log(f"connesso da {peer[0]}:{peer[1]}")
+        self.hub.clients[self.index] = self
+        try:
+            while True:
+                data = await self.reader.read(4096)
+                if not data:
+                    break
+                if self.rec_c2s:
+                    self.rec_c2s.write(data)
+                    self.rec_c2s.flush()
+                for code, payload in self.parser.feed(data):
+                    await self.on_frame(code, payload)
+        except (ConnectionError, ValueError, asyncio.IncompleteReadError) as e:
+            self.log(f"errore: {e}")
+        finally:
+            if self.ping_task:
+                self.ping_task.cancel()
+            self.hub.clients.pop(self.index, None)
+            if self.hub.holder == self.index:
+                self.hub.holder = None
+                await self.hub.announce()
+            for f in (self.rec_c2s, self.rec_s2c):
+                if f:
+                    f.close()
+            self.writer.close()
+            self.log("chiuso")
+
+
+async def serve(cfg):
+    hub = Hub(cfg.key_hold_ms)
+
+    async def on_connect(reader, writer):
+        c = Client(hub, hub.next_index, reader, writer, cfg)
+        hub.next_index += 1
+        await c.run()
+
+    lh, lp = hostport(cfg.listen)
+    server = await asyncio.start_server(on_connect, lh, lp)
+    print(f"echo server in ascolto su {lh}:{lp}, permessi 0x{cfg.permissions:02X}, "
+          f"ping ogni {cfg.ping_interval:g} s" + (f", ritardo {cfg.delay_ms} ms" if cfg.delay_ms else ""))
+    print("il client CWNet deve puntare a questo indirizzo. Ctrl-C per finire.\n", flush=True)
+    asyncio.create_task(hub.release_loop())
+    async with server:
+        await server.serve_forever()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--listen", default="0.0.0.0:7355")
+    ap.add_argument("--permissions", type=lambda s: int(s, 0), default=7,
+                    help="bitmask nel CONNECT echo: TALK 1, TRANSMIT 2, CTRL_RIG 4, ADMIN 8 (default 7)")
+    ap.add_argument("--ping-interval", type=float, default=2.0, help="secondi fra i PING (il riferimento: 2)")
+    ap.add_argument("--key-hold-ms", type=int, default=1000, help="silenzio dopo cui la chiave torna a nessuno (il riferimento: 1000)")
+    ap.add_argument("--delay-ms", type=int, default=0, help="ritardo di ogni risposta, per simulare latenza")
+    ap.add_argument("--record", default=None, help="prefisso dei file di byte grezzi, uno per verso e per connessione")
+    ap.add_argument("--verbose", action="store_true", help="logga ogni frame e decodifica il keying")
+    cfg = ap.parse_args()
+    try:
+        asyncio.run(serve(cfg))
+    except KeyboardInterrupt:
+        print("\nfine.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changes

`tools/cwnet/cwnet_echo.py`: a minimal CWNet server that does what a client needs to connect and transmit, with the server's bytes where the client looks at them (CONNECT echo with the chosen permissions, PRINT, PING as requester every 2 s and RESPONSE_2, `RPRT 0` to the 0x06 strings, `TX_INFO` with the key taken on the first MORSE byte and released after a second of silence), and sends every MORSE frame back to its sender byte for byte. It records both directions like the tap and can delay every reply to simulate latency. Python 3 stdlib, asyncio, like the other tools. The DL4YHF server never sends MORSE to a client (H6), so this is the RX end of the determinism loop of R7: what the box sends must come back identical, and the comparison is on its decode path.

Decision: the echo is verbatim, same framing and same bytes, not a re-encode; the loop measures our encode/decode round trip and the link, nothing else. `TX_INFO` and the 1 s hold mirror the reference so the client work of #25 can be driven against it.

## Closes

#14. Condition: a minimal server of our own that echoes keying back. Holds in `tools/cwnet/cwnet_echo.py`, exercised with a scripted client (CONNECT, PING, MORSE, 0x06, key handover); its recording decodes with `cwnet_dump`.

## Definition of done

- Host tests: 201/201 plain, 201/201 ASan/UBSan. Was 200: `test_client_round_trip_returns_the_edges_sent` sends the letter A and the end of the over, feeds the frames straight back as the echo server would, and finds the five events with the encoded waits, end of over included.
- Reference test: the server's frames follow the server side of the 2026-09-05 capture (CONNECT echo, PRINT, PING request and response 2 layout and 2 s cadence, `TX_INFO` payloads). The tool is a bench end, not `keyer_cwnet`; the host test above is the `keyer_cwnet` half.
- RT path: untouched.
- Blocking issues open on this work: none. #60 names #14 as not blocked.

## Not done here

- The box-side comparison on hardware, its RX FIFO against what it sent, needs a way to read the FIFO out of the box (console or WebUI); the host test covers the same path without the link.
- Observation, no action: the reference client's PING RESPONSE_1 carries its raw local clock in slot 1 and the previous round's `t2` in slot 2 (`CwNet.c:1403`, `:1478`); ours carries the synced time and 0. The server copies slot 1 back and overwrites slot 2. Noted in `.claude/code-quality.md`.
