### PR TITLE
CWNet: PTT on the wire mirrors the box's PTT

### DIFF
--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -36,6 +36,14 @@
  *   several bytes with the same key state. Once the key has been up for more
  *   than 14 dot-times the sender emits a second key-up: that is how the
  *   receiver learns the over has ended.
+ *
+ * PTT on the wire mirrors the box's own PTT, as the reference mirrors its
+ * local PTT flag (CwNet.c, CwNet_OnPoll): "set_ptt 1" in a 0x06 string right
+ * after the MORSE byte of the key-down that raises it, "set_ptt 0" once the
+ * key has been up for the PTT tail. The server applies the string on arrival
+ * and plays the keying after its latency buffer, so the "1" leads the first
+ * element by that buffer; its own hang time decides when the radio's PTT
+ * drops, not our "0". The server answers "RPRT 0", or a negative code.
  */
 
 #pragma once
@@ -73,10 +81,14 @@ typedef enum {
     CWNET_CMD_CONNECT = 0x01,   /**< Client -> Server request; echoed back by the server to confirm */
     CWNET_CMD_DISCONNECT = 0x02,/**< Bidirectional: disconnect */
     CWNET_CMD_PING = 0x03,      /**< Bidirectional: time sync */
+    CWNET_CMD_RIG_STRING = 0x06,/**< ASCII rig-control string with a trailing NUL: "set_ptt 0|1\n" from us, "RPRT n\n" back */
     CWNET_CMD_MORSE = 0x10,     /**< Keying: 7-bit stream, bit 7 = key state, bits 6..0 = wait */
     CWNET_CMD_CI_V = 0x14,      /**< A single CI-V packet (Icom rig control). Not keying. */
     CWNET_CMD_SPECTRUM = 0x15,  /**< Spectrum data for the waterfall display. Not keying. */
 } cwnet_cmd_t;
+
+/** No "RPRT" reply received yet */
+#define CWNET_RIG_RESULT_NONE INT32_MIN
 
 /**
  * Longest MORSE payload this client sends in one frame (bytes = events).
@@ -259,6 +271,12 @@ typedef struct {
     bool tx_filling;     /**< Inside an over: waits are measured, not forced to 0 */
     bool tx_key_down;    /**< Last key state put on the wire */
 
+    /* PTT on the wire: the box's PTT model, mirrored as "set_ptt" strings */
+    uint32_t tx_last_edge_ms; /**< Instant of the last key transition, as given (not quantised) */
+    int32_t ptt_tail_ms;      /**< Key-up time before "set_ptt 0"; 0 = send no PTT strings */
+    bool ptt_on;              /**< "set_ptt 1" is the last PTT string sent */
+    int32_t rig_result;       /**< Last "RPRT n" from the server; CWNET_RIG_RESULT_NONE until one arrives */
+
     /* Frame parser for incoming data */
     cwnet_frame_parser_t parser;
 } cwnet_client_t;
@@ -438,12 +456,13 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
                                                 int32_t at_ms);
 
 /**
- * @brief Close an over that has gone quiet
+ * @brief Drop PTT and close an over that has gone quiet
  *
- * Call periodically. When the key has been up for more than 14 dot-times
- * since the last transition, sends the second key-up the reference uses to
- * mark the end of an over, and stops measuring: the next transition starts
- * a new over with wait 0.
+ * Call periodically. Once the key has been up for the PTT tail, sends
+ * "set_ptt 0". When it has been up for more than 14 dot-times since the last
+ * transition, sends the second key-up the reference uses to mark the end of
+ * an over, and stops measuring: the next transition starts a new over with
+ * wait 0. Below about 33 WPM the tail comes first, as in the reference.
  *
  * @param client Client context
  * @param now_ms Current instant on the same clock as send_key_event()'s at_ms
@@ -484,3 +503,29 @@ bool cwnet_client_key_on_wire(const cwnet_client_t *client);
  * @return true between the first transition of an over and its end
  */
 bool cwnet_client_over_open(const cwnet_client_t *client);
+
+/*===========================================================================*/
+/* PTT on the wire                                                           */
+/*===========================================================================*/
+
+/**
+ * @brief Set the PTT tail the wire mirrors
+ *
+ * The box's timing.ptt_tail_ms: once the key has been up that long,
+ * cwnet_client_poll() sends "set_ptt 0". 0 sends no PTT strings at all.
+ *
+ * @param client Client context
+ * @param tail_ms Tail in milliseconds
+ */
+void cwnet_client_set_ptt_tail_ms(cwnet_client_t *client, int32_t tail_ms);
+
+/** @return true if the last PTT string sent was "set_ptt 1" */
+bool cwnet_client_ptt_on_wire(const cwnet_client_t *client);
+
+/**
+ * @brief The server's last answer to a rig-control string
+ *
+ * @return the n of "RPRT n" (0 = accepted, negative = refused, for instance
+ *         -11 when the user may not transmit), CWNET_RIG_RESULT_NONE if none
+ */
+int32_t cwnet_client_get_rig_result(const cwnet_client_t *client);

--- a/components/keyer_cwnet/include/cwnet_feed.h
+++ b/components/keyer_cwnet/include/cwnet_feed.h
@@ -49,6 +49,8 @@ typedef struct {
     bool end_of_over;       /**< The quiet-over second key-up was sent */
     bool aborted;           /**< The over on the wire was closed by force */
     bool stuck;             /**< It had to be and could not: retried next pass */
+    bool ptt_on;            /**< "set_ptt 1" went out this pass */
+    bool ptt_off;           /**< "set_ptt 0" went out this pass */
 } cwnet_feed_result_t;
 
 /**

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -284,6 +284,52 @@ static void handle_ping(cwnet_client_t *client,
 }
 
 /**
+ * @brief Send a rig-control string in a 0x06 frame, trailing NUL included
+ *
+ * CwNet.c:1000-1007: the payload is the C string with its terminator.
+ */
+static cwnet_client_err_t send_rig_string(cwnet_client_t *client, const char *text) {
+    size_t len = strlen(text) + 1;
+    uint8_t frame[2 + 32];
+    if (len > sizeof(frame) - 2) {
+        return CWNET_CLIENT_ERR_INVALID_ARG;
+    }
+    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_RIG_STRING);
+    frame[1] = (uint8_t)len;
+    memcpy(&frame[2], text, len);
+    int sent = send_frame(client, frame, 2 + len);
+    if (sent < 0 || (size_t)sent != 2 + len) {
+        return CWNET_CLIENT_ERR_SEND_FAILED;
+    }
+    return CWNET_CLIENT_OK;
+}
+
+/**
+ * @brief The server's "RPRT n" answer to a rig-control string
+ */
+static void handle_rig_string(cwnet_client_t *client, const uint8_t *payload, size_t len) {
+    /* "RPRT " then a signed decimal, then "\n\0" */
+    if (len < 6 || memcmp(payload, "RPRT ", 5) != 0) {
+        return;
+    }
+    size_t i = 5;
+    bool negative = false;
+    if (i < len && payload[i] == '-') {
+        negative = true;
+        i++;
+    }
+    if (i >= len || payload[i] < '0' || payload[i] > '9') {
+        return;
+    }
+    int32_t value = 0;
+    while (i < len && payload[i] >= '0' && payload[i] <= '9') {
+        value = value * 10 + (payload[i] - '0');
+        i++;
+    }
+    client->rig_result = negative ? -value : value;
+}
+
+/**
  * @brief Queue every byte of a MORSE frame as a received keying event
  *
  * The reference does this per byte as it parses (CwNet.c:2875-2902,
@@ -326,6 +372,10 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
 
         case CWNET_CMD_MORSE:
             handle_morse(client, payload, payload_len);
+            break;
+
+        case CWNET_CMD_RIG_STRING:
+            handle_rig_string(client, payload, payload_len);
             break;
 
         default:
@@ -384,6 +434,7 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     client->state = CWNET_STATE_DISCONNECTED;
     client->latency_ms = -1;
     client->latency_peak_ms = -1;
+    client->rig_result = CWNET_RIG_RESULT_NONE;
 
     /* Initialize timer */
     cwnet_timer_init(&client->timer);
@@ -435,10 +486,12 @@ void cwnet_client_on_connected(cwnet_client_t *client) {
     /* Reset parser for new connection */
     cwnet_frame_parser_reset(&client->parser);
 
-    /* A new session starts a new over: first transition waits 0 */
+    /* A new session starts a new over: first transition waits 0, PTT off */
     client->tx_ref_ms = 0;
     client->tx_filling = false;
     client->tx_key_down = false;
+    client->tx_last_edge_ms = 0;
+    client->ptt_on = false;
 
     /* Nothing received yet, and no latency known: the reference keeps both
      * across a reconnect, which is stale data with a fresh server. */
@@ -446,6 +499,7 @@ void cwnet_client_on_connected(cwnet_client_t *client) {
     client->rx_dropped = 0;
     client->latency_ms = -1;
     client->latency_peak_ms = -1;
+    client->rig_result = CWNET_RIG_RESULT_NONE;
 
     /* Transition to CONNECTING */
     set_state(client, CWNET_STATE_CONNECTING);
@@ -559,6 +613,14 @@ cwnet_client_err_t cwnet_client_send_key_event(cwnet_client_t *client,
         client->tx_ref_ms += (uint32_t)encoded_ms;
     }
     client->tx_key_down = key_down;
+    client->tx_last_edge_ms = (uint32_t)at_ms;
+
+    /* PTT rises with a key-down, right after its MORSE byte, as the
+     * reference's network poll orders them (CwNet.c:2616 then :2648). */
+    if (key_down && client->ptt_tail_ms > 0 && !client->ptt_on) {
+        client->ptt_on = true;
+        return send_rig_string(client, "set_ptt 1\n");
+    }
     return CWNET_CLIENT_OK;
 }
 
@@ -584,13 +646,34 @@ bool cwnet_client_abort_over(cwnet_client_t *client) {
             }
             client->tx_filling = false;
         }
+        if (client->ptt_on) {
+            if (send_rig_string(client, "set_ptt 0\n") != CWNET_CLIENT_OK) {
+                return false;
+            }
+            client->ptt_on = false;
+        }
     }
     /* Not READY: there is no session, so nothing is on the wire */
 
     client->tx_ref_ms = 0;
     client->tx_filling = false;
     client->tx_key_down = false;
+    client->ptt_on = false;
     return true;
+}
+
+void cwnet_client_set_ptt_tail_ms(cwnet_client_t *client, int32_t tail_ms) {
+    if (client != NULL) {
+        client->ptt_tail_ms = tail_ms > 0 ? tail_ms : 0;
+    }
+}
+
+bool cwnet_client_ptt_on_wire(const cwnet_client_t *client) {
+    return client != NULL && client->ptt_on;
+}
+
+int32_t cwnet_client_get_rig_result(const cwnet_client_t *client) {
+    return client == NULL ? CWNET_RIG_RESULT_NONE : client->rig_result;
 }
 
 bool cwnet_client_key_on_wire(const cwnet_client_t *client) {
@@ -665,7 +748,22 @@ bool cwnet_client_poll(cwnet_client_t *client, int32_t now_ms, int32_t dot_ms) {
     if (client == NULL || client->state != CWNET_STATE_READY) {
         return false;
     }
-    if (!client->tx_filling || client->tx_key_down) {
+    if (client->tx_key_down) {
+        return false;
+    }
+
+    /* PTT drops once the key has been up for the box's tail, whether or
+     * not the over is still open: below about 33 WPM it comes before the
+     * end of the over, above it after, as in the reference. */
+    if (client->ptt_on &&
+        (int32_t)((uint32_t)now_ms - client->tx_last_edge_ms) >= client->ptt_tail_ms) {
+        if (send_rig_string(client, "set_ptt 0\n") != CWNET_CLIENT_OK) {
+            return false;
+        }
+        client->ptt_on = false;
+    }
+
+    if (!client->tx_filling) {
         return false;
     }
 

--- a/components/keyer_cwnet/src/cwnet_feed.c
+++ b/components/keyer_cwnet/src/cwnet_feed.c
@@ -26,7 +26,8 @@ void cwnet_feed_init(cwnet_feed_t *feed, const keying_stream_t *stream, int64_t 
  * later pass retries before anything else goes out.
  */
 static void close_wire(cwnet_feed_t *feed, cwnet_client_t *client, cwnet_feed_result_t *result) {
-    bool open = cwnet_client_key_on_wire(client) || cwnet_client_over_open(client);
+    bool open = cwnet_client_key_on_wire(client) || cwnet_client_over_open(client) ||
+                cwnet_client_ptt_on_wire(client);
     if (cwnet_client_abort_over(client)) {
         feed->wire_stuck = false;
         if (open) {
@@ -83,6 +84,7 @@ cwnet_feed_result_t cwnet_feed_process(cwnet_feed_t *feed,
     if (feed == NULL || client == NULL || feed->consumer.stream == NULL) {
         return result;
     }
+    bool ptt_before = cwnet_client_ptt_on_wire(client);
 
     /* A previous pass could not close the over on the wire: nothing else
      * goes out before it is closed. */
@@ -132,5 +134,8 @@ cwnet_feed_result_t cwnet_feed_process(cwnet_feed_t *feed,
         }
     }
 
+    bool ptt_after = cwnet_client_ptt_on_wire(client);
+    result.ptt_on = ptt_after && !ptt_before;
+    result.ptt_off = !ptt_after && ptt_before;
     return result;
 }

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -357,6 +357,8 @@ void cwnet_socket_process(void) {
     {
         uint32_t wpm = (uint32_t)CONFIG_GET_WPM();
         int32_t dot_ms = wpm > 0 ? (int32_t)(1200u / wpm) : 0;
+        /* The wire mirrors the box's PTT, same tail as the local PTT line */
+        cwnet_client_set_ptt_tail_ms(&s_ctx.client, (int32_t)CONFIG_GET_PTT_TAIL_MS());
         int64_t feed_now_us = esp_timer_get_time();
         cwnet_feed_result_t r = cwnet_feed_process(&s_ctx.feed, &s_ctx.client, feed_now_us, dot_ms);
         if (r.aborted) {
@@ -370,6 +372,9 @@ void cwnet_socket_process(void) {
         }
         if (r.end_of_over) {
             RT_DEBUG(&g_bg_log_stream, feed_now_us, "CWNet TX: end of over");
+        }
+        if (r.ptt_on || r.ptt_off) {
+            RT_DEBUG(&g_bg_log_stream, feed_now_us, "CWNet TX: set_ptt %d", r.ptt_on ? 1 : 0);
         }
     }
 

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -746,6 +746,100 @@ void test_client_rx_ignores_ci_v_and_spectrum(void) {
 }
 
 /*===========================================================================*/
+/* PTT on the wire                                                          */
+/*===========================================================================*/
+
+static const uint8_t ptt_on_frame[]  = {0x46, 0x0B, 's', 'e', 't', '_', 'p', 't', 't', ' ', '1', '\n', 0x00};
+static const uint8_t ptt_off_frame[] = {0x46, 0x0B, 's', 'e', 't', '_', 'p', 't', 't', ' ', '0', '\n', 0x00};
+
+void test_client_tx_first_over_with_ptt_matches_reference_capture_whole(void) {
+    ready_client_accumulating();
+    cwnet_client_set_ptt_tail_ms(&client, 100);
+
+    /* The same edges as the filtered test; now the PTT strings come out too
+     * and the whole 41-byte slice of the capture is the expectation, in
+     * order: 0x80, set_ptt 1, 0x24, 0xA4, 0x3C, set_ptt 0, 0x60. The
+     * reference dropped its PTT 500 ms after the last key-up, we after our
+     * 100 ms tail; both before the end of the over at 25 WPM. */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1000));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1048));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  1096));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 1240));
+    TEST_ASSERT_TRUE(cwnet_client_ptt_on_wire(&client));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 1240 + 99, 48));
+    TEST_ASSERT_TRUE(cwnet_client_ptt_on_wire(&client));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 1240 + 100, 48));
+    TEST_ASSERT_FALSE(cwnet_client_ptt_on_wire(&client));
+    TEST_ASSERT_TRUE(cwnet_client_poll(&client, 1240 + 673, 48));
+
+    TEST_ASSERT_EQUAL(sizeof(ref_first_over), mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(ref_first_over, mock_tx_all, sizeof(ref_first_over));
+}
+
+void test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail(void) {
+    ready_client_accumulating();
+    cwnet_client_set_ptt_tail_ms(&client, 100);
+
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  0));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 48));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 90, 48));          /* 42 ms up: PTT stays */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  96));
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, false, 240));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 339, 48));
+    TEST_ASSERT_FALSE(cwnet_client_poll(&client, 340, 48));         /* tail: set_ptt 0 */
+    /* The over is still open (14 dot-times not reached): the key-down
+     * carries its wait, and PTT rises again right after it */
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true,  400));
+
+    uint8_t expected[128];
+    size_t n = 0;
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x80}, 3); n += 3;
+    memcpy(expected + n, ptt_on_frame, sizeof(ptt_on_frame)); n += sizeof(ptt_on_frame);
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x24}, 3); n += 3;
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0xA4}, 3); n += 3;
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x3C}, 3); n += 3;
+    memcpy(expected + n, ptt_off_frame, sizeof(ptt_off_frame)); n += sizeof(ptt_off_frame);
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0xC0}, 3); n += 3;   /* down after 160 ms */
+    memcpy(expected + n, ptt_on_frame, sizeof(ptt_on_frame)); n += sizeof(ptt_on_frame);
+    TEST_ASSERT_EQUAL(n, mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, n);
+}
+
+void test_client_abort_over_drops_ptt_too(void) {
+    ready_client_accumulating();
+    cwnet_client_set_ptt_tail_ms(&client, 100);
+
+    TEST_ASSERT_EQUAL(CWNET_CLIENT_OK, cwnet_client_send_key_event(&client, true, 0));
+    TEST_ASSERT_TRUE(cwnet_client_abort_over(&client));
+    TEST_ASSERT_FALSE(cwnet_client_ptt_on_wire(&client));
+
+    uint8_t expected[64];
+    size_t n = 0;
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x80}, 3); n += 3;
+    memcpy(expected + n, ptt_on_frame, sizeof(ptt_on_frame)); n += sizeof(ptt_on_frame);
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x00}, 3); n += 3;   /* key up, now */
+    memcpy(expected + n, (uint8_t[]){0x50, 0x01, 0x00}, 3); n += 3;   /* end of over */
+    memcpy(expected + n, ptt_off_frame, sizeof(ptt_off_frame)); n += sizeof(ptt_off_frame);
+    TEST_ASSERT_EQUAL(n, mock_tx_all_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, mock_tx_all, n);
+}
+
+void test_client_rx_keeps_the_rig_result(void) {
+    ready_client_accumulating();
+    TEST_ASSERT_EQUAL(CWNET_RIG_RESULT_NONE, cwnet_client_get_rig_result(&client));
+
+    /* The server's answer in the capture: "RPRT 0\n" with its NUL */
+    static const uint8_t ok[] = {0x46, 0x08, 'R', 'P', 'R', 'T', ' ', '0', '\n', 0x00};
+    cwnet_client_on_data(&client, ok, sizeof(ok));
+    TEST_ASSERT_EQUAL(0, cwnet_client_get_rig_result(&client));
+
+    /* What CwNet_Rigctld_OnSetPTT returns without TRANSMIT: -11 */
+    static const uint8_t refused[] = {0x46, 0x0A, 'R', 'P', 'R', 'T', ' ', '-', '1', '1', '\n', 0x00};
+    cwnet_client_on_data(&client, refused, sizeof(refused));
+    TEST_ASSERT_EQUAL(-11, cwnet_client_get_rig_result(&client));
+}
+
+/*===========================================================================*/
 /* Determinism: what we send comes back as what we sent                     */
 /*===========================================================================*/
 
@@ -987,6 +1081,10 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
     RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
     RUN_TEST(test_client_round_trip_returns_the_edges_sent);
+    RUN_TEST(test_client_tx_first_over_with_ptt_matches_reference_capture_whole);
+    RUN_TEST(test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail);
+    RUN_TEST(test_client_abort_over_drops_ptt_too);
+    RUN_TEST(test_client_rx_keeps_the_rig_result);
     RUN_TEST(test_client_rejects_events_when_not_ready);
 
     /* Error Handling */

--- a/test_host/test_cwnet_feed.c
+++ b/test_host/test_cwnet_feed.c
@@ -122,24 +122,25 @@ void test_feed_waits_are_tick_distances_whatever_the_drain(void) {
 void test_feed_first_over_from_stream_matches_reference_capture(void) {
     setup_stream();
     setup_client(true);
+    cwnet_client_set_ptt_tail_ms(&s_client, 100);   /* the box's timing.ptt_tail_ms default */
     cwnet_feed_init(&s_feed, &s_stream, 0);
 
     key_for_ticks(0, 100);
     key_letter_a();
     cwnet_feed_result_t r = cwnet_feed_process(&s_feed, &s_client, 1000000, 48);
     TEST_ASSERT_EQUAL(4, r.edges);
+    TEST_ASSERT_TRUE(r.ptt_on);
 
     /* Nothing else happens on the key: 673 ms later on the caller's clock
-     * the over is closed, on stream time aged by that clock. */
+     * PTT has been up past its tail and the over is closed, on stream time
+     * aged by that clock, in that order. */
     r = cwnet_feed_process(&s_feed, &s_client, 1000000 + 673000, 48);
+    TEST_ASSERT_TRUE(r.ptt_off);
     TEST_ASSERT_TRUE(r.end_of_over);
 
-    uint8_t expected[sizeof(ref_first_over)];
-    size_t expected_len = 0;
-    TEST_ASSERT_TRUE(ref_morse_frames(ref_first_over, sizeof(ref_first_over),
-                                      expected, &expected_len));
-    TEST_ASSERT_EQUAL(expected_len, s_tx_len);
-    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, s_tx, expected_len);
+    /* The whole slice of the capture, PTT strings included */
+    TEST_ASSERT_EQUAL(sizeof(ref_first_over), s_tx_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(ref_first_over, s_tx, sizeof(ref_first_over));
 }
 
 void test_feed_idle_stream_ages_on_the_caller_clock(void) {

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -239,6 +239,10 @@ void test_client_rx_fifo_full_drops_and_counts(void);
 void test_client_rx_ignores_ci_v_and_spectrum(void);
 void test_client_latency_peak_holds_and_decays_like_the_reference(void);
 void test_client_round_trip_returns_the_edges_sent(void);
+void test_client_tx_first_over_with_ptt_matches_reference_capture_whole(void);
+void test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail(void);
+void test_client_abort_over_drops_ptt_too(void);
+void test_client_rx_keeps_the_rig_result(void);
 void test_client_rejects_events_when_not_ready(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
@@ -547,6 +551,10 @@ int main(void) {
     RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
     RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
     RUN_TEST(test_client_round_trip_returns_the_edges_sent);
+    RUN_TEST(test_client_tx_first_over_with_ptt_matches_reference_capture_whole);
+    RUN_TEST(test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail);
+    RUN_TEST(test_client_abort_over_drops_ptt_too);
+    RUN_TEST(test_client_rx_keeps_the_rig_result);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);


### PR DESCRIPTION
## What changes

PTT on the wire mirrors the box's own PTT. `set_ptt 1` goes out in a 0x06 string right after the MORSE byte of the key-down that raises it, `set_ptt 0` once the key has been up for `timing.ptt_tail_ms` (default 100 ms), from `cwnet_client_poll()` on the same stream time as the end of the over; a forced close drops it too. The server's `RPRT n` is parsed and kept (`cwnet_client_get_rig_result()`, -11 when the user may not transmit). No new parameter.

Decision, written in #13: the tail is the box's, not the reference's 500 ms hang. The server applies the string on arrival and plays the keying after its latency buffer (250 ms by default), so the `1` leads the first element by that buffer whatever our tail; its own hang time decides when the radio's PTT drops, so a tail longer than the buffer only adds to it. Alternative rejected: a second timer for the wire.

## Closes

#13. Condition: the box drives PTT this way and emits and accepts the 0x06 strings around an over. Holds in `components/keyer_cwnet/src/cwnet_client.c`: `send_rig_string()`, the tail in `cwnet_client_poll()`, `handle_rig_string()`.

## Definition of done

- Host tests: 205/205 plain, 205/205 ASan/UBSan. Was 201: four added, one upgraded.
- Reference test: the pin on the first over of session 12 of the 2026-09-05 capture is now the whole 41-byte client→server slice, PTT strings included, with no filtering: `test_client_tx_first_over_with_ptt_matches_reference_capture_whole` from the client, `test_feed_first_over_from_stream_matches_reference_capture` from a real `keying_stream_t`. Frame order matches the reference at 25 WPM: `0x80`, `set_ptt 1`, keying, `set_ptt 0`, end of over. The instant of `set_ptt 0` differs (our 100 ms tail, its 500 ms hang); the bench keeps PTT outside the byte equality by design (R7).
- RT path: untouched.
- Blocking issues open on this work: none.

## Not done here

- Above about 33 WPM `set_ptt 0` follows the end of the over, as in the reference; not pinned by a capture.
- The `RPRT` result is kept, not shown: #26.
- Firmware build checked by CI only.
