### PR TITLE
CWNet: the box knows who has the server's key

### DIFF
--- a/.claude/code-quality.md
+++ b/.claude/code-quality.md
@@ -11,7 +11,7 @@
 
 ## Da sistemare
 - `.devcontainer/Dockerfile`: `ARG DOCKER_TAG=v5.5.1` e path `idf5.5_py3.12_env` hardcoded — non aggiornati dopo la migrazione a IDF v6. Da verificare su un'immagine `espressif/idf:v6.x` prima di cambiare.
-- `test_host/CLAUDE.md` e `components/keyer_core/CLAUDE.md` (blocchi `treecode` auto) nominano ancora `keyer_iambic` come dipendenza in-tree: dal 2026-09-06 è il submodule `Esp32KeyerTest`. `components/keyer_cwnet/CLAUDE.md` dice ancora che è `bg_task` a passare gli eventi di keying: dal 2026-09-07 il modulo consuma lo stream da sé (`cwnet_feed`, #55). Si risincronizzano con `map-tree`, non a mano.
+- `test_host/CLAUDE.md` e `components/keyer_core/CLAUDE.md` (blocchi `treecode` auto) nominano ancora `keyer_iambic` come dipendenza in-tree: dal 2026-09-06 è il submodule `Esp32KeyerTest`. `components/keyer_cwnet/CLAUDE.md` dice ancora che è `bg_task` a passare gli eventi di keying: dal 2026-09-07 il modulo consuma lo stream da sé (`cwnet_feed`, #55); e che la config viene solo da `g_config.remote`: dal 2026-09-08 il CONNECT porta `g_config.system.callsign` (#25). Si risincronizzano con `map-tree`, non a mano.
 - `sample_silence()` clampa il marker a `UINT16_MAX`: oltre 65,5 s di stream immutato i tick in eccesso spariscono dal marker e il tempo di stream ricostruito da un consumer (`cwnet_feed`) resta indietro. Innocuo finché il fine over chiude l'over; il rimedio è che `stream_push` scarichi il marker quando `idle_ticks` arriva a `UINT16_MAX` (RT path, un confronto per tick, test host possibile).
 - Ramo remoto `k8-differential-bench` (`fae2f57`), senza PR: lo scheletro del banco è migrato in Esp32KeyerTest, `FINDINGS.md` (numeri superati) vive solo lì. Da cancellare quando nessuno lo cita più.
 

--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -44,6 +44,15 @@
  * and plays the keying after its latency buffer, so the "1" leads the first
  * element by that buffer; its own hang time decides when the radio's PTT
  * drops, not our "0". The server answers "RPRT 0", or a negative code.
+ *
+ * Who has the key (reference: CwNet.c, iTransmittingClient): the server
+ * plays the keying of one client at a time and drops every other client's
+ * MORSE bytes without a word. Nothing is sent to claim the key: the first
+ * MORSE byte to arrive while nobody holds it takes it, a 1 s stopwatch on
+ * the server hands it back to nobody, and every change is announced to all
+ * clients in a TX_INFO 0x05 frame. The client keeps the last announcement
+ * and says whether the key is free, ours or somebody else's; it keys
+ * regardless (#25), and the box signals the state.
  */
 
 #pragma once
@@ -81,6 +90,7 @@ typedef enum {
     CWNET_CMD_CONNECT = 0x01,   /**< Client -> Server request; echoed back by the server to confirm */
     CWNET_CMD_DISCONNECT = 0x02,/**< Bidirectional: disconnect */
     CWNET_CMD_PING = 0x03,      /**< Bidirectional: time sync */
+    CWNET_CMD_TX_INFO = 0x05,   /**< Server -> all clients: who has the key; index byte + callsign with NUL */
     CWNET_CMD_RIG_STRING = 0x06,/**< ASCII rig-control string with a trailing NUL: "set_ptt 0|1\n" from us, "RPRT n\n" back */
     CWNET_CMD_MORSE = 0x10,     /**< Keying: 7-bit stream, bit 7 = key state, bits 6..0 = wait */
     CWNET_CMD_CI_V = 0x14,      /**< A single CI-V packet (Icom rig control). Not keying. */
@@ -109,6 +119,31 @@ typedef enum {
 #define CWNET_PERMISSION_TRANSMIT  0x02u  /**< May transmit (CW) */
 #define CWNET_PERMISSION_CTRL_RIG  0x04u  /**< May control the remote rig */
 #define CWNET_PERMISSION_ADMIN     0x08u  /**< Is the server administrator */
+
+/*===========================================================================*/
+/* Who has the key                                                           */
+/*===========================================================================*/
+
+/** Longest TX_INFO payload the reference accepts (CwNet.c, case CWNET_CMD_TX_INFO): 2..80 bytes */
+#define CWNET_TX_INFO_MAX_LEN 80
+
+/** The announced name, NUL included: the payload minus its index byte fits */
+#define CWNET_KEY_HOLDER_NAME_LEN CWNET_TX_INFO_MAX_LEN
+
+/**
+ * @brief Who holds the server's single key, from its last TX_INFO
+ *
+ * The index byte is the server's client index: negative for nobody, 0 for
+ * the server's own operator (CWNET_LOCAL_CLIENT_INDEX), 1 and up for remote
+ * clients. The name is the holder's callsign as it sent it in CONNECT, so
+ * "mine" is a remote index and a callsign equal to the one we sent.
+ */
+typedef enum {
+    CWNET_KEY_HOLDER_UNKNOWN = 0,  /**< No announcement yet in this session */
+    CWNET_KEY_HOLDER_FREE,         /**< "-- nobody --": the next MORSE byte takes it */
+    CWNET_KEY_HOLDER_MINE,         /**< We hold it: our keying is played */
+    CWNET_KEY_HOLDER_OTHER,        /**< The sysop or another client: our keying is dropped */
+} cwnet_key_holder_t;
 
 /*===========================================================================*/
 /* Received keying                                                           */
@@ -216,6 +251,7 @@ typedef struct {
     const char *server_host;            /**< Server hostname/IP (required) */
     uint16_t server_port;               /**< Server port (required) */
     const char *username;               /**< Username for logging (case sensitive) */
+    const char *callsign;               /**< Callsign for the CONNECT record; NULL or empty = the username */
 
     /* Required callbacks */
     cwnet_send_cb_t send_cb;            /**< Send data callback (required) */
@@ -241,6 +277,7 @@ typedef struct {
     char server_host[CWNET_MAX_HOST_LEN];
     uint16_t server_port;
     char username[CWNET_MAX_USERNAME_LEN];
+    char callsign[CWNET_MAX_USERNAME_LEN]; /**< What we put in the CONNECT callsign field */
 
     /* Callbacks */
     cwnet_send_cb_t send_cb;
@@ -260,6 +297,12 @@ typedef struct {
 
     /* Permissions granted by the server in its CONNECT echo */
     uint32_t permissions;
+
+    /* Who has the key, from the server's last TX_INFO */
+    cwnet_key_holder_t key_holder;
+    int8_t key_holder_index;     /**< The announced index; -1 until one arrives */
+    char key_holder_name[CWNET_KEY_HOLDER_NAME_LEN]; /**< The announced callsign, "" until one arrives */
+    uint32_t key_announcements;  /**< TX_INFO frames taken this session */
 
     /* Keying received in MORSE frames, oldest first */
     cwnet_rx_fifo_t rx;
@@ -420,6 +463,35 @@ void cwnet_client_on_disconnected(cwnet_client_t *client);
  * @return uint32_t Granted permission bitmask, 0 if client is NULL
  */
 uint32_t cwnet_client_get_permissions(const cwnet_client_t *client);
+
+/**
+ * @brief Who holds the key, from the server's last TX_INFO
+ *
+ * Reported as announced, with no timer of ours: during an over the
+ * reference alternates between us and nobody every second, and both mean
+ * our next byte is played. OTHER is the state to signal.
+ *
+ * @param client Client context
+ * @return The holder, UNKNOWN if client is NULL or nothing was announced yet
+ */
+cwnet_key_holder_t cwnet_client_get_key_holder(const cwnet_client_t *client);
+
+/**
+ * @brief The name the server announced with the key
+ *
+ * The holder's callsign, or "-- nobody --", or "The Sysop": the text the
+ * reference client shows as "On the key now".
+ *
+ * @param client Client context
+ * @return NUL-terminated, "" until the first announcement or if client is NULL
+ */
+const char *cwnet_client_get_key_holder_name(const cwnet_client_t *client);
+
+/** @return TX_INFO frames taken this session, 0 if client is NULL */
+uint32_t cwnet_client_get_key_announcements(const cwnet_client_t *client);
+
+/** @return "unknown", "free", "mine" or "other" */
+const char *cwnet_client_key_holder_str(cwnet_key_holder_t holder);
 
 void cwnet_client_on_data(cwnet_client_t *client,
                            const uint8_t *data,

--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -300,7 +300,6 @@ typedef struct {
 
     /* Who has the key, from the server's last TX_INFO */
     cwnet_key_holder_t key_holder;
-    int8_t key_holder_index;     /**< The announced index; -1 until one arrives */
     char key_holder_name[CWNET_KEY_HOLDER_NAME_LEN]; /**< The announced callsign, "" until one arrives */
     uint32_t key_announcements;  /**< TX_INFO frames taken this session */
 

--- a/components/keyer_cwnet/include/cwnet_socket.h
+++ b/components/keyer_cwnet/include/cwnet_socket.h
@@ -76,6 +76,17 @@ int32_t cwnet_socket_get_latency_ms(void);
 int32_t cwnet_socket_get_latency_peak_ms(void);
 
 /**
+ * @brief Who has the server's key, from its last TX_INFO
+ *
+ * OTHER means the server is dropping our keying (#25); the box keys anyway
+ * and signals it. UNKNOWN when disabled, not connected, or not announced yet.
+ */
+cwnet_key_holder_t cwnet_socket_get_key_holder(void);
+
+/** @return The announced name ("-- nobody --", a callsign, "The Sysop"), "" if none */
+const char *cwnet_socket_get_key_holder_name(void);
+
+/**
  * @brief Get state as string (for logging)
  */
 const char *cwnet_socket_state_str(cwnet_socket_state_t state);

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -337,7 +337,6 @@ static void handle_rig_string(cwnet_client_t *client, const uint8_t *payload, si
  */
 static void forget_key_holder(cwnet_client_t *client) {
     client->key_holder = CWNET_KEY_HOLDER_UNKNOWN;
-    client->key_holder_index = -1;
     client->key_holder_name[0] = '\0';
     client->key_announcements = 0;
 }
@@ -360,7 +359,6 @@ static void handle_tx_info(cwnet_client_t *client, const uint8_t *payload, size_
         n++;
     }
     client->key_holder_name[n] = '\0';
-    client->key_holder_index = index;
 
     cwnet_key_holder_t was = client->key_holder;
     if (index < 0) {
@@ -375,15 +373,9 @@ static void handle_tx_info(cwnet_client_t *client, const uint8_t *payload, size_
     /* The mine/free alternation is the server's timer at work, once a
      * second during an over: noise at INFO. Somebody else taking or leaving
      * the key is what the operator must know. */
-    int64_t now_us = esp_timer_get_time();
     bool other_changed = (was == CWNET_KEY_HOLDER_OTHER) != (client->key_holder == CWNET_KEY_HOLDER_OTHER);
-    if (other_changed) {
-        RT_INFO(&g_bg_log_stream, now_us, "CWNet key: %s (%s)",
-                cwnet_client_key_holder_str(client->key_holder), client->key_holder_name);
-    } else {
-        RT_DEBUG(&g_bg_log_stream, now_us, "CWNet key: %s (%s)",
-                 cwnet_client_key_holder_str(client->key_holder), client->key_holder_name);
-    }
+    RT_LOG(&g_bg_log_stream, other_changed ? LOG_LEVEL_INFO : LOG_LEVEL_DEBUG, esp_timer_get_time(),
+           "CWNet key: %s (%s)", cwnet_client_key_holder_str(client->key_holder), client->key_holder_name);
 }
 
 /**
@@ -449,6 +441,18 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
 /* Public API                                                                */
 /*===========================================================================*/
 
+/**
+ * @brief Copy a C string into a fixed buffer, truncated to fit, always terminated
+ */
+static void copy_string(char *dst, size_t dst_size, const char *src) {
+    size_t len = strlen(src);
+    if (len >= dst_size) {
+        len = dst_size - 1;
+    }
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+}
+
 cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
                                       const cwnet_client_config_t *config) {
     if (client == NULL || config == NULL) {
@@ -467,33 +471,16 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     memset(client, 0, sizeof(*client));
 
     /* Copy configuration */
-    size_t host_len = strlen(config->server_host);
-    if (host_len >= CWNET_MAX_HOST_LEN) {
-        host_len = CWNET_MAX_HOST_LEN - 1;
-    }
-    memcpy(client->server_host, config->server_host, host_len);
-    client->server_host[host_len] = '\0';
-
+    copy_string(client->server_host, sizeof(client->server_host), config->server_host);
     client->server_port = config->server_port;
-
     if (config->username != NULL) {
-        size_t user_len = strlen(config->username);
-        if (user_len >= CWNET_MAX_USERNAME_LEN) {
-            user_len = CWNET_MAX_USERNAME_LEN - 1;
-        }
-        memcpy(client->username, config->username, user_len);
-        client->username[user_len] = '\0';
+        copy_string(client->username, sizeof(client->username), config->username);
     }
 
     /* The callsign the server will announce us by; the username when none */
     const char *callsign = (config->callsign != NULL && config->callsign[0] != '\0')
                            ? config->callsign : client->username;
-    size_t call_len = strlen(callsign);
-    if (call_len >= sizeof(client->callsign)) {
-        call_len = sizeof(client->callsign) - 1;
-    }
-    memcpy(client->callsign, callsign, call_len);
-    client->callsign[call_len] = '\0';
+    copy_string(client->callsign, sizeof(client->callsign), callsign);
 
     /* Set callbacks */
     client->send_cb = config->send_cb;

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -90,8 +90,11 @@ static cwnet_client_err_t send_connect(cwnet_client_t *client) {
     size_t username_len = strlen(client->username);
     memcpy(&frame[2], client->username, username_len);
 
-    /* Callsign field (44 bytes) - use same as username for now */
-    memcpy(&frame[2 + CWNET_CONNECT_USERNAME_LEN], client->username, username_len);
+    /* Callsign field (44 bytes). The server keeps it as the name it announces
+     * with the key (CwNet.c:1295) and strips TRANSMIT if it is empty. */
+    _Static_assert(sizeof(((cwnet_client_t *)0)->callsign) <= CWNET_CONNECT_CALLSIGN_LEN,
+                   "callsign buffer must fit in connect frame field");
+    memcpy(&frame[2 + CWNET_CONNECT_USERNAME_LEN], client->callsign, strlen(client->callsign));
 
     /* Permissions field (4 bytes) - leave as zero */
 
@@ -330,6 +333,60 @@ static void handle_rig_string(cwnet_client_t *client, const uint8_t *payload, si
 }
 
 /**
+ * @brief Forget who had the key: a new session announces it afresh
+ */
+static void forget_key_holder(cwnet_client_t *client) {
+    client->key_holder = CWNET_KEY_HOLDER_UNKNOWN;
+    client->key_holder_index = -1;
+    client->key_holder_name[0] = '\0';
+    client->key_announcements = 0;
+}
+
+/**
+ * @brief Take the server's announcement of who has the key
+ *
+ * CwNet.c, case CWNET_CMD_TX_INFO: a payload of 2..80 bytes, the index as
+ * a signed char, then the callsign, copied up to 80 bytes. The reference
+ * client only displays it; we derive free / mine / other from it.
+ */
+static void handle_tx_info(cwnet_client_t *client, const uint8_t *payload, size_t len) {
+    if (len < 2 || len > CWNET_TX_INFO_MAX_LEN) {
+        return;
+    }
+    int8_t index = (int8_t)payload[0];
+    size_t n = 0;
+    while (n < len - 1 && n < CWNET_KEY_HOLDER_NAME_LEN - 1 && payload[1 + n] != '\0') {
+        client->key_holder_name[n] = (char)payload[1 + n];
+        n++;
+    }
+    client->key_holder_name[n] = '\0';
+    client->key_holder_index = index;
+
+    cwnet_key_holder_t was = client->key_holder;
+    if (index < 0) {
+        client->key_holder = CWNET_KEY_HOLDER_FREE;
+    } else if (index >= 1 && strcmp(client->key_holder_name, client->callsign) == 0) {
+        client->key_holder = CWNET_KEY_HOLDER_MINE;
+    } else {
+        client->key_holder = CWNET_KEY_HOLDER_OTHER;
+    }
+    client->key_announcements++;
+
+    /* The mine/free alternation is the server's timer at work, once a
+     * second during an over: noise at INFO. Somebody else taking or leaving
+     * the key is what the operator must know. */
+    int64_t now_us = esp_timer_get_time();
+    bool other_changed = (was == CWNET_KEY_HOLDER_OTHER) != (client->key_holder == CWNET_KEY_HOLDER_OTHER);
+    if (other_changed) {
+        RT_INFO(&g_bg_log_stream, now_us, "CWNet key: %s (%s)",
+                cwnet_client_key_holder_str(client->key_holder), client->key_holder_name);
+    } else {
+        RT_DEBUG(&g_bg_log_stream, now_us, "CWNet key: %s (%s)",
+                 cwnet_client_key_holder_str(client->key_holder), client->key_holder_name);
+    }
+}
+
+/**
  * @brief Queue every byte of a MORSE frame as a received keying event
  *
  * The reference does this per byte as it parses (CwNet.c:2875-2902,
@@ -378,6 +435,10 @@ static void process_frame(cwnet_client_t *client, const cwnet_parse_result_t *re
             handle_rig_string(client, payload, payload_len);
             break;
 
+        case CWNET_CMD_TX_INFO:
+            handle_tx_info(client, payload, payload_len);
+            break;
+
         default:
             /* Not handled, ignore */
             break;
@@ -424,6 +485,16 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
         client->username[user_len] = '\0';
     }
 
+    /* The callsign the server will announce us by; the username when none */
+    const char *callsign = (config->callsign != NULL && config->callsign[0] != '\0')
+                           ? config->callsign : client->username;
+    size_t call_len = strlen(callsign);
+    if (call_len >= sizeof(client->callsign)) {
+        call_len = sizeof(client->callsign) - 1;
+    }
+    memcpy(client->callsign, callsign, call_len);
+    client->callsign[call_len] = '\0';
+
     /* Set callbacks */
     client->send_cb = config->send_cb;
     client->get_time_ms_cb = config->get_time_ms_cb;
@@ -435,6 +506,7 @@ cwnet_client_err_t cwnet_client_init(cwnet_client_t *client,
     client->latency_ms = -1;
     client->latency_peak_ms = -1;
     client->rig_result = CWNET_RIG_RESULT_NONE;
+    forget_key_holder(client);
 
     /* Initialize timer */
     cwnet_timer_init(&client->timer);
@@ -450,6 +522,37 @@ uint32_t cwnet_client_get_permissions(const cwnet_client_t *client) {
         return 0;
     }
     return client->permissions;
+}
+
+cwnet_key_holder_t cwnet_client_get_key_holder(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return CWNET_KEY_HOLDER_UNKNOWN;
+    }
+    return client->key_holder;
+}
+
+const char *cwnet_client_get_key_holder_name(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return "";
+    }
+    return client->key_holder_name;
+}
+
+uint32_t cwnet_client_get_key_announcements(const cwnet_client_t *client) {
+    if (client == NULL) {
+        return 0;
+    }
+    return client->key_announcements;
+}
+
+const char *cwnet_client_key_holder_str(cwnet_key_holder_t holder) {
+    switch (holder) {
+        case CWNET_KEY_HOLDER_FREE:  return "free";
+        case CWNET_KEY_HOLDER_MINE:  return "mine";
+        case CWNET_KEY_HOLDER_OTHER: return "other";
+        case CWNET_KEY_HOLDER_UNKNOWN:
+        default:                     return "unknown";
+    }
 }
 
 cwnet_client_state_t cwnet_client_get_state(const cwnet_client_t *client) {
@@ -500,6 +603,7 @@ void cwnet_client_on_connected(cwnet_client_t *client) {
     client->latency_ms = -1;
     client->latency_peak_ms = -1;
     client->rig_result = CWNET_RIG_RESULT_NONE;
+    forget_key_holder(client);
 
     /* Transition to CONNECTING */
     set_state(client, CWNET_STATE_CONNECTING);
@@ -515,6 +619,9 @@ void cwnet_client_on_disconnected(cwnet_client_t *client) {
 
     /* Reset parser */
     cwnet_frame_parser_reset(&client->parser);
+
+    /* No link, no key: the next session's server announces it afresh */
+    forget_key_holder(client);
 
     /* Transition to DISCONNECTED */
     set_state(client, CWNET_STATE_DISCONNECTED);

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -46,6 +46,7 @@ static struct {
     char host[CWNET_MAX_HOST_LEN];
     uint16_t port;
     char username[CWNET_MAX_USERNAME_LEN];
+    char callsign[CWNET_MAX_USERNAME_LEN];
     bool enabled;
     bool send_failed;   /**< A send() in this pass did not go out whole */
 } s_ctx;
@@ -267,6 +268,9 @@ void cwnet_socket_init(const keying_stream_t *keying_stream) {
     strncpy(s_ctx.host, g_config.remote.server_host, sizeof(s_ctx.host) - 1);
     s_ctx.port = g_config.remote.server_port;
     strncpy(s_ctx.username, g_config.remote.username, sizeof(s_ctx.username) - 1);
+    /* The server announces the key holder by callsign, and strips TRANSMIT
+     * from a client that sent none: the client falls back to the username. */
+    strncpy(s_ctx.callsign, g_config.system.callsign, sizeof(s_ctx.callsign) - 1);
 
     /* Validate */
     if (s_ctx.host[0] == '\0') {
@@ -281,6 +285,7 @@ void cwnet_socket_init(const keying_stream_t *keying_stream) {
         .server_host = s_ctx.host,
         .server_port = s_ctx.port,
         .username = s_ctx.username,
+        .callsign = s_ctx.callsign,
         .send_cb = socket_send_cb,
         .get_time_ms_cb = get_time_ms_cb,
         .state_change_cb = state_change_cb,
@@ -406,6 +411,14 @@ int32_t cwnet_socket_get_latency_ms(void) {
 
 int32_t cwnet_socket_get_latency_peak_ms(void) {
     return cwnet_client_get_latency_peak_ms(&s_ctx.client);
+}
+
+cwnet_key_holder_t cwnet_socket_get_key_holder(void) {
+    return cwnet_client_get_key_holder(&s_ctx.client);
+}
+
+const char *cwnet_socket_get_key_holder_name(void) {
+    return cwnet_client_get_key_holder_name(&s_ctx.client);
 }
 
 const char *cwnet_socket_state_str(cwnet_socket_state_t state) {

--- a/components/keyer_webui/src/api_system.c
+++ b/components/keyer_webui/src/api_system.c
@@ -47,6 +47,9 @@ esp_err_t api_status_handler(httpd_req_t *req) {
     cJSON_AddStringToObject(cwnet, "state", cwnet_socket_state_str(cwnet_state));
     cJSON_AddNumberToObject(cwnet, "latency_ms", cwnet_socket_get_latency_ms());
     cJSON_AddNumberToObject(cwnet, "latency_peak_ms", cwnet_socket_get_latency_peak_ms());
+    cJSON_AddStringToObject(cwnet, "key_holder",
+                            cwnet_client_key_holder_str(cwnet_socket_get_key_holder()));
+    cJSON_AddStringToObject(cwnet, "key_holder_name", cwnet_socket_get_key_holder_name());
     cJSON_AddItemToObject(root, "cwnet", cwnet);
 
     char *json_str = cJSON_PrintUnformatted(root);

--- a/main/bg_task.c
+++ b/main/bg_task.c
@@ -253,8 +253,10 @@ void bg_task(void *arg) {
             if (cwnet_state != CWNET_SOCK_DISABLED) {
                 int32_t latency = cwnet_socket_get_latency_ms();
                 if (latency >= 0) {
-                    RT_INFO(&g_bg_log_stream, now_us, "CWNet: %s, latency=%"PRId32"ms",
-                            cwnet_socket_state_str(cwnet_state), latency);
+                    RT_INFO(&g_bg_log_stream, now_us, "CWNet: %s, latency=%"PRId32"ms, key %s (%s)",
+                            cwnet_socket_state_str(cwnet_state), latency,
+                            cwnet_client_key_holder_str(cwnet_socket_get_key_holder()),
+                            cwnet_socket_get_key_holder_name());
                 } else {
                     RT_INFO(&g_bg_log_stream, now_us, "CWNet: %s",
                             cwnet_socket_state_str(cwnet_state));

--- a/test_host/cwnet_fixtures.h
+++ b/test_host/cwnet_fixtures.h
@@ -54,6 +54,24 @@ static const uint8_t ref_first_over[] = {
     0x50, 0x01, 0x60,                                     /* end of over, 669 ms   */
 };
 
+/*
+ * The server's announcements of who has the key, CWNET_CMD_TX_INFO 0x05:
+ * one signed index byte, then the holder's callsign with its NUL. The three
+ * payloads the 2026-09-05 capture carries, bytes verbatim.
+ *   Session 12, server-to-client 169..184: nobody has the key (index -1).
+ *   Session 12, server-to-client 465..474: remote client 1, "Moritz".
+ *   Session 10, server-to-client 239..251: the server's own operator, index 0.
+ */
+static const uint8_t ref_tx_info_nobody[] = {
+    0x45, 0x0E, 0xFF, '-', '-', ' ', 'n', 'o', 'b', 'o', 'd', 'y', ' ', '-', '-', 0x00,
+};
+static const uint8_t ref_tx_info_moritz[] = {
+    0x45, 0x08, 0x01, 'M', 'o', 'r', 'i', 't', 'z', 0x00,
+};
+static const uint8_t ref_tx_info_sysop[] = {
+    0x45, 0x0B, 0x00, 'T', 'h', 'e', ' ', 'S', 'y', 's', 'o', 'p', 0x00,
+};
+
 /**
  * @brief Copy the raw bytes of every MORSE frame of a capture slice, in order
  *

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -938,6 +938,87 @@ void test_client_key_holder_ignores_malformed_tx_info(void) {
     cwnet_client_on_data(&client, no_nul, sizeof(no_nul));
     TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
     TEST_ASSERT_EQUAL_STRING("Mo", cwnet_client_get_key_holder_name(&client));
+
+    /* A NUL inside the length bound ends the name there, as the reference's
+     * strncpy does; the bytes after it are not the name */
+    static const uint8_t early_nul[] = {0x45, 0x07, 0x01, 'M', 'o', 0x00, 'r', 'i', 'X'};
+    cwnet_client_on_data(&client, early_nul, sizeof(early_nul));
+    TEST_ASSERT_EQUAL_STRING("Mo", cwnet_client_get_key_holder_name(&client));
+    TEST_ASSERT_EQUAL(3, cwnet_client_get_key_announcements(&client));
+}
+
+void test_client_callsign_goes_on_the_wire_and_decides_mine(void) {
+    /* The box logs in under one name and is known by another: the server
+     * stores the callsign field of CONNECT (CwNet.c:1295) and announces the
+     * key holder by it, so "mine" is decided on the callsign, never on the
+     * login name. */
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "op1",
+        .callsign = "IU3QEZ",
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+    test_setup();
+    mock_tx_all_len = 0;
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+
+    /* The CONNECT record: username at 2, callsign at 2 + 44, both NUL-padded */
+    TEST_ASSERT_EQUAL(2 + CWNET_CONNECT_PAYLOAD_LEN, mock_tx_all_len);
+    TEST_ASSERT_EQUAL_MEMORY("op1\0", &mock_tx_all[2], 4);
+    TEST_ASSERT_EQUAL_MEMORY("IU3QEZ\0", &mock_tx_all[2 + CWNET_CONNECT_USERNAME_LEN], 7);
+    feed_connect_echo();
+
+    static const uint8_t by_callsign[] = {0x45, 0x08, 0x01, 'I', 'U', '3', 'Q', 'E', 'Z', 0x00};
+    cwnet_client_on_data(&client, by_callsign, sizeof(by_callsign));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+
+    static const uint8_t by_username[] = {0x45, 0x05, 0x01, 'o', 'p', '1', 0x00};
+    cwnet_client_on_data(&client, by_username, sizeof(by_username));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+}
+
+void test_client_callsign_falls_back_to_the_username(void) {
+    /* No callsign configured: the username goes in the field, as before,
+     * because a client without a callsign is stripped of TRANSMIT */
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "op1",
+        .callsign = "",
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+    test_setup();
+    mock_tx_all_len = 0;
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+    TEST_ASSERT_EQUAL_MEMORY("op1\0", &mock_tx_all[2 + CWNET_CONNECT_USERNAME_LEN], 4);
+}
+
+void test_client_key_holder_index_zero_is_never_mine(void) {
+    /* Index 0 is the server's own operator, whatever the name says: a box
+     * that calls itself "The Sysop" does not hold the key when the sysop does */
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "The Sysop",
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+    test_setup();
+    mock_tx_all_len = 0;
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+    feed_connect_echo();
+    cwnet_client_on_data(&client, ref_tx_info_sysop, sizeof(ref_tx_info_sysop));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("The Sysop", cwnet_client_get_key_holder_name(&client));
 }
 
 void test_client_key_holder_forgotten_across_a_reconnect(void) {

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -89,6 +89,25 @@ static void ready_client_accumulating(void) {
     mock_tx_all_len = 0;
 }
 
+/* As ready_client_accumulating(), with the name the server will know us by. */
+static void ready_client_named(const char *username) {
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = username,
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+
+    test_setup();
+    mock_tx_all_len = 0;
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+    feed_connect_echo();
+    mock_tx_all_len = 0;
+}
+
 /*===========================================================================*/
 /* Initialization Tests                                                      */
 /*===========================================================================*/
@@ -840,6 +859,118 @@ void test_client_rx_keeps_the_rig_result(void) {
 }
 
 /*===========================================================================*/
+/* Who has the key: the server's TX_INFO announcements                       */
+/*===========================================================================*/
+
+void test_client_key_holder_unknown_until_announced(void) {
+    ready_client_accumulating();
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_UNKNOWN, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("", cwnet_client_get_key_holder_name(&client));
+    TEST_ASSERT_EQUAL(0, cwnet_client_get_key_announcements(&client));
+}
+
+void test_client_key_holder_reads_the_three_captured_announcements(void) {
+    /* The capture's client logged in as "Moritz": the name the server
+     * announces is the callsign we sent, and we send the username there. */
+    ready_client_named("Moritz");
+
+    cwnet_client_on_data(&client, ref_tx_info_nobody, sizeof(ref_tx_info_nobody));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_FREE, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("-- nobody --", cwnet_client_get_key_holder_name(&client));
+
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("Moritz", cwnet_client_get_key_holder_name(&client));
+
+    cwnet_client_on_data(&client, ref_tx_info_sysop, sizeof(ref_tx_info_sysop));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("The Sysop", cwnet_client_get_key_holder_name(&client));
+
+    TEST_ASSERT_EQUAL(3, cwnet_client_get_key_announcements(&client));
+}
+
+void test_client_key_holder_another_client_is_other(void) {
+    ready_client_accumulating();   /* we are "TEST" */
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("Moritz", cwnet_client_get_key_holder_name(&client));
+}
+
+void test_client_key_holder_alternates_as_the_reference_announces(void) {
+    /* Session 12, the first over: the server announces nobody, Moritz,
+     * nobody, Moritz, nobody (offsets 169, 465, 475, 491, 511) because its
+     * release timer runs on while the client keys. We report each one as
+     * announced, as the reference client displays them (Keyer_Main.cpp,
+     * Ed_OnTheKeyNow): no hysteresis of ours. */
+    ready_client_named("Moritz");
+    static const cwnet_key_holder_t expected[] = {
+        CWNET_KEY_HOLDER_FREE, CWNET_KEY_HOLDER_MINE, CWNET_KEY_HOLDER_FREE,
+        CWNET_KEY_HOLDER_MINE, CWNET_KEY_HOLDER_FREE,
+    };
+    for (size_t i = 0; i < 5; i++) {
+        if (expected[i] == CWNET_KEY_HOLDER_FREE) {
+            cwnet_client_on_data(&client, ref_tx_info_nobody, sizeof(ref_tx_info_nobody));
+        } else {
+            cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+        }
+        TEST_ASSERT_EQUAL(expected[i], cwnet_client_get_key_holder(&client));
+    }
+    TEST_ASSERT_EQUAL(5, cwnet_client_get_key_announcements(&client));
+}
+
+void test_client_key_holder_frame_in_fragments(void) {
+    ready_client_named("Moritz");
+    for (size_t i = 0; i < sizeof(ref_tx_info_moritz); i++) {
+        cwnet_client_on_data(&client, &ref_tx_info_moritz[i], 1);
+    }
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("Moritz", cwnet_client_get_key_holder_name(&client));
+}
+
+void test_client_key_holder_ignores_malformed_tx_info(void) {
+    ready_client_named("Moritz");
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+
+    /* The reference takes a payload of 2..80 bytes (CwNet.c:1555): the index
+     * alone is not an announcement, and neither is an 81-byte one. */
+    static const uint8_t index_only[] = {0x45, 0x01, 0xFF};
+    cwnet_client_on_data(&client, index_only, sizeof(index_only));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+
+    uint8_t too_long[2 + 81];
+    too_long[0] = 0x45;
+    too_long[1] = 81;
+    too_long[2] = 0xFF;
+    memset(&too_long[3], 'x', 79);
+    too_long[2 + 80] = 0x00;
+    cwnet_client_on_data(&client, too_long, sizeof(too_long));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL(1, cwnet_client_get_key_announcements(&client));
+
+    /* A name without its NUL is taken as far as it goes, and is not ours */
+    static const uint8_t no_nul[] = {0x45, 0x03, 0x01, 'M', 'o'};
+    cwnet_client_on_data(&client, no_nul, sizeof(no_nul));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("Mo", cwnet_client_get_key_holder_name(&client));
+}
+
+void test_client_key_holder_forgotten_across_a_reconnect(void) {
+    ready_client_named("Moritz");
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+
+    cwnet_client_on_disconnected(&client);
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_UNKNOWN, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL_STRING("", cwnet_client_get_key_holder_name(&client));
+
+    cwnet_client_on_connected(&client);
+    feed_connect_echo();
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_UNKNOWN, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_EQUAL(0, cwnet_client_get_key_announcements(&client));
+}
+
+/*===========================================================================*/
 /* Determinism: what we send comes back as what we sent                     */
 /*===========================================================================*/
 
@@ -1086,6 +1217,13 @@ void run_cwnet_client_tests(void) {
     RUN_TEST(test_client_abort_over_drops_ptt_too);
     RUN_TEST(test_client_rx_keeps_the_rig_result);
     RUN_TEST(test_client_rejects_events_when_not_ready);
+    RUN_TEST(test_client_key_holder_unknown_until_announced);
+    RUN_TEST(test_client_key_holder_reads_the_three_captured_announcements);
+    RUN_TEST(test_client_key_holder_another_client_is_other);
+    RUN_TEST(test_client_key_holder_alternates_as_the_reference_announces);
+    RUN_TEST(test_client_key_holder_frame_in_fragments);
+    RUN_TEST(test_client_key_holder_ignores_malformed_tx_info);
+    RUN_TEST(test_client_key_holder_forgotten_across_a_reconnect);
 
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -69,27 +69,8 @@ static int mock_send_accumulate(const uint8_t *data, size_t len, void *user_data
     return (int)len;
 }
 
-/* A client at READY with TRANSMIT granted, capturing every byte it sends
- * from here on (the CONNECT it sent is dropped). */
-static void ready_client_accumulating(void) {
-    cwnet_client_config_t config = {
-        .server_host = "test.server.com",
-        .server_port = 7373,
-        .username = "TEST",
-        .send_cb = mock_send_accumulate,
-        .get_time_ms_cb = mock_get_time_ms,
-        .user_data = NULL
-    };
-
-    test_setup();
-    mock_tx_all_len = 0;
-    cwnet_client_init(&client, &config);
-    cwnet_client_on_connected(&client);
-    feed_connect_echo();
-    mock_tx_all_len = 0;
-}
-
-/* As ready_client_accumulating(), with the name the server will know us by. */
+/* A client at READY with TRANSMIT granted, logged in under the given name,
+ * capturing every byte it sends from here on (the CONNECT it sent is dropped). */
 static void ready_client_named(const char *username) {
     cwnet_client_config_t config = {
         .server_host = "test.server.com",
@@ -106,6 +87,10 @@ static void ready_client_named(const char *username) {
     cwnet_client_on_connected(&client);
     feed_connect_echo();
     mock_tx_all_len = 0;
+}
+
+static void ready_client_accumulating(void) {
+    ready_client_named("TEST");
 }
 
 /*===========================================================================*/
@@ -1166,70 +1151,4 @@ void test_client_handles_ping_in_fragments(void) {
 
     /* Now should have responded */
     TEST_ASSERT_GREATER_THAN(0, mock_tx_len);
-}
-
-/*===========================================================================*/
-/* Test Runner                                                               */
-/*===========================================================================*/
-
-void run_cwnet_client_tests(void) {
-    /* Initialization */
-    RUN_TEST(test_client_init_basic);
-    RUN_TEST(test_client_init_null_client);
-    RUN_TEST(test_client_init_null_config);
-    RUN_TEST(test_client_init_null_callbacks);
-    RUN_TEST(test_client_init_empty_host);
-    RUN_TEST(test_client_init_empty_username);
-
-    /* State Transitions */
-    RUN_TEST(test_client_connect_transitions_to_connecting);
-    RUN_TEST(test_client_disconnect_from_any_state);
-
-    /* Protocol Handshake */
-    RUN_TEST(test_client_sends_ident_on_connect);
-    RUN_TEST(test_client_reaches_ready_on_connect_echo);
-
-    /* PING Handling */
-    RUN_TEST(test_client_responds_to_ping_request);
-    RUN_TEST(test_client_syncs_timer_on_ping_request);
-    RUN_TEST(test_client_updates_latency_on_ping_response2);
-
-    /* CW Events */
-    RUN_TEST(test_client_tx_first_transition_of_an_over_waits_zero);
-    RUN_TEST(test_client_tx_wait_is_measured_from_previous_transition);
-    RUN_TEST(test_client_tx_first_over_matches_reference_capture);
-    RUN_TEST(test_client_tx_advances_by_encoded_not_measured_ms);
-    RUN_TEST(test_client_tx_splits_wait_above_1165_ms);
-    RUN_TEST(test_client_tx_end_of_over_after_14_dot_times);
-    RUN_TEST(test_client_tx_end_of_over_splits_at_slow_speed);
-    RUN_TEST(test_client_tx_ignores_repeated_key_state);
-    RUN_TEST(test_client_tx_wait_beyond_one_frame_rebases_on_the_edge);
-    RUN_TEST(test_client_rx_decodes_every_event_of_a_morse_frame);
-    RUN_TEST(test_client_rx_synthetic_frame_from_reference_encoder);
-    RUN_TEST(test_client_rx_frame_in_fragments);
-    RUN_TEST(test_client_rx_event_carries_reception_time);
-    RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
-    RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
-    RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
-    RUN_TEST(test_client_round_trip_returns_the_edges_sent);
-    RUN_TEST(test_client_tx_first_over_with_ptt_matches_reference_capture_whole);
-    RUN_TEST(test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail);
-    RUN_TEST(test_client_abort_over_drops_ptt_too);
-    RUN_TEST(test_client_rx_keeps_the_rig_result);
-    RUN_TEST(test_client_rejects_events_when_not_ready);
-    RUN_TEST(test_client_key_holder_unknown_until_announced);
-    RUN_TEST(test_client_key_holder_reads_the_three_captured_announcements);
-    RUN_TEST(test_client_key_holder_another_client_is_other);
-    RUN_TEST(test_client_key_holder_alternates_as_the_reference_announces);
-    RUN_TEST(test_client_key_holder_frame_in_fragments);
-    RUN_TEST(test_client_key_holder_ignores_malformed_tx_info);
-    RUN_TEST(test_client_key_holder_forgotten_across_a_reconnect);
-
-    /* Error Handling */
-    RUN_TEST(test_client_handles_invalid_frame);
-    RUN_TEST(test_client_handles_disconnect_during_operation);
-
-    /* Fragmentation */
-    RUN_TEST(test_client_handles_fragmented_frame);
-    RUN_TEST(test_client_handles_ping_in_fragments);
 }

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -244,6 +244,13 @@ void test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail(void);
 void test_client_abort_over_drops_ptt_too(void);
 void test_client_rx_keeps_the_rig_result(void);
 void test_client_rejects_events_when_not_ready(void);
+void test_client_key_holder_unknown_until_announced(void);
+void test_client_key_holder_reads_the_three_captured_announcements(void);
+void test_client_key_holder_another_client_is_other(void);
+void test_client_key_holder_alternates_as_the_reference_announces(void);
+void test_client_key_holder_frame_in_fragments(void);
+void test_client_key_holder_ignores_malformed_tx_info(void);
+void test_client_key_holder_forgotten_across_a_reconnect(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
 void test_client_handles_fragmented_frame(void);
@@ -556,6 +563,14 @@ int main(void) {
     RUN_TEST(test_client_abort_over_drops_ptt_too);
     RUN_TEST(test_client_rx_keeps_the_rig_result);
     RUN_TEST(test_client_rejects_events_when_not_ready);
+    /* Who has the key: TX_INFO 0x05 against the 2026-09-05 capture */
+    RUN_TEST(test_client_key_holder_unknown_until_announced);
+    RUN_TEST(test_client_key_holder_reads_the_three_captured_announcements);
+    RUN_TEST(test_client_key_holder_another_client_is_other);
+    RUN_TEST(test_client_key_holder_alternates_as_the_reference_announces);
+    RUN_TEST(test_client_key_holder_frame_in_fragments);
+    RUN_TEST(test_client_key_holder_ignores_malformed_tx_info);
+    RUN_TEST(test_client_key_holder_forgotten_across_a_reconnect);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);
     RUN_TEST(test_client_handles_disconnect_during_operation);

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -251,6 +251,9 @@ void test_client_key_holder_alternates_as_the_reference_announces(void);
 void test_client_key_holder_frame_in_fragments(void);
 void test_client_key_holder_ignores_malformed_tx_info(void);
 void test_client_key_holder_forgotten_across_a_reconnect(void);
+void test_client_callsign_goes_on_the_wire_and_decides_mine(void);
+void test_client_callsign_falls_back_to_the_username(void);
+void test_client_key_holder_index_zero_is_never_mine(void);
 void test_client_handles_invalid_frame(void);
 void test_client_handles_disconnect_during_operation(void);
 void test_client_handles_fragmented_frame(void);
@@ -571,6 +574,9 @@ int main(void) {
     RUN_TEST(test_client_key_holder_frame_in_fragments);
     RUN_TEST(test_client_key_holder_ignores_malformed_tx_info);
     RUN_TEST(test_client_key_holder_forgotten_across_a_reconnect);
+    RUN_TEST(test_client_callsign_goes_on_the_wire_and_decides_mine);
+    RUN_TEST(test_client_callsign_falls_back_to_the_username);
+    RUN_TEST(test_client_key_holder_index_zero_is_never_mine);
     /* Error Handling */
     RUN_TEST(test_client_handles_invalid_frame);
     RUN_TEST(test_client_handles_disconnect_during_operation);


### PR DESCRIPTION
## What changes

The box now knows whether the server is playing its keying. The client reads the server's `TX_INFO` announcements and reports the key as free, mine or somebody else's (`cwnet_client_get_key_holder()`, with the announced name beside it); it keys regardless, and signals the state on the periodic status line and as `key_holder` / `key_holder_name` in `/api/system`. The CONNECT record now carries `system.callsign` instead of repeating the username.

Decision, written in #25: the state is reported as announced, with no timer of ours. The server releases the key on a 1 s stopwatch that a remote take does not restart, so inside an over the announcement alternates mine / nobody every second, and both mean the next byte is played; the state to signal is "other". Alternative rejected: refusing to key when somebody else holds it, which trades a visible fault for an unexplained silence while the reference hands the key to the next byte within a second anyway. The callsign goes on the wire because the server announces the holder by callsign, never checks it at login (`CwNet_CheckUserAndGetPermissions` matches the username only) and strips TRANSMIT from a client that sends none; with no callsign configured the username is sent, as before.

## Closes

#25. Condition: a host test replays the captured frames through `cwnet_client_on_data()` and reads the three states back from `cwnet_client_get_key_holder()`. Holds in `test_host/test_cwnet_client.c`: `test_client_key_holder_reads_the_three_captured_announcements`, and the nobody / Moritz alternation of session 12's first over in `test_client_key_holder_alternates_as_the_reference_announces`.

## Definition of done

- Host tests: 215/215 plain, 215/215 ASan/UBSan. Was 205: ten added.
- Reference test: the three `TX_INFO` payloads of the 2026-09-05 capture, bytes verbatim in `test_host/cwnet_fixtures.h` (session 12 at 169 and 465, session 10 at 239), against `CwNet.c` case `CWNET_CMD_TX_INFO` (:1550-1565) and `CwNet_GetClientCallOrInfo()` (:432-452): `test_client_key_holder_reads_the_three_captured_announcements`. The callsign field of CONNECT against `CwNet.c:1295`: `test_client_callsign_goes_on_the_wire_and_decides_mine`.
- RT path: untouched. Everything runs on Core 1 (`bg_task`, the HTTP server).
- Blocking issues open on this work: none. #60 blocks the server role only.

## Not done here

- LEDs and the Web UI page for the state: #26. The JSON fields are there for it.
- Firmware build checked by CI only.

## Post-Deploy Monitoring & Validation

First session against the DL4YHF server, owner the maintainer. Healthy: the periodic line `CWNet: READY, latency=..ms, key free (-- nobody --)` between overs and `key mine (<callsign>)` while keying, the same values in `curl /api/system` under `cwnet`. Failure: `key other (<name>)` while keying, which means the server is dropping us, or `unknown` with the link READY after the first PING. Rollback: revert the PR; no persisted state.

