### PR TITLE
RT: the config re-read is ordered after the copy

### DIFF
--- a/components/keyer_hal/src/hal_audio.c
+++ b/components/keyer_hal/src/hal_audio.c
@@ -301,13 +301,6 @@ size_t hal_audio_write(const int16_t *samples, size_t count) {
         stereo_buf[i * 2 + 1] = samples[i];  /* Right (copy) */
     }
 
-    /* DEBUG: Log first write */
-    static bool first_write = true;
-    if (first_write && to_write > 0) {
-        ESP_LOGI(TAG, "First audio write: count=%zu, sample[0]=%d", to_write, samples[0]);
-        first_write = false;
-    }
-
     /* Write through codec device (not directly to I2S) */
     size_t byte_count = to_write * 2 * sizeof(int16_t);
 

--- a/main/rt_task.c
+++ b/main/rt_task.c
@@ -198,11 +198,15 @@ void rt_task(void *arg) {
 
             /* Verify generation didn't change mid-read (optimistic read).
              * The fence orders the field loads above before the re-read; an
-             * acquire load alone does not, so a field read after the re-read
-             * could carry a value whose bump the re-read did not see (RULE
-             * 3.1.3, the same seqlock reader as stream_read(); #69). Each
-             * field is its own atomic, so what this guards is the set, not a
-             * value: WPM from one change with the mode from another. */
+             * acquire load alone does not, so a field load could complete
+             * after the re-read and carry a value whose bump the re-read did
+             * not see (RULE 3.1.3, the same seqlock reader as stream_read();
+             * #69). What the re-read proves is only that no bump became
+             * visible during the copy: each setter bumps after its store, so
+             * a store in flight is invisible here, and each field is its own
+             * atomic, so no value is ever torn. A mixed set can be applied
+             * for one tick; last_config_gen keeps the pre-read value, so the
+             * bump that made it mixed reloads the set on the next idle tick. */
             atomic_thread_fence(memory_order_acquire);
             uint16_t gen_after = atomic_load_explicit(&g_config.generation, memory_order_relaxed);
             if (gen_after != current_gen) {

--- a/main/rt_task.c
+++ b/main/rt_task.c
@@ -196,8 +196,15 @@ void rt_task(void *arg) {
             iambic_cfg.mem_window_start_pct = CONFIG_GET_MEM_WINDOW_START_PCT();
             iambic_cfg.mem_window_end_pct = CONFIG_GET_MEM_WINDOW_END_PCT();
 
-            /* Verify generation didn't change mid-read (optimistic read) */
-            uint16_t gen_after = atomic_load_explicit(&g_config.generation, memory_order_acquire);
+            /* Verify generation didn't change mid-read (optimistic read).
+             * The fence orders the field loads above before the re-read; an
+             * acquire load alone does not, so a field read after the re-read
+             * could carry a value whose bump the re-read did not see (RULE
+             * 3.1.3, the same seqlock reader as stream_read(); #69). Each
+             * field is its own atomic, so what this guards is the set, not a
+             * value: WPM from one change with the mode from another. */
+            atomic_thread_fence(memory_order_acquire);
+            uint16_t gen_after = atomic_load_explicit(&g_config.generation, memory_order_relaxed);
             if (gen_after != current_gen) {
                 continue;  /* Torn read - retry next tick */
             }


### PR DESCRIPTION
## What changes

The RT task's config hot-reload now proves what it claims. It copies the iambic fields, then re-reads the generation behind an acquire fence, with a relaxed load: the fence orders the copy before the re-read, which the acquire load it replaces did not on a weakly ordered core. Same seqlock reader as `stream_read()` since #70, RULE 3.1.3.

Decision, written in #69: the fence, not a comment accepting the risk. What the re-read proves is only that no bump became visible during the copy: each setter bumps *after* its store, so a store in flight is invisible, and each field is its own atomic, so no value is ever torn. A mixed set can be applied for one idle tick; `last_config_gen` keeps the pre-read value, so the bump that made it mixed reloads the set on the next one. A guard that protects the set would need a pre-store bump on the writer, a `keyer_config` design change nobody has asked for.

Also removed, found by the review: a one-shot `ESP_LOGI` in `hal_audio_write()`, on Core 0.

## Closes

#69. Condition: `rt_task.c` carries the fence or a comment accepting the risk, and the choice is named in the commit. Holds in `main/rt_task.c`, the block under "Verify generation didn't change mid-read", commit 4d516f5.

## Definition of done

- Host tests: 218/218 plain, 218/218 ASan/UBSan, unchanged: `main/` is not built on the host.
- Reference test: n/a. The reader idiom is pinned in `test_stream_two_threads_never_accept_a_stale_or_torn_sample` against `stream_read()`; this call site is verified by the firmware build only.
- RT path: one `atomic_thread_fence(memory_order_acquire)` inside the branch that runs only when the generation changed and the keyer is idle; one `memw`. And one blocking log fewer on the audio write path.
- Blocking issues open on this work: none.

## Not done here

- The torn-read `continue` skips the rest of the tick, delay included, so the loop body runs twice in one period rather than "retrying next tick". Pre-existing and benign today; a scoped guard would be the fix.
- `CONFIG_GET_SIDETONE_FREQ_HZ()` and `CONFIG_GET_PTT_TAIL_MS()` are read after the guard, not inside it. Same self-healing on the next tick.
- No host test for `rt_task.c`; extracting the optimistic read into a host-testable helper is not proportionate to eleven lines.

## Post-Deploy Monitoring & Validation

First flashed session, owner the maintainer: change WPM and mode from the Web UI while idle and while keying; the new values must apply within a tick of going idle and the keying must not stutter. Failure: a config change that does not apply, or a FAULT. Rollback: revert the PR; no persisted state.
