### PR TITLE
led: green means your CW goes out, and nothing else is green

### DIFF
--- a/components/keyer_cwnet/include/cwnet_client.h
+++ b/components/keyer_cwnet/include/cwnet_client.h
@@ -492,6 +492,22 @@ uint32_t cwnet_client_get_key_announcements(const cwnet_client_t *client);
 /** @return "unknown", "free", "mine" or "other" */
 const char *cwnet_client_key_holder_str(cwnet_key_holder_t holder);
 
+/**
+ * @brief Whether the next MORSE byte we send is played by the server
+ *
+ * What the reference server does with a MORSE frame (CwNet.c:2875-2902):
+ * it takes the key for the sender when nobody has it and the sender has
+ * TRANSMIT, keeps playing while the sender holds it, and drops the frame
+ * otherwise. So: READY, TRANSMIT granted, and the key announced free or
+ * ours. UNKNOWN counts as not ours: the announcement follows the CONNECT
+ * echo within the same burst in the capture, so the gap is milliseconds,
+ * and a doubt reads as "do not key" (FAULT philosophy).
+ *
+ * @param client Client context
+ * @return true when our keying goes on the air, false otherwise or if NULL
+ */
+bool cwnet_client_can_transmit(const cwnet_client_t *client);
+
 void cwnet_client_on_data(cwnet_client_t *client,
                            const uint8_t *data,
                            size_t len);

--- a/components/keyer_cwnet/include/cwnet_socket.h
+++ b/components/keyer_cwnet/include/cwnet_socket.h
@@ -87,6 +87,16 @@ cwnet_key_holder_t cwnet_socket_get_key_holder(void);
 const char *cwnet_socket_get_key_holder_name(void);
 
 /**
+ * @brief Whether our keying goes on the air right now
+ *
+ * READY, TRANSMIT granted and the key free or ours (#26). false when
+ * disabled, not connected, not permitted, or someone else has the key:
+ * in all of those the operator hears the sidetone and the server plays
+ * nothing.
+ */
+bool cwnet_socket_can_transmit(void);
+
+/**
  * @brief Get state as string (for logging)
  */
 const char *cwnet_socket_state_str(cwnet_socket_state_t state);

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -532,6 +532,16 @@ uint32_t cwnet_client_get_key_announcements(const cwnet_client_t *client) {
     return client->key_announcements;
 }
 
+bool cwnet_client_can_transmit(const cwnet_client_t *client) {
+    if (client == NULL || client->state != CWNET_STATE_READY) {
+        return false;
+    }
+    if ((client->permissions & CWNET_PERMISSION_TRANSMIT) == 0) {
+        return false;
+    }
+    return client->key_holder == CWNET_KEY_HOLDER_FREE || client->key_holder == CWNET_KEY_HOLDER_MINE;
+}
+
 const char *cwnet_client_key_holder_str(cwnet_key_holder_t holder) {
     switch (holder) {
         case CWNET_KEY_HOLDER_FREE:  return "free";

--- a/components/keyer_cwnet/src/cwnet_socket.c
+++ b/components/keyer_cwnet/src/cwnet_socket.c
@@ -421,6 +421,10 @@ const char *cwnet_socket_get_key_holder_name(void) {
     return cwnet_client_get_key_holder_name(&s_ctx.client);
 }
 
+bool cwnet_socket_can_transmit(void) {
+    return s_ctx.state == CWNET_SOCK_READY && cwnet_client_can_transmit(&s_ctx.client);
+}
+
 const char *cwnet_socket_state_str(cwnet_socket_state_t state) {
     switch (state) {
         case CWNET_SOCK_DISABLED:     return "DISABLED";

--- a/components/keyer_led/CLAUDE.md
+++ b/components/keyer_led/CLAUDE.md
@@ -1,24 +1,28 @@
 <!-- BEGIN treecode (auto) — do not edit inside this block -->
-# keyer_led — WS2812B RGB status LED driver (Core 1)
+# keyer_led — WS2812B status LED strip: five situations, one colour, a paddle overlay (Core 1)
 
-Responsibility: Owns the WS2812B status LED strip: a state machine of connectivity/keyer states (boot, wifi-connecting, failed, degraded, AP mode, provisioning, connected, idle) rendered as breathing/flashing animations, plus a real-time keying overlay (DIT/DAH/squeeze) driven by the paddle inputs. Purely a display sink — it must NOT influence keying, TX, or the stream.
+Responsibility: Owns what the strip shows. `led_render.h`/`led_render.c` are the pure half — no ESP-IDF, host-tested by `test_host/test_led.c` — and own the colour vocabulary, the five situations, the animation clocks, the paddle overlay and `led_render()` itself. `src/led.c` is only the RMT shell: it owns the WS2812B bit encoding, the strip's atomic situation/notify state, and calls `led_render()` on tick. Purely a display sink — it must NOT influence keying, TX, or the stream, and the DIT/DAH it reads are for display, never a keying source.
 
 Key abstractions:
-- `led_init(led_config_t)` / `led_deinit()` — sets up the RMT TX channel and a custom byte+copy strip encoder; init is non-fatal (keyer runs on if it fails).
-- `led_set_state(led_state_t)` / `led_get_state()` — pick the base animation.
-- `led_tick(now_us, dit, dah)` — call periodically from bg_task; advances animations and overlays live paddle state.
-- `led_config_t` (gpio, count, brightness, brightness_dim) with `LED_CONFIG_DEFAULT` (GPIO38, 7 LEDs); `led_set_brightness()`.
+- `led_situation_t` (`led_render.h`): five values, one colour each — `STARTING` (orange, breathing), `SETUP` (blue, breathing), `LOCAL_ONLY` (yellow, dim), `ON_AIR` (green, dim), `OFF_AIR` (red, dim). The governing rule, stated at the top of `led_render.h`: green means the operator's CW goes out; any other colour means it does not, and the colour says why. Nothing but `LED_SITUATION_ON_AIR` is ever green — magenta and the old nine-value `led_state_t` are gone.
+- `led_render(const led_scene_t*, led_frame_t*)`: pure function, scene in, per-LED colour frame out. Base colour/level from the situation (breathing for STARTING/SETUP, `brightness_dim` otherwise); a running notification overrides the level with flashes in that same colour; the paddle overlay then lights its LEDs at full brightness in that same colour. No step introduces a colour of its own.
+- `led_notify()`: an event, not a state — three attention flashes (`LED_NOTIFY_FLASHES`, 100ms on/100ms gap) in the colour of whatever situation they land on, so a notification can never assert a colour the situation contradicts.
+- The paddle overlay: raw, undebounced DIT/DAH pins, applied in every situation (previously idle-only). It carries position and brightness only, never its own colour — lit-but-silent means a software fault, dark means the contact or wiring, since it is fed upstream of debounce and the FSM.
+- `led_set_situation()`/`led_get_situation()`: idempotent — setting the situation already showing does not restart its clock, so `bg_task` can call it every tick from a mapping. `led_tick(now_us, dit, dah)`: builds the `led_scene_t`, calls `led_render()`, pushes the frame over RMT.
+- `led_config_t` (gpio, count, brightness, brightness_dim) with `LED_CONFIG_DEFAULT` (GPIO38, 7 LEDs); `led_set_brightness()`. `LED_MAX_COUNT` (16, public header) replaces the old `MAX_LEDS`.
 
-Depends on: driver, esp_driver_rmt (WS2812B bit-banging via RMT), esp_timer (animation clock).
+Depends on: driver, esp_driver_rmt (WS2812B bit-banging via RMT), esp_timer (situation/notify clocks). `led_render.c` itself depends on nothing beyond the standard headers in `led_render.h`.
 
-Used by: main/bg_task.c calls `led_tick` with current paddle state; main sets states on lifecycle events; provisioning drives AP/provisioning states.
+Used by: main/bg_task.c's `led_situation_now(wifi_state_t)` maps WiFi state and, once connected, `cwnet_socket_can_transmit()` to a situation, called every tick (the key can change hands without WiFi moving); it calls `led_notify()` on WiFi connect/fail transitions and `led_tick()` with the raw paddle read from `hal_gpio_read_paddles()`. main.c sets `LED_SITUATION_STARTING` after init and on WiFi bring-up, `LED_SITUATION_LOCAL_ONLY` on WiFi init failure, `LED_SITUATION_ON_AIR` when WiFi is disabled by config. components/provisioning/src/provisioning.c sets `LED_SITUATION_SETUP` and drives `led_tick()` itself during the AP-mode provisioning loop.
 
-External deps of note: esp_driver_rmt — timing constants encode the WS2812B protocol (T0H/T0L/T1H/T1L ticks at 10MHz/100ns resolution, plus a reset symbol). Changing them breaks the LED protocol, not just brightness.
+External deps of note: esp_driver_rmt — the WS2812B timing constants (T0H/T0L/T1H/T1L ticks at 10MHz/100ns resolution, plus a low reset symbol) live in `led.c`'s custom bytes+copy strip encoder. Changing them breaks the LED protocol, not just brightness.
 
-Conventions: Built with -Wall -Wextra -Werror -Wconversion -Wshadow (strictest in the tree). Colors are 0xRRGGBB; MAX_LEDS 16.
+Conventions: Built with -Wall -Wextra -Werror -Wconversion -Wshadow (strictest in the tree). Colours are 0xRRGGBB, one constant per situation and no spares (`LED_COLOR_OFF/RED/GREEN/BLUE/ORANGE/YELLOW` — magenta was removed) so a colour that belongs to nothing cannot be misread. `led_render.h`/`.c` stay free of ESP-IDF so they build under `test_host`; hardware concerns belong in `led.c`.
 
 Gotchas:
-- Runs on Core 1 only — never call from the RT task. It is a status sink; the DIT/DAH args are for display, not a keying source.
-- Init failure is deliberately non-fatal: always guard with `led_is_initialized()` and let the keyer continue if the strip is absent.
-- WS2812B is GRB on the wire; the encoder handles ordering — pass logical 0xRRGGBB, don't pre-swap.
+- Runs on Core 1 only — never call from the RT task.
+- Init failure is deliberately non-fatal: always guard with `led_is_initialized()` and let the keyer continue if the strip is absent; `led_tick`/`transmit_leds` also no-op when uninitialized.
+- WS2812B is GRB on the wire; the encoder handles ordering — pass logical 0xRRGGBB into `led_render`/`led.c`, don't pre-swap.
+- Only `led.c` (the RMT shell) may know about ESP-IDF or hardware; any new display logic — a colour, a clock, an overlay rule — belongs in `led_render.c` so it stays provable by `test_host/test_led.c` without a strip attached.
+- The paddle overlay is fed raw pins from `bg_task`'s own `hal_gpio_read_paddles()` call, not the debounced/FSM state used for keying — it is a deliberate second, independent read for hardware-vs-software fault diagnosis; don't collapse it into a single read path.
 <!-- END treecode (auto) -->

--- a/components/keyer_led/CMakeLists.txt
+++ b/components/keyer_led/CMakeLists.txt
@@ -3,6 +3,7 @@
 idf_component_register(
     SRCS
         "src/led.c"
+        "src/led_render.c"
     INCLUDE_DIRS "include"
     REQUIRES driver esp_driver_rmt esp_timer
 )

--- a/components/keyer_led/include/led.h
+++ b/components/keyer_led/include/led.h
@@ -1,13 +1,10 @@
 /**
  * @file led.h
- * @brief WS2812B RGB LED status driver
+ * @brief WS2812B RGB LED status driver: the RMT shell
  *
- * Displays keyer state through RGB LEDs:
- * - Boot/connecting: orange breathing
- * - Connected: green flash then dim
- * - AP mode: alternating orange/blue
- * - Degraded: dim yellow
- * - Keying: DIT/DAH/squeeze indication
+ * What the strip shows, and the colour rule it obeys, is led_render.h.
+ * This header is the driver around it: the RMT channel, the situation and
+ * its clock, and the periodic tick.
  */
 
 #ifndef KEYER_LED_H
@@ -16,25 +13,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "esp_err.h"
+#include "led_render.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief LED state machine states
- */
-typedef enum {
-    LED_STATE_OFF = 0,          /**< LEDs off */
-    LED_STATE_BOOT,             /**< Boot: orange breathing */
-    LED_STATE_WIFI_CONNECTING,  /**< Connecting: orange breathing */
-    LED_STATE_WIFI_FAILED,      /**< Brief red flash */
-    LED_STATE_DEGRADED,         /**< Dim yellow steady */
-    LED_STATE_AP_MODE,          /**< Alternating orange/blue */
-    LED_STATE_PROVISIONING,     /**< Provisioning: blue breathing */
-    LED_STATE_CONNECTED,        /**< Green flash sequence */
-    LED_STATE_IDLE,             /**< Dim green steady */
-} led_state_t;
 
 /**
  * @brief LED configuration
@@ -72,29 +55,35 @@ esp_err_t led_init(const led_config_t *config);
 void led_deinit(void);
 
 /**
- * @brief Set LED state
+ * @brief Set the situation the strip shows
  *
- * @param state New state
+ * Idempotent: setting the situation already showing does not restart its
+ * animation clock, so this may be called every tick from a mapping.
+ *
+ * @param situation What the box is doing now
  */
-void led_set_state(led_state_t state);
+void led_set_situation(led_situation_t situation);
 
 /**
- * @brief Get current LED state
- *
- * @return Current state
+ * @brief The situation the strip is showing
  */
-led_state_t led_get_state(void);
+led_situation_t led_get_situation(void);
+
+/**
+ * @brief Ask for attention: three flashes, then back to the situation
+ *
+ * The flashes are in the colour of whatever situation they land on, so an
+ * event can never assert a colour the situation contradicts. Use it for a
+ * change worth looking up for, such as the link coming up.
+ */
+void led_notify(void);
 
 /**
  * @brief Update LED display (call periodically from bg_task)
  *
- * Handles:
- * - State machine animations (breathing, flashing)
- * - Keying overlay (DIT/DAH/squeeze)
- *
  * @param now_us Current timestamp in microseconds
- * @param dit DIT paddle pressed
- * @param dah DAH paddle pressed
+ * @param dit DIT pin closed, read raw
+ * @param dah DAH pin closed, read raw
  */
 void led_tick(int64_t now_us, bool dit, bool dah);
 

--- a/components/keyer_led/include/led_render.h
+++ b/components/keyer_led/include/led_render.h
@@ -1,0 +1,110 @@
+/**
+ * @file led_render.h
+ * @brief What the seven LEDs show, as a pure function
+ *
+ * The rule the whole vocabulary obeys, and the only thing an operator has
+ * to remember with a paddle in one hand:
+ *
+ *     Green means your CW goes out. Any other colour means it does not,
+ *     and the colour says why.
+ *
+ * So colour carries the situation and nothing else. The paddle overlay
+ * carries position and brightness only (#26): a green overlay on a red
+ * base would contradict the rule at the exact moment the operator is
+ * keying, which is when the rule has to hold.
+ *
+ * This header has no ESP-IDF dependency: the render is a pure function of
+ * the situation, the clocks and the paddle, so it is proven by host tests
+ * rather than by looking at the strip. led.c is the RMT shell around it.
+ */
+
+#ifndef KEYER_LED_RENDER_H
+#define KEYER_LED_RENDER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Longest strip the render will fill */
+#define LED_MAX_COUNT 16
+
+/* Colours, 0xRRGGBB. One per situation, and no others: a colour that
+ * belongs to nothing cannot be misread. */
+#define LED_COLOR_OFF     0x000000U
+#define LED_COLOR_RED     0xFF0000U  /**< off air */
+#define LED_COLOR_GREEN   0x00FF00U  /**< on air, and nothing else is ever green */
+#define LED_COLOR_BLUE    0x0000FFU  /**< setup */
+#define LED_COLOR_ORANGE  0xFF8000U  /**< starting */
+#define LED_COLOR_YELLOW  0xFFA000U  /**< local only */
+
+/* Animation clocks */
+#define LED_BREATH_PERIOD_US   2000000  /**< full breath, rise and fall */
+#define LED_FLASH_DURATION_US   100000  /**< one flash of a notification */
+#define LED_FLASH_GAP_US        100000  /**< the dark between two flashes */
+#define LED_NOTIFY_FLASHES            3
+#define LED_NOTIFY_TOTAL_US  (LED_NOTIFY_FLASHES * (LED_FLASH_DURATION_US + LED_FLASH_GAP_US))
+
+/**
+ * @brief What the box is doing, in the operator's terms
+ *
+ * Five situations, one colour each. They are situations and not states:
+ * nothing here is a transition, an animation or a notification, because
+ * those are events and live on their own clock (led_notify()).
+ */
+typedef enum {
+    LED_SITUATION_STARTING = 0, /**< orange, breathing: not usable yet */
+    LED_SITUATION_SETUP,        /**< blue, breathing: come to the access point */
+    LED_SITUATION_LOCAL_ONLY,   /**< yellow, dim: the network is gone, the keyer is local */
+    LED_SITUATION_ON_AIR,       /**< green, dim: your keying goes out */
+    LED_SITUATION_OFF_AIR,      /**< red, dim: connected, and your keying is dropped */
+} led_situation_t;
+
+/** Everything the render needs, and nothing it could read for itself */
+typedef struct {
+    led_situation_t situation;
+    int64_t situation_elapsed_us; /**< since the situation was entered */
+    int64_t notify_elapsed_us;    /**< since led_notify(); negative when none is running */
+    bool    dit;                  /**< the DIT pin, read raw: this is a hardware indication */
+    bool    dah;                  /**< the DAH pin, read raw */
+    uint8_t count;                /**< LEDs on the strip, clamped to LED_MAX_COUNT */
+    uint8_t brightness;           /**< 0-100, the lit level */
+    uint8_t brightness_dim;       /**< 0-100, the resting level of a steady situation */
+} led_scene_t;
+
+/** One colour per LED, 0xRRGGBB */
+typedef struct {
+    uint32_t color[LED_MAX_COUNT];
+    uint8_t  count;
+} led_frame_t;
+
+/**
+ * @brief The colour that belongs to a situation
+ *
+ * @return 0xRRGGBB; LED_COLOR_GREEN only for LED_SITUATION_ON_AIR
+ */
+uint32_t led_situation_color(led_situation_t situation);
+
+/** @return the triangle-wave level of a breathing situation, 0..brightness */
+uint8_t led_breathing_level(int64_t elapsed_us, uint8_t brightness);
+
+/**
+ * @brief Fill one frame from one scene
+ *
+ * Base colour from the situation, at the breathing or the resting level; a
+ * running notification overrides that level with its flashes, in the same
+ * colour it is landing on; the paddle overlay then lights its LEDs at full
+ * brightness in that same colour. No step introduces a colour of its own.
+ *
+ * Does nothing when either argument is NULL.
+ */
+void led_render(const led_scene_t *scene, led_frame_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KEYER_LED_RENDER_H */

--- a/components/keyer_led/src/led.c
+++ b/components/keyer_led/src/led.c
@@ -12,24 +12,7 @@
 
 static const char *TAG = "led";
 
-/* Maximum number of LEDs supported */
-#define MAX_LEDS 16
-
-/* RGB color definitions (format: 0xRRGGBB) */
-#define COLOR_OFF       0x000000U
-#define COLOR_RED       0xFF0000U   /* R=FF, G=0, B=0 */
-#define COLOR_GREEN     0x00FF00U   /* R=0, G=FF, B=0 */
-#define COLOR_BLUE      0x0000FFU   /* R=0, G=0, B=FF */
-#define COLOR_ORANGE    0xFF8000U   /* R=FF, G=80, B=0 */
-#define COLOR_YELLOW    0xFFA000U   /* R=FF, G=A0, B=0 */
-#define COLOR_MAGENTA   0xFF00FFU   /* R=FF, G=0, B=FF */
-
-/* Animation timing constants */
-#define BREATH_PERIOD_US    2000000  /* 2s full breath cycle */
-#define FLASH_DURATION_US   100000   /* 100ms per flash */
-#define FLASH_GAP_US        100000   /* 100ms between flashes */
-#define RED_FLASH_US        500000   /* 500ms red flash */
-#define AP_TOGGLE_US        500000   /* 500ms alternating */
+/* Colours, animation clocks and the render itself: led_render.h */
 
 /* RMT configuration */
 #define RMT_RESOLUTION_HZ   10000000 /* 10MHz resolution (100ns) */
@@ -58,9 +41,11 @@ static struct {
     led_config_t config;
     rmt_channel_handle_t rmt_channel;
     rmt_encoder_handle_t encoder;
-    uint8_t pixel_buf[MAX_LEDS * 3];
-    _Atomic led_state_t state;
-    int64_t state_start_us;
+    uint8_t pixel_buf[LED_MAX_COUNT * 3];
+    _Atomic led_situation_t situation;
+    int64_t situation_start_us;
+    int64_t notify_start_us;
+    bool notify_active;
     _Atomic uint8_t brightness;
     _Atomic uint8_t brightness_dim;
 } s_led;
@@ -201,52 +186,6 @@ static esp_err_t led_strip_reset(rmt_encoder_t *encoder)
 }
 
 /**
- * @brief Apply brightness scaling to a 24-bit GRB color
- */
-static uint32_t apply_brightness(uint32_t color, uint8_t brightness)
-{
-    if (brightness >= 100U) {
-        return color;
-    }
-
-    uint8_t g = (uint8_t)((color >> 16) & 0xFFU);
-    uint8_t r = (uint8_t)((color >> 8) & 0xFFU);
-    uint8_t b = (uint8_t)(color & 0xFFU);
-
-    g = (uint8_t)((g * brightness) / 100U);
-    r = (uint8_t)((r * brightness) / 100U);
-    b = (uint8_t)((b * brightness) / 100U);
-
-    return ((uint32_t)g << 16) | ((uint32_t)r << 8) | (uint32_t)b;
-}
-
-/**
- * @brief Set all LEDs to a single color
- */
-static void set_all_leds(uint32_t color)
-{
-    for (size_t i = 0; i < s_led.config.led_count; i++) {
-        s_led.pixel_buf[i * 3U + 0U] = (uint8_t)((color >> 16) & 0xFFU); /* R */
-        s_led.pixel_buf[i * 3U + 1U] = (uint8_t)((color >> 8) & 0xFFU);  /* G */
-        s_led.pixel_buf[i * 3U + 2U] = (uint8_t)(color & 0xFFU);         /* B */
-    }
-}
-
-/**
- * @brief Set a single LED to a color
- */
-static void set_led(size_t index, uint32_t color)
-{
-    if (index >= s_led.config.led_count) {
-        return;
-    }
-
-    s_led.pixel_buf[index * 3U + 0U] = (uint8_t)((color >> 16) & 0xFFU); /* R */
-    s_led.pixel_buf[index * 3U + 1U] = (uint8_t)((color >> 8) & 0xFFU);  /* G */
-    s_led.pixel_buf[index * 3U + 2U] = (uint8_t)(color & 0xFFU);         /* B */
-}
-
-/**
  * @brief Transmit pixel buffer to LEDs
  */
 static void transmit_leds(void)
@@ -267,27 +206,6 @@ static void transmit_leds(void)
     }
 }
 
-/**
- * @brief Calculate breathing brightness (triangle wave)
- */
-static uint8_t calculate_breathing(int64_t elapsed_us, uint8_t brightness)
-{
-    /* Triangle wave: 0 -> max -> 0 over BREATH_PERIOD_US */
-    int64_t phase = elapsed_us % BREATH_PERIOD_US;
-    uint32_t half_period = (uint32_t)(BREATH_PERIOD_US / 2);
-
-    uint32_t value;
-    if (phase < (int64_t)half_period) {
-        /* Rising edge: 0 to brightness */
-        value = ((uint32_t)phase * brightness) / half_period;
-    } else {
-        /* Falling edge: brightness to 0 */
-        value = (((uint32_t)(BREATH_PERIOD_US - phase)) * brightness) / half_period;
-    }
-
-    return (uint8_t)value;
-}
-
 esp_err_t led_init(const led_config_t *config)
 {
     if (config == NULL) {
@@ -299,8 +217,8 @@ esp_err_t led_init(const led_config_t *config)
         return ESP_OK;
     }
 
-    if (config->led_count > MAX_LEDS) {
-        ESP_LOGE(TAG, "led_count %u exceeds MAX_LEDS %u", config->led_count, MAX_LEDS);
+    if (config->led_count > LED_MAX_COUNT) {
+        ESP_LOGE(TAG, "led_count %u exceeds LED_MAX_COUNT %u", config->led_count, LED_MAX_COUNT);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -313,8 +231,10 @@ esp_err_t led_init(const led_config_t *config)
     s_led.config = *config;
     atomic_store_explicit(&s_led.brightness, config->brightness, memory_order_relaxed);
     atomic_store_explicit(&s_led.brightness_dim, config->brightness_dim, memory_order_relaxed);
-    atomic_store_explicit(&s_led.state, LED_STATE_OFF, memory_order_relaxed);
-    s_led.state_start_us = 0;
+    atomic_store_explicit(&s_led.situation, LED_SITUATION_STARTING, memory_order_relaxed);
+    s_led.situation_start_us = 0;
+    s_led.notify_start_us = 0;
+    s_led.notify_active = false;
 
     /* Configure RMT TX channel */
     rmt_tx_channel_config_t tx_config = {
@@ -380,19 +300,25 @@ void led_deinit(void)
     ESP_LOGI(TAG, "Deinitialized");
 }
 
-void led_set_state(led_state_t state)
+void led_set_situation(led_situation_t situation)
 {
-    led_state_t old_state = atomic_load_explicit(&s_led.state, memory_order_relaxed);
-    if (state != old_state) {
-        atomic_store_explicit(&s_led.state, state, memory_order_relaxed);
-        s_led.state_start_us = esp_timer_get_time();
-        ESP_LOGI(TAG, "State: %d -> %d", old_state, state);
+    led_situation_t previous = atomic_load_explicit(&s_led.situation, memory_order_relaxed);
+    if (situation != previous) {
+        atomic_store_explicit(&s_led.situation, situation, memory_order_relaxed);
+        s_led.situation_start_us = esp_timer_get_time();
+        ESP_LOGI(TAG, "Situation: %d -> %d", (int)previous, (int)situation);
     }
 }
 
-led_state_t led_get_state(void)
+led_situation_t led_get_situation(void)
 {
-    return atomic_load_explicit(&s_led.state, memory_order_relaxed);
+    return atomic_load_explicit(&s_led.situation, memory_order_relaxed);
+}
+
+void led_notify(void)
+{
+    s_led.notify_start_us = esp_timer_get_time();
+    s_led.notify_active = true;
 }
 
 void led_tick(int64_t now_us, bool dit, bool dah)
@@ -401,113 +327,33 @@ void led_tick(int64_t now_us, bool dit, bool dah)
         return;
     }
 
-    led_state_t current_state = atomic_load_explicit(&s_led.state, memory_order_relaxed);
-    int64_t elapsed_us = now_us - s_led.state_start_us;
-    uint8_t brightness = atomic_load_explicit(&s_led.brightness, memory_order_relaxed);
-    uint8_t brightness_dim = atomic_load_explicit(&s_led.brightness_dim, memory_order_relaxed);
-
-    switch (current_state) {
-    case LED_STATE_OFF:
-        set_all_leds(COLOR_OFF);
-        break;
-
-    case LED_STATE_BOOT:
-    case LED_STATE_WIFI_CONNECTING: {
-        /* Orange breathing */
-        uint8_t breath = calculate_breathing(elapsed_us, brightness);
-        uint32_t color = apply_brightness(COLOR_ORANGE, breath);
-        set_all_leds(color);
-        break;
-    }
-
-    case LED_STATE_WIFI_FAILED: {
-        /* Red flash for 500ms, then auto-transition to DEGRADED */
-        if (elapsed_us < RED_FLASH_US) {
-            uint32_t color = apply_brightness(COLOR_RED, brightness);
-            set_all_leds(color);
-        } else {
-            led_set_state(LED_STATE_DEGRADED);
-            return; /* Will be rendered on next tick */
+    int64_t notify_elapsed = -1;
+    if (s_led.notify_active) {
+        notify_elapsed = now_us - s_led.notify_start_us;
+        if (notify_elapsed >= LED_NOTIFY_TOTAL_US) {
+            s_led.notify_active = false;
+            notify_elapsed = -1;
         }
-        break;
     }
 
-    case LED_STATE_DEGRADED: {
-        /* Dim yellow steady */
-        uint32_t color = apply_brightness(COLOR_YELLOW, brightness_dim);
-        set_all_leds(color);
-        break;
-    }
+    const led_scene_t scene = {
+        .situation = atomic_load_explicit(&s_led.situation, memory_order_relaxed),
+        .situation_elapsed_us = now_us - s_led.situation_start_us,
+        .notify_elapsed_us = notify_elapsed,
+        .dit = dit,
+        .dah = dah,
+        .count = s_led.config.led_count,
+        .brightness = atomic_load_explicit(&s_led.brightness, memory_order_relaxed),
+        .brightness_dim = atomic_load_explicit(&s_led.brightness_dim, memory_order_relaxed),
+    };
 
-    case LED_STATE_AP_MODE: {
-        /* Alternating orange/blue every 500ms */
-        int64_t phase = elapsed_us % (AP_TOGGLE_US * 2);
-        uint32_t base_color = (phase < AP_TOGGLE_US) ? COLOR_ORANGE : COLOR_BLUE;
-        uint32_t color = apply_brightness(base_color, brightness);
-        set_all_leds(color);
-        break;
-    }
+    led_frame_t frame;
+    led_render(&scene, &frame);
 
-    case LED_STATE_PROVISIONING: {
-        /* Blue breathing for provisioning mode */
-        uint8_t breath_brightness = calculate_breathing(elapsed_us, brightness);
-        uint32_t color = apply_brightness(COLOR_BLUE, breath_brightness);
-        set_all_leds(color);
-        break;
-    }
-
-    case LED_STATE_CONNECTED: {
-        /* 3 quick green flashes, then auto-transition to IDLE */
-        int64_t flash_cycle = FLASH_DURATION_US + FLASH_GAP_US;
-        int64_t flash_num = elapsed_us / flash_cycle;
-
-        if (flash_num >= 3) {
-            led_set_state(LED_STATE_IDLE);
-            return; /* Will be rendered on next tick */
-        }
-
-        int64_t phase = elapsed_us % flash_cycle;
-        if (phase < FLASH_DURATION_US) {
-            uint32_t color = apply_brightness(COLOR_GREEN, brightness);
-            set_all_leds(color);
-        } else {
-            set_all_leds(COLOR_OFF);
-        }
-        break;
-    }
-
-    case LED_STATE_IDLE: {
-        /* Dim green steady with keying overlay */
-        uint32_t base_color = apply_brightness(COLOR_GREEN, brightness_dim);
-        set_all_leds(base_color);
-
-        /* Keying overlay */
-        if (dit && dah) {
-            /* Squeeze: center LED magenta */
-            size_t center = (size_t)s_led.config.led_count / 2U;
-            uint32_t magenta = apply_brightness(COLOR_MAGENTA, brightness);
-            set_led(center, magenta);
-        } else if (dit) {
-            /* DIT: left LEDs bright green */
-            size_t center = (size_t)s_led.config.led_count / 2U;
-            uint32_t bright_green = apply_brightness(COLOR_GREEN, brightness);
-            for (size_t i = 0; i < center; i++) {
-                set_led(i, bright_green);
-            }
-        } else if (dah) {
-            /* DAH: right LEDs bright green */
-            size_t center = (size_t)s_led.config.led_count / 2U;
-            uint32_t bright_green = apply_brightness(COLOR_GREEN, brightness);
-            for (size_t i = center + 1U; i < s_led.config.led_count; i++) {
-                set_led(i, bright_green);
-            }
-        }
-        break;
-    }
-
-    default:
-        set_all_leds(COLOR_OFF);
-        break;
+    for (uint8_t i = 0; i < frame.count; i++) {
+        s_led.pixel_buf[i * 3U + 0U] = (uint8_t)((frame.color[i] >> 16) & 0xFFU); /* R */
+        s_led.pixel_buf[i * 3U + 1U] = (uint8_t)((frame.color[i] >> 8) & 0xFFU);  /* G */
+        s_led.pixel_buf[i * 3U + 2U] = (uint8_t)(frame.color[i] & 0xFFU);         /* B */
     }
 
     transmit_leds();

--- a/components/keyer_led/src/led_render.c
+++ b/components/keyer_led/src/led_render.c
@@ -1,0 +1,95 @@
+/**
+ * @file led_render.c
+ * @brief The pure half of the LED driver: a scene becomes a frame
+ */
+
+#include "led_render.h"
+
+/** Scale a 0xRRGGBB colour by a percentage */
+static uint32_t scale(uint32_t color, uint8_t brightness)
+{
+    if (brightness >= 100U) {
+        return color;
+    }
+    uint32_t r = ((color >> 16) & 0xFFU) * brightness / 100U;
+    uint32_t g = ((color >> 8) & 0xFFU) * brightness / 100U;
+    uint32_t b = (color & 0xFFU) * brightness / 100U;
+    return (r << 16) | (g << 8) | b;
+}
+
+uint32_t led_situation_color(led_situation_t situation)
+{
+    switch (situation) {
+        case LED_SITUATION_STARTING:   return LED_COLOR_ORANGE;
+        case LED_SITUATION_SETUP:      return LED_COLOR_BLUE;
+        case LED_SITUATION_LOCAL_ONLY: return LED_COLOR_YELLOW;
+        case LED_SITUATION_ON_AIR:     return LED_COLOR_GREEN;
+        case LED_SITUATION_OFF_AIR:    return LED_COLOR_RED;
+        default:                       return LED_COLOR_OFF;
+    }
+}
+
+uint8_t led_breathing_level(int64_t elapsed_us, uint8_t brightness)
+{
+    int64_t phase = elapsed_us % LED_BREATH_PERIOD_US;
+    if (phase < 0) {
+        phase += LED_BREATH_PERIOD_US;
+    }
+    const int64_t half = LED_BREATH_PERIOD_US / 2;
+    int64_t rising = (phase < half) ? phase : (LED_BREATH_PERIOD_US - phase);
+    return (uint8_t)((rising * (int64_t)brightness) / half);
+}
+
+void led_render(const led_scene_t *scene, led_frame_t *out)
+{
+    if (scene == NULL || out == NULL) {
+        return;
+    }
+
+    uint8_t count = (scene->count > LED_MAX_COUNT) ? (uint8_t)LED_MAX_COUNT : scene->count;
+    out->count = count;
+
+    const uint32_t hue = led_situation_color(scene->situation);
+    const bool breathing = (scene->situation == LED_SITUATION_STARTING) ||
+                           (scene->situation == LED_SITUATION_SETUP);
+
+    uint8_t level = breathing
+                  ? led_breathing_level(scene->situation_elapsed_us, scene->brightness)
+                  : scene->brightness_dim;
+
+    /* A notification is an event asking for attention, so it flashes in the
+     * colour it is landing on rather than a colour of its own. */
+    if (scene->notify_elapsed_us >= 0 && scene->notify_elapsed_us < LED_NOTIFY_TOTAL_US) {
+        int64_t phase = scene->notify_elapsed_us % (LED_FLASH_DURATION_US + LED_FLASH_GAP_US);
+        level = (phase < LED_FLASH_DURATION_US) ? scene->brightness : 0U;
+    }
+
+    const uint32_t base = scale(hue, level);
+    for (uint8_t i = 0; i < count; i++) {
+        out->color[i] = base;
+    }
+
+    if (!scene->dit && !scene->dah) {
+        return;
+    }
+
+    /* The overlay is the raw pins, so it says whether the contact closes at
+     * all: lit but silent is a software fault, dark is the contact or the
+     * wiring. It carries position and brightness, never a colour. */
+    const uint32_t lit = scale(hue, scene->brightness);
+    const uint8_t center = (uint8_t)(count / 2U);
+
+    if (scene->dit && scene->dah) {
+        for (uint8_t i = 0; i < count; i++) {
+            out->color[i] = lit;
+        }
+    } else if (scene->dit) {
+        for (uint8_t i = 0; i < center; i++) {
+            out->color[i] = lit;
+        }
+    } else {
+        for (uint8_t i = (uint8_t)(center + 1U); i < count; i++) {
+            out->color[i] = lit;
+        }
+    }
+}

--- a/components/keyer_webui/frontend/src/lib/types.ts
+++ b/components/keyer_webui/frontend/src/lib/types.ts
@@ -1,6 +1,12 @@
 export interface CWNetStatus {
   state: string;
   latency_ms: number;
+  /** "unknown" | "free" | "mine" | "other": who has the server's key */
+  key_holder?: string;
+  /** The name the server announced with the key, "" until one arrives */
+  key_holder_name?: string;
+  /** READY, TRANSMIT granted, key free or ours: our keying goes on the air */
+  can_transmit?: boolean;
 }
 
 export interface DeviceStatus {

--- a/components/keyer_webui/frontend/src/pages/System.svelte
+++ b/components/keyer_webui/frontend/src/pages/System.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { api } from '../lib/api';
-  import type { SystemStats, DeviceStatus, VpnStatus } from '../lib/types';
+  import type { SystemStats, DeviceStatus, VpnStatus, CWNetStatus } from '../lib/types';
 
   let status = $state<DeviceStatus | null>(null);
   let stats = $state<SystemStats | null>(null);
@@ -15,6 +15,17 @@
     if (bytes < 1024) return bytes + ' B';
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
     return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+  }
+
+  /** What the server does with our keying, in words, with the name where it matters */
+  function keyLabel(c: CWNetStatus): string {
+    if (c.state !== 'READY') return '---';
+    switch (c.key_holder) {
+      case 'free':  return c.can_transmit ? 'FREE' : 'NOT PERMITTED';
+      case 'mine':  return c.can_transmit ? 'MINE' : 'NOT PERMITTED';
+      case 'other': return 'BUSY: ' + (c.key_holder_name || '?');
+      default:      return 'WAITING';
+    }
   }
 
   function getStateClass(state: string): string {
@@ -180,6 +191,12 @@
             <span class="stat-label">RTT</span>
             <span class="stat-value rtt">
               {status.cwnet.latency_ms >= 0 ? status.cwnet.latency_ms + ' ms' : '---'}
+            </span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-label">KEY</span>
+            <span class="stat-value" class:key-free={status.cwnet.can_transmit} class:key-busy={status.cwnet.state === 'READY' && !status.cwnet.can_transmit}>
+              {keyLabel(status.cwnet)}
             </span>
           </div>
         </div>
@@ -471,6 +488,14 @@
   }
 
   .stat-value.cwnet-error {
+    color: var(--accent-red);
+  }
+
+  .stat-value.key-free {
+    color: var(--accent-green);
+  }
+
+  .stat-value.key-busy {
     color: var(--accent-red);
   }
 

--- a/components/keyer_webui/src/api_system.c
+++ b/components/keyer_webui/src/api_system.c
@@ -50,6 +50,7 @@ esp_err_t api_status_handler(httpd_req_t *req) {
     cJSON_AddStringToObject(cwnet, "key_holder",
                             cwnet_client_key_holder_str(cwnet_socket_get_key_holder()));
     cJSON_AddStringToObject(cwnet, "key_holder_name", cwnet_socket_get_key_holder_name());
+    cJSON_AddBoolToObject(cwnet, "can_transmit", cwnet_socket_can_transmit());
     cJSON_AddItemToObject(root, "cwnet", cwnet);
 
     char *json_str = cJSON_PrintUnformatted(root);

--- a/components/provisioning/src/provisioning.c
+++ b/components/provisioning/src/provisioning.c
@@ -227,9 +227,9 @@ void provisioning_start(void)
     /* Start HTTP server */
     prov_http_start();
 
-    /* Set LED to blue breathing to indicate provisioning mode */
+    /* Blue breathing: come to the access point */
     if (led_is_initialized()) {
-        led_set_state(LED_STATE_PROVISIONING);
+        led_set_situation(LED_SITUATION_SETUP);
     }
 
     ESP_LOGI(TAG, "Provisioning ready. Connect to 'CWKeyer-Setup' and open http://192.168.4.1");

--- a/main/bg_task.c
+++ b/main/bg_task.c
@@ -52,21 +52,36 @@ static uint8_t s_tl_prev_local_key = 0;
 /**
  * @brief Map WiFi state to LED state
  */
-static led_state_t wifi_to_led_state(wifi_state_t ws) {
+/**
+ * @brief The situation the LEDs show, from WiFi and from CWNet (#26)
+ *
+ * The rule is green means the operator's CW goes out (led_render.h), so
+ * this answers exactly that. WiFi off in config is not a degradation: the
+ * box was asked to be a local keyer and it is one, and the key line still
+ * works, so it is green. WiFi asked for and missing is yellow. With the
+ * link up, CWNet decides: disabled promises nothing remote and stays
+ * green, otherwise the server has to be ready, TRANSMIT granted and the
+ * key free or ours, which is what cwnet_socket_can_transmit() is.
+ */
+static led_situation_t led_situation_now(wifi_state_t ws) {
     switch (ws) {
-        case WIFI_STATE_DISABLED:
-            return LED_STATE_IDLE;  /* Skip to idle if WiFi disabled */
         case WIFI_STATE_CONNECTING:
-            return LED_STATE_WIFI_CONNECTING;
-        case WIFI_STATE_CONNECTED:
-            return LED_STATE_CONNECTED;
-        case WIFI_STATE_FAILED:
-            return LED_STATE_WIFI_FAILED;
+            return LED_SITUATION_STARTING;
         case WIFI_STATE_AP_MODE:
-            return LED_STATE_AP_MODE;
+            return LED_SITUATION_SETUP;
+        case WIFI_STATE_FAILED:
+            return LED_SITUATION_LOCAL_ONLY;
+        case WIFI_STATE_CONNECTED:
+            break;
+        case WIFI_STATE_DISABLED:
         default:
-            return LED_STATE_IDLE;
+            return LED_SITUATION_ON_AIR;
     }
+
+    if (cwnet_socket_get_state() == CWNET_SOCK_DISABLED) {
+        return LED_SITUATION_ON_AIR;
+    }
+    return cwnet_socket_can_transmit() ? LED_SITUATION_ON_AIR : LED_SITUATION_OFF_AIR;
 }
 
 void bg_task(void *arg) {
@@ -88,19 +103,24 @@ void bg_task(void *arg) {
     uint32_t stats_counter = 0;
     wifi_state_t prev_wifi_state = WIFI_STATE_DISABLED;
     vpn_state_t prev_vpn_state = VPN_STATE_DISABLED;
-    bool wifi_connected_flash_done = false;
 
     for (;;) {
         now_us = esp_timer_get_time();
 
-        /* Update LED state from WiFi */
+        /* What the LEDs show, from WiFi and CWNet. Recomputed every tick:
+         * the key can change hands without WiFi moving at all, and
+         * led_set_situation() only restarts a clock on a real change. */
         if (led_is_initialized()) {
             wifi_state_t ws = wifi_get_state();
 
+            led_set_situation(led_situation_now(ws));
+
             /* Detect state changes */
             if (ws != prev_wifi_state) {
-                led_state_t new_led_state = wifi_to_led_state(ws);
-                led_set_state(new_led_state);
+                /* An event worth looking up for, in the colour it lands on */
+                if (ws == WIFI_STATE_CONNECTED || ws == WIFI_STATE_FAILED) {
+                    led_notify();
+                }
 
                 /* Log state change */
                 if (ws == WIFI_STATE_CONNECTED) {
@@ -108,7 +128,6 @@ void bg_task(void *arg) {
                     if (wifi_get_ip(ip_buf, sizeof(ip_buf))) {
                         RT_INFO(&g_bg_log_stream, now_us, "WiFi connected: %s", ip_buf);
                     }
-                    wifi_connected_flash_done = false;
                 } else if (ws == WIFI_STATE_AP_MODE) {
                     RT_INFO(&g_bg_log_stream, now_us, "WiFi AP mode active");
                 } else if (ws == WIFI_STATE_FAILED) {
@@ -143,13 +162,9 @@ void bg_task(void *arg) {
                 prev_vpn_state = vs;
             }
 
-            /* After connected flash sequence, transition to idle */
-            led_state_t current_led = led_get_state();
-            if (current_led == LED_STATE_IDLE && !wifi_connected_flash_done) {
-                wifi_connected_flash_done = true;
-            }
-
-            /* Read paddle state for keying overlay */
+            /* The paddle overlay is a second, independent read of the pins,
+             * upstream of the debounce and the FSM: lit but silent means the
+             * fault is in software, dark means the contact never closed. */
             gpio_state_t paddles = hal_gpio_read_paddles();
             led_tick(now_us, gpio_dit(paddles), gpio_dah(paddles));
         }

--- a/main/main.c
+++ b/main/main.c
@@ -156,7 +156,7 @@ void app_main(void) {
     };
     ret = led_init(&led_cfg);
     if (ret == ESP_OK) {
-        led_set_state(LED_STATE_BOOT);
+        led_set_situation(LED_SITUATION_STARTING);
     } else {
         ESP_LOGW(TAG, "LED init failed (non-fatal): %s", esp_err_to_name(ret));
     }
@@ -178,15 +178,15 @@ void app_main(void) {
 
         ret = wifi_app_init(&wifi_cfg);
         if (ret == ESP_OK) {
-            led_set_state(LED_STATE_WIFI_CONNECTING);
+            led_set_situation(LED_SITUATION_STARTING);
             wifi_app_start();
         } else {
             ESP_LOGE(TAG, "WiFi init failed: %s", esp_err_to_name(ret));
-            led_set_state(LED_STATE_DEGRADED);
+            led_set_situation(LED_SITUATION_LOCAL_ONLY);
         }
     } else {
         ESP_LOGI(TAG, "WiFi disabled");
-        led_set_state(LED_STATE_IDLE);
+        led_set_situation(LED_SITUATION_ON_AIR);
     }
 
     /* Initialize VPN if enabled (requires WiFi) */

--- a/test_host/CMakeLists.txt
+++ b/test_host/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories(
     ${COMPONENT_DIR}/keyer_config           # Generated headers in root
     ${COMPONENT_DIR}/keyer_decoder/include
     ${COMPONENT_DIR}/keyer_cwnet/include
+    ${COMPONENT_DIR}/keyer_led/include
     ${CMAKE_SOURCE_DIR}/stubs
 )
 
@@ -86,6 +87,7 @@ set(DECODER_SOURCES
 
 # CWNet sources (TDD - implementation files added as they are created)
 set(CWNET_SOURCES
+    ${COMPONENT_DIR}/keyer_led/src/led_render.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_timestamp.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_frame.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_ping.c
@@ -104,6 +106,7 @@ set(TEST_SOURCES
     # test_history.c  # Excluded: requires console system
     # test_completion.c  # Excluded: requires commands.c
     test_rt_diag.c
+    test_led.c
     test_morse_table.c
     test_timing_classifier.c
     test_decoder.c

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -847,6 +847,69 @@ void test_client_rx_keeps_the_rig_result(void) {
 /* Who has the key: the server's TX_INFO announcements                       */
 /*===========================================================================*/
 
+/*
+ * What the reference server does with a MORSE frame (CwNet.c:2875-2902):
+ * plays it when the key is free or the sender's and the sender has
+ * TRANSMIT, drops it otherwise. can_transmit is that verdict, taken from
+ * the CONNECT echo (permissions 7 in the capture) and the announcements.
+ */
+void test_client_can_transmit_only_when_the_reference_would_play_it(void) {
+    ready_client_named("Moritz");
+    TEST_ASSERT_EQUAL(CWNET_PERMISSION_TALK | CWNET_PERMISSION_TRANSMIT | CWNET_PERMISSION_CTRL_RIG,
+                      cwnet_client_get_permissions(&client));
+    /* READY with TRANSMIT, nothing announced yet: a doubt reads as no */
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));
+
+    cwnet_client_on_data(&client, ref_tx_info_nobody, sizeof(ref_tx_info_nobody));
+    TEST_ASSERT_TRUE(cwnet_client_can_transmit(&client));   /* free: the first byte takes it */
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_TRUE(cwnet_client_can_transmit(&client));   /* ours: it keeps playing */
+    cwnet_client_on_data(&client, ref_tx_info_sysop, sizeof(ref_tx_info_sysop));
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));  /* the sysop's: ours is dropped */
+    cwnet_client_on_data(&client, ref_tx_info_nobody, sizeof(ref_tx_info_nobody));
+    TEST_ASSERT_TRUE(cwnet_client_can_transmit(&client));
+
+    /* Another client's key, even with our permissions intact */
+    ready_client_named("TEST");
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_OTHER, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));
+}
+
+void test_client_can_transmit_needs_transmit_permission_and_ready(void) {
+    /* The captured echo with TRANSMIT cleared: TALK | CTRL_RIG only */
+    cwnet_client_config_t config = {
+        .server_host = "test.server.com",
+        .server_port = 7373,
+        .username = "Moritz",
+        .send_cb = mock_send_accumulate,
+        .get_time_ms_cb = mock_get_time_ms,
+        .user_data = NULL
+    };
+    test_setup();
+    cwnet_client_init(&client, &config);
+    cwnet_client_on_connected(&client);
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));  /* not READY yet */
+
+    uint8_t echo[sizeof(ref_connect_echo)];
+    memcpy(echo, ref_connect_echo, sizeof(echo));
+    echo[2 + CWNET_CONNECT_PERMISSIONS_OFFSET] &= (uint8_t)~CWNET_PERMISSION_TRANSMIT;
+    cwnet_client_on_data(&client, echo, sizeof(echo));
+    TEST_ASSERT_EQUAL(CWNET_STATE_READY, cwnet_client_get_state(&client));
+    TEST_ASSERT_EQUAL(CWNET_PERMISSION_TALK | CWNET_PERMISSION_CTRL_RIG, cwnet_client_get_permissions(&client));
+
+    cwnet_client_on_data(&client, ref_tx_info_nobody, sizeof(ref_tx_info_nobody));
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));  /* free, but not permitted */
+    cwnet_client_on_data(&client, ref_tx_info_moritz, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_MINE, cwnet_client_get_key_holder(&client));
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));
+
+    /* Losing the connection forgets everything */
+    cwnet_client_on_disconnected(&client);
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(&client));
+    TEST_ASSERT_FALSE(cwnet_client_can_transmit(NULL));
+}
+
 void test_client_key_holder_unknown_until_announced(void) {
     ready_client_accumulating();
     TEST_ASSERT_EQUAL(CWNET_KEY_HOLDER_UNKNOWN, cwnet_client_get_key_holder(&client));

--- a/test_host/test_led.c
+++ b/test_host/test_led.c
@@ -1,0 +1,244 @@
+/**
+ * @file test_led.c
+ * @brief The LED vocabulary, pinned to its one rule
+ *
+ * The rule (#26, led_render.h): green means the operator's CW goes out,
+ * and every other colour means it does not. The render is a pure function
+ * precisely so that rule can be proven here instead of looked at on a
+ * bench, and the test that matters is the one that would fail the moment
+ * some future state, overlay or notification lights green for anything
+ * but being on air.
+ */
+
+#include "unity.h"
+#include "led_render.h"
+#include <string.h>
+
+/* Exact arithmetic: at 100 a colour is itself, at 10 each channel is a
+ * tenth, so the expectations below are written out rather than recomputed
+ * with the implementation's own formula. */
+#define FULL 100
+#define DIM   10
+
+static const led_situation_t all_situations[] = {
+    LED_SITUATION_STARTING,
+    LED_SITUATION_SETUP,
+    LED_SITUATION_LOCAL_ONLY,
+    LED_SITUATION_ON_AIR,
+    LED_SITUATION_OFF_AIR,
+};
+
+static led_scene_t scene_of(led_situation_t s) {
+    led_scene_t scene;
+    memset(&scene, 0, sizeof(scene));
+    scene.situation = s;
+    scene.notify_elapsed_us = -1;
+    scene.count = 7;
+    scene.brightness = FULL;
+    scene.brightness_dim = DIM;
+    return scene;
+}
+
+/* Green on the wire: no red, some green, no blue. Orange and yellow both
+ * carry red, blue carries only blue, so this catches exactly the lie. */
+static bool is_green(uint32_t c) {
+    return ((c >> 16) & 0xFFU) == 0U && ((c >> 8) & 0xFFU) > 0U && (c & 0xFFU) == 0U;
+}
+
+void test_led_green_belongs_to_on_air_and_to_nothing_else(void) {
+    /* Every situation, across a full breath, with every paddle combination:
+     * the only frames carrying green are the on-air ones. */
+    static const int64_t phases[] = {0, 250000, 500000, 999999, 1000000, 1500000, 1999999};
+
+    for (size_t s = 0; s < sizeof(all_situations) / sizeof(all_situations[0]); s++) {
+        for (size_t p = 0; p < sizeof(phases) / sizeof(phases[0]); p++) {
+            for (int paddles = 0; paddles < 4; paddles++) {
+                led_scene_t scene = scene_of(all_situations[s]);
+                scene.situation_elapsed_us = phases[p];
+                scene.dit = (paddles & 1) != 0;
+                scene.dah = (paddles & 2) != 0;
+
+                led_frame_t frame;
+                memset(&frame, 0, sizeof(frame));
+                led_render(&scene, &frame);
+
+                bool on_air = (all_situations[s] == LED_SITUATION_ON_AIR);
+                for (uint8_t i = 0; i < frame.count; i++) {
+                    if (!on_air) {
+                        TEST_ASSERT_FALSE_MESSAGE(is_green(frame.color[i]),
+                            "a situation that is not on air lit an LED green");
+                    }
+                }
+            }
+        }
+    }
+}
+
+void test_led_each_situation_carries_its_own_colour(void) {
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_ORANGE, led_situation_color(LED_SITUATION_STARTING));
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_BLUE,   led_situation_color(LED_SITUATION_SETUP));
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_YELLOW, led_situation_color(LED_SITUATION_LOCAL_ONLY));
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_GREEN,  led_situation_color(LED_SITUATION_ON_AIR));
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_RED,    led_situation_color(LED_SITUATION_OFF_AIR));
+
+    /* Five situations, five distinct colours: none is a synonym of another */
+    for (size_t a = 0; a < 5; a++) {
+        for (size_t b = a + 1; b < 5; b++) {
+            TEST_ASSERT_NOT_EQUAL(led_situation_color(all_situations[a]),
+                                  led_situation_color(all_situations[b]));
+        }
+    }
+}
+
+void test_led_a_steady_situation_lights_the_whole_strip_dim(void) {
+    led_scene_t scene = scene_of(LED_SITUATION_OFF_AIR);
+    led_frame_t frame;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&scene, &frame);
+
+    TEST_ASSERT_EQUAL_UINT8(7, frame.count);
+    for (uint8_t i = 0; i < frame.count; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0x190000U, frame.color[i]);  /* red at a tenth */
+    }
+}
+
+/*
+ * The overlay is the raw DIT/DAH pins, so it answers "does the contact
+ * close at all" without the debounce or the FSM in the way. It carries
+ * position and brightness and never a colour, which is what keeps the
+ * rule true while the operator is actually keying: here the situation is
+ * off air, and the lit LEDs must be red, not the green they used to be.
+ */
+void test_led_overlay_carries_position_and_never_a_colour(void) {
+    led_frame_t frame;
+
+    led_scene_t dit = scene_of(LED_SITUATION_OFF_AIR);
+    dit.dit = true;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&dit, &frame);
+    for (uint8_t i = 0; i < 3; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0xFF0000U, frame.color[i]);   /* left three, full red */
+    }
+    for (uint8_t i = 3; i < 7; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0x190000U, frame.color[i]);   /* the rest at rest */
+    }
+
+    led_scene_t dah = scene_of(LED_SITUATION_OFF_AIR);
+    dah.dah = true;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&dah, &frame);
+    for (uint8_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0x190000U, frame.color[i]);
+    }
+    for (uint8_t i = 4; i < 7; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0xFF0000U, frame.color[i]);   /* right three */
+    }
+
+    /* Squeeze is both sides and the centre, so the whole strip lights: one
+     * more picture in the same colour, where the magenta pixel used to be. */
+    led_scene_t squeeze = scene_of(LED_SITUATION_OFF_AIR);
+    squeeze.dit = true;
+    squeeze.dah = true;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&squeeze, &frame);
+    for (uint8_t i = 0; i < 7; i++) {
+        TEST_ASSERT_EQUAL_HEX32(0xFF0000U, frame.color[i]);
+    }
+}
+
+void test_led_overlay_shows_the_paddle_in_every_situation(void) {
+    /* It used to exist only in the idle state, so a box that was not idle
+     * showed nothing about the paddle at all: exactly when a diagnosis is
+     * wanted. Every situation now carries it. */
+    for (size_t s = 0; s < sizeof(all_situations) / sizeof(all_situations[0]); s++) {
+        led_scene_t resting = scene_of(all_situations[s]);
+        led_scene_t keyed = scene_of(all_situations[s]);
+        keyed.dit = true;
+
+        led_frame_t a, b;
+        memset(&a, 0, sizeof(a));
+        memset(&b, 0, sizeof(b));
+        led_render(&resting, &a);
+        led_render(&keyed, &b);
+
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(a.color[0], b.color[0],
+            "closing DIT changed nothing on the strip in some situation");
+    }
+}
+
+void test_led_notification_flashes_in_the_colour_it_lands_on(void) {
+    led_frame_t frame;
+
+    /* Landing on off air: the attention flashes are red, not a colour of
+     * their own, so an event can never announce something the situation
+     * contradicts. */
+    led_scene_t lit = scene_of(LED_SITUATION_OFF_AIR);
+    lit.notify_elapsed_us = 0;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&lit, &frame);
+    TEST_ASSERT_EQUAL_HEX32(0xFF0000U, frame.color[0]);
+
+    led_scene_t gap = scene_of(LED_SITUATION_OFF_AIR);
+    gap.notify_elapsed_us = LED_FLASH_DURATION_US;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&gap, &frame);
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_OFF, frame.color[0]);
+
+    /* Three flashes, then the situation has the strip back */
+    led_scene_t done = scene_of(LED_SITUATION_OFF_AIR);
+    done.notify_elapsed_us = LED_NOTIFY_TOTAL_US;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&done, &frame);
+    TEST_ASSERT_EQUAL_HEX32(0x190000U, frame.color[0]);
+
+    /* A paddle still wins over a flash: the pin is the more urgent fact */
+    led_scene_t keyed = scene_of(LED_SITUATION_OFF_AIR);
+    keyed.notify_elapsed_us = LED_FLASH_DURATION_US;  /* dark phase */
+    keyed.dit = true;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&keyed, &frame);
+    TEST_ASSERT_EQUAL_HEX32(0xFF0000U, frame.color[0]);
+}
+
+void test_led_breathing_rises_and_falls_over_the_period(void) {
+    TEST_ASSERT_EQUAL_UINT8(0,   led_breathing_level(0, FULL));
+    TEST_ASSERT_EQUAL_UINT8(50,  led_breathing_level(LED_BREATH_PERIOD_US / 4, FULL));
+    TEST_ASSERT_EQUAL_UINT8(100, led_breathing_level(LED_BREATH_PERIOD_US / 2, FULL));
+    TEST_ASSERT_EQUAL_UINT8(50,  led_breathing_level(3 * (LED_BREATH_PERIOD_US / 4), FULL));
+    /* It cycles: the next period repeats the first */
+    TEST_ASSERT_EQUAL_UINT8(100, led_breathing_level(LED_BREATH_PERIOD_US + LED_BREATH_PERIOD_US / 2, FULL));
+
+    /* Only the two breathing situations breathe; the others sit still */
+    led_scene_t starting_low = scene_of(LED_SITUATION_STARTING);
+    led_scene_t starting_high = scene_of(LED_SITUATION_STARTING);
+    starting_high.situation_elapsed_us = LED_BREATH_PERIOD_US / 2;
+    led_frame_t low, high;
+    memset(&low, 0, sizeof(low));
+    memset(&high, 0, sizeof(high));
+    led_render(&starting_low, &low);
+    led_render(&starting_high, &high);
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_OFF, low.color[0]);
+    TEST_ASSERT_EQUAL_HEX32(LED_COLOR_ORANGE, high.color[0]);
+
+    led_scene_t steady_a = scene_of(LED_SITUATION_ON_AIR);
+    led_scene_t steady_b = scene_of(LED_SITUATION_ON_AIR);
+    steady_b.situation_elapsed_us = LED_BREATH_PERIOD_US / 2;
+    memset(&low, 0, sizeof(low));
+    memset(&high, 0, sizeof(high));
+    led_render(&steady_a, &low);
+    led_render(&steady_b, &high);
+    TEST_ASSERT_EQUAL_HEX32(low.color[0], high.color[0]);
+}
+
+void test_led_render_clamps_the_strip_and_survives_null(void) {
+    led_scene_t scene = scene_of(LED_SITUATION_ON_AIR);
+    scene.count = LED_MAX_COUNT + 5;
+    led_frame_t frame;
+    memset(&frame, 0, sizeof(frame));
+    led_render(&scene, &frame);
+    TEST_ASSERT_EQUAL_UINT8(LED_MAX_COUNT, frame.count);
+
+    led_render(NULL, &frame);
+    led_render(&scene, NULL);
+    TEST_ASSERT_EQUAL_UINT8(LED_MAX_COUNT, frame.count);
+}

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -247,6 +247,17 @@ void test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail(void);
 void test_client_abort_over_drops_ptt_too(void);
 void test_client_rx_keeps_the_rig_result(void);
 void test_client_rejects_events_when_not_ready(void);
+/* LED vocabulary: the colour rule (#26) */
+void test_led_green_belongs_to_on_air_and_to_nothing_else(void);
+void test_led_each_situation_carries_its_own_colour(void);
+void test_led_a_steady_situation_lights_the_whole_strip_dim(void);
+void test_led_overlay_carries_position_and_never_a_colour(void);
+void test_led_overlay_shows_the_paddle_in_every_situation(void);
+void test_led_notification_flashes_in_the_colour_it_lands_on(void);
+void test_led_breathing_rises_and_falls_over_the_period(void);
+void test_led_render_clamps_the_strip_and_survives_null(void);
+void test_client_can_transmit_only_when_the_reference_would_play_it(void);
+void test_client_can_transmit_needs_transmit_permission_and_ready(void);
 void test_client_key_holder_unknown_until_announced(void);
 void test_client_key_holder_reads_the_three_captured_announcements(void);
 void test_client_key_holder_another_client_is_other(void);
@@ -573,6 +584,17 @@ int main(void) {
     RUN_TEST(test_client_rx_keeps_the_rig_result);
     RUN_TEST(test_client_rejects_events_when_not_ready);
     /* Who has the key: TX_INFO 0x05 against the 2026-09-05 capture */
+    /* LED vocabulary: green means on air, and nothing else is green */
+    RUN_TEST(test_led_green_belongs_to_on_air_and_to_nothing_else);
+    RUN_TEST(test_led_each_situation_carries_its_own_colour);
+    RUN_TEST(test_led_a_steady_situation_lights_the_whole_strip_dim);
+    RUN_TEST(test_led_overlay_carries_position_and_never_a_colour);
+    RUN_TEST(test_led_overlay_shows_the_paddle_in_every_situation);
+    RUN_TEST(test_led_notification_flashes_in_the_colour_it_lands_on);
+    RUN_TEST(test_led_breathing_rises_and_falls_over_the_period);
+    RUN_TEST(test_led_render_clamps_the_strip_and_survives_null);
+    RUN_TEST(test_client_can_transmit_only_when_the_reference_would_play_it);
+    RUN_TEST(test_client_can_transmit_needs_transmit_permission_and_ready);
     RUN_TEST(test_client_key_holder_unknown_until_announced);
     RUN_TEST(test_client_key_holder_reads_the_three_captured_announcements);
     RUN_TEST(test_client_key_holder_another_client_is_other);


### PR DESCRIPTION
## What changes

The strip now says whether the operator's CW is actually going out. Free to transmit, someone else on the key, no permission and no link stop looking identical, which is the failure #26 opened on: in all of them the operator hears their own sidetone and believes they are on the air.

Getting there pruned the vocabulary rather than extending it. Nine states became five situations, one colour each, under a rule that fits in one line: green means your CW goes out, any other colour means it does not, and the colour says why. Of the nine, two were the same picture, two were transitions that consumed themselves, one was unreachable — so the tenth state this feature would have added is instead four fewer.

Decisions the diff does not show, all recorded in the body of #26:

- Animations are events, not states. `led_notify()` flashes in the colour of the situation it lands on, so nothing can announce a colour the situation contradicts. The half-second red flash before a WiFi failure is gone: it delayed the honest yellow and said nothing the yellow does not.
- The paddle overlay carries position and brightness, never a colour of its own. A green overlay above a red base would break the rule at the moment the operator is keying. Magenta leaves the vocabulary; squeeze is the whole strip lighting.
- The overlay now applies in every situation, not only when idle, and keeps its own raw read of the pins in `bg_task`, upstream of the debounce and the FSM. That is what makes it a diagnostic: lit but silent means the fault is downstream in software, dark means the contact never closed. Its limit is the tick rate, so it shows whether a contact closes, never how clean it is.
- WiFi disabled in config stays green. The box was asked to be a local keyer and it is one; a degradation is WiFi asked for and missing, which is yellow.
- Alternative rejected: reserving some of the seven LEDs for the link, which is the code nobody remembers that the maintainer ruled out on 2026-09-05.

The render moved to `led_render.c`, pure and free of ESP-IDF, so the rule is proven on the host instead of looked at on a bench. `led.c` keeps the RMT channel and nothing else.

## Closes

Issue #26, points 1 and 2 of its *What would make it right*, and point 3 as far as the announced name goes. Point 1 held already from #25. Point 2 holds at `main/bg_task.c` `led_situation_now()`, which maps WiFi and `cwnet_socket_can_transmit()` onto the five situations. Point 3 holds at `components/keyer_webui/frontend/src/pages/System.svelte`, whose KEY row reads FREE, MINE, BUSY with the holder's name, NOT PERMITTED or WAITING.

The issue closes. What it called a decision is now written in its body, not deferred.

## Definition of done

- Host tests: 228/228 plain, 228/228 ASan/UBSan. Was 218: ten added, eight for the LED render and two for the key verdict.
- Reference test: `test_client_can_transmit_only_when_the_reference_would_play_it` pins the verdict against the 2026-09-05 capture — the CONNECT echo's permissions and the three `TX_INFO` payloads — for what `CwNet.c:2875-2902` does with a MORSE frame. The LED rule is pinned by `test_led_green_belongs_to_on_air_and_to_nothing_else`, which sweeps every situation, breath phase and paddle combination and fails if anything but on-air lights green.
- RT path: untouched. `keyer_led` is a Core 1 display sink and the paddle read it uses is `bg_task`'s own.
- Blocking issues open on this work: none.

## Not done here

The firmware was not built locally: no ESP-IDF on this machine, so `led.c` and the call sites are compiled only by the firmware-build CI leg. The pure render is covered on the host and compiles clean under the component's own strict flags.

Nothing here touches #23's permissions work beyond reading the bitmask the CONNECT echo already carries.
