### PR TITLE
feat: the station replays a remote operator's keying on the rig

### DIFF
--- a/.claude/code-quality.md
+++ b/.claude/code-quality.md
@@ -49,3 +49,21 @@ Il client DL4YHF risponde alla REQUEST copiando i tre timestamp del suo array (`
 - Config hot-reload: optimistic generation re-check in rt_task.c
 - fade_duration_ms: clamp prima del cast uint16_t
 - log_stream_push: memory ordering rilassato per read_idx
+
+## Daemon di stazione (2026-09-10, #64)
+
+- **L'archivio DL4YHF è incompleto solo delle librerie personali dell'autore.**
+  I file del protocollo ci sono tutti: `HamlibResultCodes.h`, dato per mancante
+  dal piano del daemon, è nell'archivio (2051 byte). Prima di scrivere «X non
+  c'è», `unzip -l ~/Downloads/Remote_CW_Keyer_Sources.zip | grep -i <nome>`.
+- **Un'attesa spezzata e una fine over sono identiche sul filo**: byte
+  consecutivi con lo stesso stato del tasto. `cwnet_play` le distingue con la
+  convenzione dell'encoder (`CwStreamEnc.c:135-146`): ogni pezzo tranne l'ultimo
+  porta il campo a 7 bit al massimo. Il costo, scritto in `cwnet_play.h`, è che
+  un'attesa lunga esattamente il massimo codificabile perde il suo fronte e
+  suona come silenzio. Il ricevitore del riferimento invece lo applica subito e
+  manipola fino a 830 ms in anticipo: quello è timing corrotto, e non si copia.
+- **Su macOS `time.monotonic()` di Python e `CLOCK_MONOTONIC` del daemon non
+  condividono l'epoca**, su Linux sì. `tools/cwnet/cwnet_jitter.py` si calibra
+  sul primo fronte per questo; su Linux quella calibrazione nasconde un
+  controllo che lì sarebbe vero. Vedi #76.

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -86,3 +86,39 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
           ASAN_OPTIONS: detect_leaks=1
         run: ./build/test_runner
+
+  host-build:
+    # cwnetd (host/) links components/keyer_cwnet's server-side core directly
+    # by path (host/CMakeLists.txt) and never touches keyer_iambic, so this
+    # job needs neither the private submodule nor its deploy key — that is
+    # why it is a separate job rather than more steps on host-tests above.
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    name: host-build (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v4
+
+      # macOS runners already carry cmake and AppleClang; nothing to install
+      # there, and no Ninja anywhere — the default generator builds six files
+      # and a brew step is one more thing that can fail on a green tree.
+      - name: Install toolchain (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends cmake gcc
+
+      - name: Configure
+        working-directory: host
+        run: cmake -B build
+
+      - name: Build
+        working-directory: host
+        run: cmake --build build
+
+      - name: Test
+        working-directory: host
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -98,7 +98,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-    name: host-build (${{ matrix.os }})
+        name: [plain, asan-ubsan]
+        include:
+          - name: plain
+            cflags: ""
+          - name: asan-ubsan
+            cflags: "-fsanitize=address,undefined -fno-omit-frame-pointer"
+    name: host-build (${{ matrix.name }}, ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4
 
@@ -111,9 +117,12 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends cmake gcc
 
+      # The daemon is the only network-facing program in this repository and
+      # the pure core is already sanitized in host-tests; without this leg
+      # main.c and sock.c would never see ASan or UBSan anywhere.
       - name: Configure
         working-directory: host
-        run: cmake -B build
+        run: cmake -B build -DCMAKE_C_FLAGS="${{ matrix.cflags }}"
 
       - name: Build
         working-directory: host

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ components/keyer_console/include/log_tags.h
 .devcontainer/Dockerfile.old
 .cargo/config.toml.old
 scripts/__pycache__/
+# Any Python bytecode: tools/cwnet/ became importable with cwnet_jitter.py
+__pycache__/
+*.pyc
 sdkconfig.defaults.generated
 build/
 old/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,4 +286,5 @@ Keying events flow only through `keying_stream_t`; Core 0 = hard-RT, Core 1 = ba
 - `components/keyer_config/`  — GENERATED config (DO NOT EDIT; from parameters.yaml)  → components/keyer_config/CLAUDE.md
 - `main/`  — Entry point; rt_task (Core 0) + bg_task (Core 1)  → main/CLAUDE.md
 - `test_host/`  — Unity host tests (stream-based, no hardware)  → test_host/CLAUDE.md
+- `host/`  — POSIX platform layer + `cwnetd` station daemon (host-only, no GUI, no physical key/PTT backend)  → host/CLAUDE.md
 <!-- END treecode:map (auto) -->

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -31,6 +31,9 @@ La codifica non lineare del tempo di attesa fra due transizioni del tasto: risol
 ### Over
 Un turno di trasmissione continuo. La sua fine è segnalata da un secondo comando di key-up dopo che è trascorsa una soglia di silenzio; il silenzio *fra* un over e il successivo non viaggia sul filo, quindi il determinismo del keying si può pretendere dentro un over, non fra over diversi.
 
+### Titolare della chiave
+Il client la cui manipolazione il server riproduce sul rig: uno solo alla volta. La chiave si prende con il primo byte MORSE quando è libera e il server lo annuncia a tutti con un TX_INFO (indice del client e nominativo; «-- nobody --» quando è libera). Dal lato client lo stato è libera, mia o altrui; dal lato server è una policy di stazione nostra quando la chiave torna libera.
+
 ## Latenza
 
 ### PING

--- a/components/keyer_cwnet/CLAUDE.md
+++ b/components/keyer_cwnet/CLAUDE.md
@@ -13,7 +13,15 @@ Key abstractions:
   (DISCONNECTED -> CONNECTING -> READY). Socket I/O is injected via send_cb /
   get_time_ms_cb callbacks so it is testable without a network.
 - cwnet_frame_parser_t: streaming, fragmentation-tolerant frame parser
-  (command byte encodes category in bits 7-6, command in bits 5-0).
+  (command byte encodes category in bits 7-6, command in bits 5-0), plus
+  cwnet_frame_build() as the one place a frame is composed.
+- cwnet_server_t / cwnet_play_t: the station side, HOST ONLY. The server core
+  takes a client from CONNECT to READY, arbitrates the key and announces its
+  holder; the playback engine turns a holder's MORSE bytes into key edges and
+  PTT at the right instants. Neither reads a clock nor logs: time is a
+  parameter, events come back in a result struct. They are deliberately absent
+  from this component's SRCS and are compiled by host/CMakeLists.txt and by
+  test_host.
 - cwnet_ping_t / cwnet_timer_t: PING-based clock sync and RTT/latency.
 - cwstream_encode/decode_timestamp: 7-bit non-linear ms timestamp codec.
 - cwnet_socket_*: the concrete ESP-IDF layer (BSD sockets + lwIP DNS) that owns
@@ -40,4 +48,7 @@ Gotchas:
   on_connected / on_data / on_disconnected events into it.
 - Frame parser copies only small fragmented payloads into its 256-byte buffer;
   large payloads are returned as pointers into the input buffer (do not retain).
+  A fragmented payload larger than that buffer is consumed to its declared
+  length and returned as CWNET_PARSE_SKIPPED with a null payload: an error
+  there would make the client resync inside the payload and lose framing.
 <!-- END treecode (auto) -->

--- a/components/keyer_cwnet/CMakeLists.txt
+++ b/components/keyer_cwnet/CMakeLists.txt
@@ -11,6 +11,9 @@ idf_component_register(
         "src/cwnet_client.c"
         "src/cwnet_feed.c"
         "src/cwnet_socket.c"
+        # src/cwnet_play.c is deliberately absent: the station daemon's
+        # playback engine is host-only (KTD2). It has no place on the box,
+        # whose RT path never plays a remote client's keying.
     INCLUDE_DIRS "include"
     REQUIRES
         keyer_core

--- a/components/keyer_cwnet/CMakeLists.txt
+++ b/components/keyer_cwnet/CMakeLists.txt
@@ -11,9 +11,11 @@ idf_component_register(
         "src/cwnet_client.c"
         "src/cwnet_feed.c"
         "src/cwnet_socket.c"
-        # src/cwnet_play.c is deliberately absent: the station daemon's
-        # playback engine is host-only (KTD2). It has no place on the box,
-        # whose RT path never plays a remote client's keying.
+        # src/cwnet_play.c and src/cwnet_server.c are deliberately absent:
+        # the station daemon's playback engine and its server core are
+        # host-only (KTD2). They have no place on the box, whose RT path
+        # never plays a remote client's keying and which is never the
+        # server. They are built and tested by test_host/ alone.
     INCLUDE_DIRS "include"
     REQUIRES
         keyer_core

--- a/components/keyer_cwnet/include/cwnet_frame.h
+++ b/components/keyer_cwnet/include/cwnet_frame.h
@@ -34,7 +34,11 @@ typedef enum {
 typedef enum {
     CWNET_PARSE_OK = 0,         /**< Frame parsed successfully */
     CWNET_PARSE_NEED_MORE,      /**< Need more data to complete frame */
-    CWNET_PARSE_ERROR           /**< Parse error (invalid frame) */
+    CWNET_PARSE_ERROR,          /**< Parse error (invalid frame) */
+    CWNET_PARSE_SKIPPED         /**< Frame fully consumed but not buffered: its
+                                  *   declared length exceeded the internal
+                                  *   buffer and it arrived fragmented. Framing
+                                  *   stays in sync; payload is NULL, len 0. */
 } cwnet_parse_status_t;
 
 /**
@@ -44,7 +48,8 @@ typedef enum {
     CWNET_PARSER_STATE_COMMAND = 0,     /**< Waiting for command byte */
     CWNET_PARSER_STATE_LENGTH_1,        /**< Waiting for first length byte */
     CWNET_PARSER_STATE_LENGTH_2,        /**< Waiting for second length byte (long block) */
-    CWNET_PARSER_STATE_PAYLOAD          /**< Accumulating payload */
+    CWNET_PARSER_STATE_PAYLOAD,         /**< Accumulating payload into the internal buffer */
+    CWNET_PARSER_STATE_SKIP             /**< Discarding a fragmented payload too large to buffer */
 } cwnet_parser_state_t;
 
 /**
@@ -124,3 +129,26 @@ void cwnet_frame_parser_reset(cwnet_frame_parser_t *parser);
 cwnet_parse_result_t cwnet_frame_parse(cwnet_frame_parser_t *parser,
                                         const uint8_t *data,
                                         size_t len);
+
+/**
+ * @brief Build a frame into the caller's buffer
+ *
+ * Chooses the category from payload_len: 0 -> no payload (command byte
+ * only), 1-255 -> short block (1-byte length), 256-65535 -> long block
+ * (2-byte little-endian length). Writes nothing and returns false if
+ * out_buf cannot hold the whole frame, or if payload_len does not fit in
+ * a 16-bit length field.
+ *
+ * @param cmd          Command type, bits 5-0 (masked internally)
+ * @param payload      Payload bytes (may be NULL only if payload_len == 0)
+ * @param payload_len  Payload length in bytes
+ * @param out_buf      Caller's output buffer
+ * @param out_buf_size Size of out_buf
+ * @param out_len      Set to the number of bytes written, on success only
+ * @return true on success; false (nothing written) if out_buf is too
+ *         small, payload_len is out of range, or out_buf/out_len is NULL
+ */
+bool cwnet_frame_build(uint8_t cmd,
+                        const uint8_t *payload, size_t payload_len,
+                        uint8_t *out_buf, size_t out_buf_size,
+                        size_t *out_len);

--- a/components/keyer_cwnet/include/cwnet_ping.h
+++ b/components/keyer_cwnet/include/cwnet_ping.h
@@ -137,3 +137,67 @@ bool cwnet_ping_build_response(const cwnet_ping_t *request,
  * @return int32_t RTT in ms (t2 - t0), or -1 on error
  */
 int32_t cwnet_ping_calc_latency(const cwnet_ping_t *response);
+
+/**
+ * @brief Build PING REQUEST, as the initiator
+ *
+ * CwNet.c:2255-2259: the initiator (the daemon, toward each of its clients,
+ * every 2 s) builds:
+ *   - type = REQUEST
+ *   - id = caller-supplied (the reference uses the client's own index)
+ *   - t0 = t0_ms
+ *   - t1, t2 slots = 0
+ *
+ * @param id Sequence/client-index id for this exchange
+ * @param t0_ms Our clock, 31-bit range, for the requester timestamp
+ * @param buffer Output buffer (must be >= 16 bytes)
+ * @param buf_len Buffer size
+ * @return true if built successfully
+ */
+bool cwnet_ping_build_request(uint8_t id,
+                               int32_t t0_ms,
+                               uint8_t *buffer,
+                               size_t buf_len);
+
+/**
+ * @brief Build PING RESPONSE_2 from a received RESPONSE_1
+ *
+ * CwNet.c:1428-1432, and cwnet_echo.py's PING response 2: the initiator
+ * closes the loop with:
+ *   - type = RESPONSE_2
+ *   - id, t0, t1 = copied from the RESPONSE_1
+ *   - t2 = our_time_ms
+ *
+ * @param response_1 Input RESPONSE_1 ping (wrong type or NULL returns false)
+ * @param buffer Output buffer (must be >= 16 bytes)
+ * @param buf_len Buffer size
+ * @param our_time_ms Our timestamp for t2
+ * @return true if built successfully
+ */
+bool cwnet_ping_build_response2(const cwnet_ping_t *response_1,
+                                 uint8_t *buffer,
+                                 size_t buf_len,
+                                 int32_t our_time_ms);
+
+/**
+ * @brief Gate an RTT sample and fold it into a peak-hold value
+ *
+ * CwNet.c:1437-1447: an RTT outside 0..2000 ms is "unrealistic" and is
+ * discarded before it reaches either the instant latency or the peak-hold
+ * (the reference gates on a locally-measured stopwatch in microseconds;
+ * here the same 0..2000 ms window gates the wire-computed latency itself —
+ * a behaviour change from today's box, which only rejected negative values.
+ * Declared in the PR per KTD2).
+ *
+ * When the sample passes the gate: a peak-hold value that is still
+ * unheld (< 0, the -1 sentinel) or a sample at or above the current peak
+ * jumps to the new value immediately; a lower sample decays by a tenth of
+ * the gap (integer division, so a gap under 10 ms no longer descends).
+ *
+ * @param peak_ms Peak-hold value to update in place (NULL is a no-op,
+ *                returns false)
+ * @param latency_ms Candidate RTT in ms (t2 - t0)
+ * @return true if latency_ms passed the gate and *peak_ms was updated;
+ *         false if it was discarded (peak_ms left untouched)
+ */
+bool cwnet_ping_peak_hold_update(int32_t *peak_ms, int32_t latency_ms);

--- a/components/keyer_cwnet/include/cwnet_play.h
+++ b/components/keyer_cwnet/include/cwnet_play.h
@@ -219,6 +219,10 @@ void cwnet_play_tick(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *ou
 void cwnet_play_force_release(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out);
 
 /** @brief Key state on the output */
+/** B of the over in progress, zero when no over is open. The engine owns
+ *  this number: it is fixed when the over is armed and does not move. */
+uint32_t cwnet_play_buffer_ms(const cwnet_play_t *play);
+
 bool cwnet_play_key_down(const cwnet_play_t *play);
 
 /** @brief PTT state on the output */

--- a/components/keyer_cwnet/include/cwnet_play.h
+++ b/components/keyer_cwnet/include/cwnet_play.h
@@ -42,7 +42,10 @@
  * End of over is the reference's mark: two consecutive key-up bytes
  * (CwStream_CheckForAnyEndOfTransmissionInFifo). It is reported when the
  * second one is consumed, without waiting out its encoded time, and the
- * over is finished once the PTT has dropped.
+ * over is finished once the PTT has dropped. What counts is the state each
+ * byte leaves on the key, not the bit it carries: a chunk of a long
+ * key-down carries the up bit and is no part of the mark. Whatever the
+ * bytes say, the key never stays down across that mark.
  *
  * Underrun
  * --------
@@ -151,7 +154,7 @@ typedef struct {
     int64_t deadline_ms;          /**< Next keying deadline (CWNET_PLAY_RUNNING) */
     bool pending_key_down;        /**< State to apply at that deadline */
     bool key_down;                /**< State on the output now */
-    bool prev_byte_key_down;      /**< Key bit of the last byte consumed */
+    bool prev_byte_key_down;      /**< State the last byte consumed leaves on the key */
     bool have_prev_byte;          /**< A byte has been consumed in this over */
 
     bool ptt_on;                  /**< PTT on the output now */
@@ -218,11 +221,11 @@ void cwnet_play_tick(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *ou
  */
 void cwnet_play_force_release(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out);
 
-/** @brief Key state on the output */
 /** B of the over in progress, zero when no over is open. The engine owns
  *  this number: it is fixed when the over is armed and does not move. */
 uint32_t cwnet_play_buffer_ms(const cwnet_play_t *play);
 
+/** @brief Key state on the output */
 bool cwnet_play_key_down(const cwnet_play_t *play);
 
 /** @brief PTT state on the output */

--- a/components/keyer_cwnet/include/cwnet_play.h
+++ b/components/keyer_cwnet/include/cwnet_play.h
@@ -1,0 +1,231 @@
+/**
+ * @file cwnet_play.h
+ * @brief Playback of a remote client's MORSE bytes into key edges and PTT
+ *
+ * This is the station side of the keying stream: the bytes of the client
+ * that holds the key go in, key edges and PTT transitions come out at the
+ * instants the sender meant them to have, delayed by a buffer B that
+ * absorbs the jitter of the link.
+ *
+ * HOST ONLY. This module is deliberately absent from the ESP-IDF component
+ * SRCS: it belongs to the station daemon, never to the box's RT path.
+ *
+ * It has no clock and no log of its own. The caller passes the current
+ * instant to every entry point and reads what happened out of a result
+ * structure; printing it is the daemon's business.
+ *
+ * Timeline
+ * --------
+ * Each MORSE byte carries the new key state in bit 7 and, in bits 6..0, the
+ * 7-bit encoded time to wait BEFORE applying it, measured from the previous
+ * edge (CwStreamEnc.c, CwStream_DecodeKeyUpDownEvent). Playback starts at
+ * the first byte of an over, delayed by B, and from there every deadline
+ * advances by the *decoded* wait, never by the measured time, so
+ * quantisation and scheduling slack do not accumulate. Instants and
+ * deadlines are 64-bit milliseconds; the 31-bit clock stays on the wire.
+ *
+ * B is fixed when the over starts and does not change for its duration.
+ * The eligibility ceiling on B belongs to the caller, not here.
+ *
+ * A wait longer than CWSTREAM_MAX_WAIT_MS is split by the sender over
+ * several bytes carrying the same key state, all but the last with the
+ * 7-bit field at its maximum (CwStreamEnc.c:135-146). A byte whose 7-bit
+ * field is that maximum therefore carries no edge here: it only advances
+ * the timeline by CWSTREAM_MAX_WAIT_MS, and the state is applied when the
+ * remainder arrives, so the edge lands after the sum of the waits. The
+ * reference's own receiver applies such a byte immediately and keys up to
+ * a second early; that is corrupted timing, and we do not copy it
+ * (ARCHITECTURE.md 8.1). The one wait this costs us is a wait of exactly
+ * CWSTREAM_MAX_WAIT_MS, the single value the encoder can emit as a lone
+ * maximum byte: its edge is dropped, which is silence, not wrong timing.
+ *
+ * End of over is the reference's mark: two consecutive key-up bytes
+ * (CwStream_CheckForAnyEndOfTransmissionInFifo). It is reported when the
+ * second one is consumed, without waiting out its encoded time, and the
+ * over is finished once the PTT has dropped.
+ *
+ * Underrun
+ * --------
+ * If the FIFO is empty at the instant an edge leaves the key down, the key
+ * goes up at once and an underrun is reported: the length of that element
+ * is unknown, and a dash of unknown length is worse than silence. The key
+ * is never left in the pending state. The bytes that follow restart as a
+ * new over with the same B.
+ *
+ * PTT
+ * ---
+ * The PTT follows the keying that is played, not the bytes that arrive:
+ * up with the first key-down of an over, advanced by a lead that is never
+ * longer than B, and down a tail after the last key-up played. Any release
+ * of the key lowers it at the tail at the latest. The client's "set_ptt"
+ * strings never reach this module.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** The reference's CW_KEYING_FIFO_SIZE, as in cwnet_client.h */
+#define CWNET_PLAY_FIFO_SIZE 128
+
+/** Events one cwnet_play_tick() call can report before the caller must tick again */
+#define CWNET_PLAY_MAX_EVENTS 16
+
+/** Default PTT tail, the box's own value, in milliseconds */
+#define CWNET_PLAY_DEFAULT_PTT_TAIL_MS 100u
+
+/**
+ * @brief What the engine did, at the instant it was meant to happen
+ */
+typedef enum {
+    CWNET_PLAY_EV_KEY_DOWN = 0,   /**< Key edge: carrier on */
+    CWNET_PLAY_EV_KEY_UP,         /**< Key edge: carrier off */
+    CWNET_PLAY_EV_PTT_ON,         /**< PTT raised, lead ahead of the first key-down */
+    CWNET_PLAY_EV_PTT_OFF,        /**< PTT dropped, a tail after the last key-up */
+    CWNET_PLAY_EV_END_OF_OVER,    /**< Two consecutive key-up bytes were played */
+    CWNET_PLAY_EV_UNDERRUN,       /**< FIFO empty under a key-down: forced up, fault */
+    CWNET_PLAY_EV_OVER_FINISHED,  /**< Over played out and PTT down: the key can be released */
+} cwnet_play_event_type_t;
+
+/**
+ * @brief One event with the instant it belongs to
+ *
+ * @note at_ms is the scheduled instant, not the instant the caller ticked:
+ *       a late tick reports the edges where they belonged.
+ */
+typedef struct {
+    cwnet_play_event_type_t type;
+    int64_t at_ms;
+} cwnet_play_event_t;
+
+/**
+ * @brief Events of one tick, oldest first
+ *
+ * When the array fills, the tick stops and leaves the rest scheduled: the
+ * caller ticks again while cwnet_play_next_deadline() is still due.
+ */
+typedef struct {
+    cwnet_play_event_t ev[CWNET_PLAY_MAX_EVENTS];
+    size_t count;
+} cwnet_play_result_t;
+
+/**
+ * @brief Knobs the daemon owns; defaults are the reference's or the box's
+ */
+typedef struct {
+    uint32_t ptt_lead_ms;  /**< PTT ahead of the first key-down, clamped to B (default 0) */
+    uint32_t ptt_tail_ms;  /**< PTT after the last key-up (default 100, the box's) */
+} cwnet_play_cfg_t;
+
+/**
+ * @brief Received keying bytes with their instant of reception
+ */
+typedef struct {
+    uint8_t cmd[CWNET_PLAY_FIFO_SIZE];
+    int64_t received_at_ms[CWNET_PLAY_FIFO_SIZE];
+    uint16_t tail;
+    uint16_t count;
+} cwnet_play_fifo_t;
+
+/** Where the engine is in an over */
+typedef enum {
+    CWNET_PLAY_IDLE = 0,   /**< Armed with B, waiting for the first byte to anchor on */
+    CWNET_PLAY_RUNNING,    /**< A keying deadline is scheduled */
+    CWNET_PLAY_CLOSING,    /**< End of over played, waiting for the PTT to drop */
+} cwnet_play_state_t;
+
+/**
+ * @brief The playback engine. Allocated by the caller, never by us.
+ */
+typedef struct {
+    cwnet_play_cfg_t cfg;
+    cwnet_play_fifo_t fifo;
+    uint32_t dropped;             /**< Bytes that found the FIFO full */
+
+    uint32_t buffer_ms;           /**< B, fixed for the over */
+    uint32_t lead_ms;             /**< Effective lead, clamped to B */
+    cwnet_play_state_t state;
+
+    int64_t deadline_ms;          /**< Next keying deadline (CWNET_PLAY_RUNNING) */
+    bool pending_key_down;        /**< State to apply at that deadline */
+    bool key_down;                /**< State on the output now */
+    bool prev_byte_key_down;      /**< Key bit of the last byte consumed */
+    bool have_prev_byte;          /**< A byte has been consumed in this over */
+
+    bool ptt_on;                  /**< PTT on the output now */
+    bool ptt_on_pending;          /**< A PTT-on is scheduled */
+    int64_t ptt_on_at_ms;
+    bool ptt_off_pending;         /**< A PTT-off is scheduled */
+    int64_t ptt_off_at_ms;
+} cwnet_play_t;
+
+/**
+ * @brief Set up an engine with its knobs; nothing is playing yet
+ *
+ * @param play Engine, not NULL
+ * @param cfg  Knobs, or NULL for the defaults (lead 0, tail 100 ms)
+ */
+void cwnet_play_init(cwnet_play_t *play, const cwnet_play_cfg_t *cfg);
+
+/**
+ * @brief Arm an over with its buffer, discarding whatever was queued
+ *
+ * Called when a client takes the key. B is fixed here and does not move
+ * for the over; the lead is clamped to it. A PTT raised in anticipation of
+ * the discarded over is cancelled, but a PTT already up and a key already
+ * down are left alone: a caller that arms an over on top of a live one
+ * releases it first.
+ *
+ * @param play      Engine, not NULL
+ * @param buffer_ms B in milliseconds
+ */
+void cwnet_play_start_over(cwnet_play_t *play, uint32_t buffer_ms);
+
+/**
+ * @brief Queue one received MORSE byte with the instant it arrived
+ *
+ * The byte whose deadline is running is held outside the queue, so an armed
+ * over takes CWNET_PLAY_FIFO_SIZE bytes beyond the one being played.
+ *
+ * @return false when the FIFO is full; the byte is dropped and counted.
+ */
+bool cwnet_play_push(cwnet_play_t *play, uint8_t cmd, int64_t now_ms);
+
+/**
+ * @brief Instant of the next thing the engine has to do
+ *
+ * The daemon sleeps until then, or until data arrives.
+ *
+ * @return false when nothing is scheduled.
+ */
+bool cwnet_play_next_deadline(const cwnet_play_t *play, int64_t *out_ms);
+
+/**
+ * @brief Do everything that is due at or before now_ms
+ *
+ * @param out Events, cleared first, never NULL. If it fills, the rest
+ *            stays scheduled: tick again while the next deadline is due.
+ */
+void cwnet_play_tick(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out);
+
+/**
+ * @brief Safety net: end the over now, whatever the FIFO holds
+ *
+ * The key goes up at once if it was down, the queue is dropped, and the
+ * PTT drops at the tail at the latest; the over is finished when it does.
+ */
+void cwnet_play_force_release(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out);
+
+/** @brief Key state on the output */
+bool cwnet_play_key_down(const cwnet_play_t *play);
+
+/** @brief PTT state on the output */
+bool cwnet_play_ptt_on(const cwnet_play_t *play);
+
+/** @brief True while an over is being played or is closing */
+bool cwnet_play_over_open(const cwnet_play_t *play);
+
+/** @brief Bytes dropped because the FIFO was full, since init */
+uint32_t cwnet_play_dropped(const cwnet_play_t *play);

--- a/components/keyer_cwnet/include/cwnet_server.h
+++ b/components/keyer_cwnet/include/cwnet_server.h
@@ -56,6 +56,14 @@
  * A client that has never had a PING answered has no measurement (peak
  * -1): it is treated as fit and plays with B at the floor. Refusing it
  * would refuse every client for the first two seconds of its session.
+ *
+ * A client that HAS answered and still has no peak is the opposite case.
+ * The peak-hold only takes a sample the gate lets through (cwnet_ping.h,
+ * cwnet_ping_peak_hold_update): a link slow enough that every answer misses
+ * that window never records one. Left together with the client above it
+ * would look identical — fit, and playing at the floor — which is exactly
+ * the link the ceiling exists to keep off the air. So the two are kept
+ * apart: never answered is fit, answered but never measurable is not.
  */
 
 #pragma once
@@ -156,7 +164,14 @@ typedef enum {
     CWNET_SERVER_EV_CLIENT_CLOSED,    /**< Connection over; value = cwnet_server_close_reason_t */
     CWNET_SERVER_EV_KEY_HOLDER,       /**< The key changed hands; client_idx or CWNET_SERVER_NOBODY */
     CWNET_SERVER_EV_LATENCY,          /**< A PING closed; value = RTT ms, peak = peak-hold ms */
-    CWNET_SERVER_EV_LINK_UNFIT,       /**< Refused the key; value = the peak-hold that refused it */
+    /**
+     * Refused the key. Reported once per refusal, as often as the PRINT
+     * that goes with it and no more: a refused client keeps sending, and
+     * one event per rejected byte would fill this array with one line.
+     * value = the peak-hold that refused it, or -1 when the client has
+     * answered PINGs but never inside the measurement window.
+     */
+    CWNET_SERVER_EV_LINK_UNFIT,
     CWNET_SERVER_EV_OVER_BUFFER,      /**< An over started; value = B in ms */
     CWNET_SERVER_EV_KEY_DOWN,         /**< Key output: carrier on */
     CWNET_SERVER_EV_KEY_UP,           /**< Key output: carrier off */
@@ -248,6 +263,7 @@ typedef struct {
 
     int32_t latency_ms;             /**< Last gated RTT, -1 until one lands */
     int32_t latency_peak_ms;        /**< Peak-hold of it, -1 until one lands */
+    bool ping_answered;             /**< A PING came back, gate or no gate */
 } cwnet_server_client_t;
 
 /**

--- a/components/keyer_cwnet/include/cwnet_server.h
+++ b/components/keyer_cwnet/include/cwnet_server.h
@@ -1,0 +1,387 @@
+/**
+ * @file cwnet_server.h
+ * @brief The station server's core: who is connected, who has the key
+ *
+ * This is the state machine behind the station daemon. It takes a client
+ * from its CONNECT to READY, announces who holds the key, arbitrates the
+ * key between clients, answers the PINGs and the rig-control strings, and
+ * hands the key holder's MORSE bytes to the playback engine (cwnet_play).
+ *
+ * HOST ONLY. Deliberately absent from the ESP-IDF component SRCS, like
+ * cwnet_play.c: the box is never the server (KTD2).
+ *
+ * It owns no socket, no clock and no log (KTD1, KTD10):
+ *   - the caller accepts the TCP connection and calls cwnet_server_on_connected()
+ *   - it feeds received bytes to cwnet_server_on_data()
+ *   - it calls cwnet_server_poll() when a deadline comes due
+ *   - it calls cwnet_server_on_disconnected() when a socket dies
+ *   - sending goes out through one callback, addressed by client index
+ * Every entry point takes the current instant; what happened comes back in
+ * a result structure, never in a log line. Printing it is the daemon's job.
+ *
+ * Client indices are the reference's: 1 and up for remote clients
+ * (CwNet.h, CWNET_FIRST_REMOTE_CLIENT_INDEX), and they are what goes in
+ * the TX_INFO index byte and in the PING id. Index 0, the server's own
+ * operator ("The Sysop"), does not exist here: there is no local operator
+ * on this server (Scope Boundaries).
+ *
+ * Permissions
+ * -----------
+ * Everybody who connects may talk, transmit and control the rig: the echo
+ * always carries 0x07 and there is no user list (KTD6). What matters is
+ * knowing WHO is transmitting, and that is the TX_INFO.
+ *
+ * The key
+ * -------
+ * The first MORSE byte that arrives while nobody holds the key takes it,
+ * as in the reference (CwNet.c:2875-2903); every other client's MORSE is
+ * dropped without a word. Unlike the reference we keep it for the whole
+ * over: its 1 s stopwatch, which makes the announcement oscillate during
+ * an over, is not copied (KTD4). The key comes back when the end-of-over
+ * marker has been played and the PTT has dropped, or when a safety net
+ * fires: the holder's TCP closes, nothing arrives from it for the idle
+ * timeout, or the over outlasts its ceiling. Each of those forces the key
+ * up at once and drops the PTT at the tail at the latest.
+ *
+ * Link eligibility
+ * ----------------
+ * The buffer B of an over is the holder's peak-hold latency, floored at
+ * cfg.buffer_floor_ms, fixed when it takes the key. Above
+ * cfg.buffer_ceiling_ms the link is not fit to transmit: the client does
+ * not take the key, nothing of its is played, and it gets a PRINT saying
+ * so with the measured value. Two seconds of buffer means the far end is
+ * already answering when the PTT drops, and slow turnaround after a
+ * transmission is the main complaint about the original program.
+ *
+ * A client that has never had a PING answered has no measurement (peak
+ * -1): it is treated as fit and plays with B at the floor. Refusing it
+ * would refuse every client for the first two seconds of its session.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "cwnet_frame.h"
+#include "cwnet_ping.h"
+#include "cwnet_play.h"
+
+/*===========================================================================*/
+/* Constants                                                                 */
+/*===========================================================================*/
+
+/** Clients the table can hold; cfg.max_clients selects how many are used */
+#define CWNET_SERVER_MAX_CLIENTS 8
+
+/** First remote client index, as CWNET_FIRST_REMOTE_CLIENT_INDEX in CwNet.h */
+#define CWNET_SERVER_FIRST_CLIENT 1
+
+/** Key holder index meaning "nobody"; 0xFF on the wire */
+#define CWNET_SERVER_NOBODY (-1)
+
+/** cwnet_server_on_connected() when every slot is taken: accept, then close */
+#define CWNET_SERVER_NO_SLOT (-1)
+
+/** Longest announced name, NUL included ("NoCall #8", a callsign, "-- nobody --") */
+#define CWNET_SERVER_NAME_LEN 48
+
+/**
+ * @brief "Text the receiver should print somewhere", CWNET_CMD_PRINT in CwNet.h:65
+ *
+ * Not in cwnet_client.h's command enum: the box never sends one, and the
+ * server is the only side here that does.
+ */
+#define CWNET_SERVER_CMD_PRINT 0x04u
+
+/** Events one call can report before the caller must call again */
+#define CWNET_SERVER_MAX_EVENTS 32
+
+/* Defaults: the reference's, the box's, or the decisions of the plan */
+#define CWNET_SERVER_DEFAULT_MAX_CLIENTS 4u
+#define CWNET_SERVER_DEFAULT_PING_INTERVAL_MS 2000u   /**< CwNet.c:2251 */
+#define CWNET_SERVER_DEFAULT_HANDSHAKE_MS 5000u
+#define CWNET_SERVER_DEFAULT_IDLE_MS 5000u
+#define CWNET_SERVER_DEFAULT_OVER_MAX_MS 120000u
+#define CWNET_SERVER_DEFAULT_BUFFER_FLOOR_MS 50u
+#define CWNET_SERVER_DEFAULT_BUFFER_CEILING_MS 1000u  /**< The eligibility ceiling */
+
+/** Unanswered PING requests in a row that close a client (R16) */
+#define CWNET_SERVER_PING_MISSES 3u
+
+/*===========================================================================*/
+/* Rig-control result codes                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief What a 0x06 rig-control string is answered with
+ *
+ * The values are the reference's (HamlibResultCodes.h, as CwNet.c uses
+ * them). Nothing is ever applied to a rig here: "set_ptt" is acknowledged
+ * and dropped, because the PTT follows the keying that is played, not the
+ * strings that arrive (KTD5, R10).
+ */
+#define CWNET_SERVER_RPRT_OK 0            /**< HAMLIB_RESULT_NO_ERROR */
+#define CWNET_SERVER_RPRT_BAD_ARG (-17)   /**< HAMLIB_RESULT_ARG_OUT_OF_DOM, CwNet.c:4102 */
+#define CWNET_SERVER_RPRT_NO_FUNC (-11)   /**< HAMLIB_RESULT_NOT_AVAILABLE, CwNet.c:4114 */
+
+/*===========================================================================*/
+/* Events                                                                    */
+/*===========================================================================*/
+
+/** Why a client's connection ended */
+typedef enum {
+    CWNET_SERVER_CLOSE_NO_SLOT = 0,     /**< Accepted past the client limit */
+    CWNET_SERVER_CLOSE_BAD_CONNECT,     /**< CONNECT of the wrong length */
+    CWNET_SERVER_CLOSE_PARSE_ERROR,     /**< Frame parse error (R15) */
+    CWNET_SERVER_CLOSE_BAD_STRING,      /**< 0x06 string with no NUL in its payload */
+    CWNET_SERVER_CLOSE_HANDSHAKE,       /**< No CONNECT within the handshake timeout */
+    CWNET_SERVER_CLOSE_PING_TIMEOUT,    /**< Three PING requests unanswered */
+    CWNET_SERVER_CLOSE_SEND_FAILED,     /**< The send callback failed */
+    CWNET_SERVER_CLOSE_PEER,            /**< The socket died: on_disconnected() */
+} cwnet_server_close_reason_t;
+
+/** What went wrong badly enough to write a line about */
+typedef enum {
+    CWNET_SERVER_FAULT_UNDERRUN = 0,    /**< The engine ran out of bytes mid-element */
+    CWNET_SERVER_FAULT_HOLDER_GONE,     /**< The key holder's TCP closed mid-over */
+    CWNET_SERVER_FAULT_IDLE,            /**< Nothing from the holder for the idle timeout */
+    CWNET_SERVER_FAULT_OVER_TOO_LONG,   /**< The over outlasted its ceiling */
+} cwnet_server_fault_t;
+
+/** What the core did, for the daemon to print and to put on the key output */
+typedef enum {
+    CWNET_SERVER_EV_CLIENT_READY = 0, /**< CONNECT confirmed; client_idx, name available */
+    CWNET_SERVER_EV_CLIENT_CLOSED,    /**< Connection over; value = cwnet_server_close_reason_t */
+    CWNET_SERVER_EV_KEY_HOLDER,       /**< The key changed hands; client_idx or CWNET_SERVER_NOBODY */
+    CWNET_SERVER_EV_LATENCY,          /**< A PING closed; value = RTT ms, peak = peak-hold ms */
+    CWNET_SERVER_EV_LINK_UNFIT,       /**< Refused the key; value = the peak-hold that refused it */
+    CWNET_SERVER_EV_OVER_BUFFER,      /**< An over started; value = B in ms */
+    CWNET_SERVER_EV_KEY_DOWN,         /**< Key output: carrier on */
+    CWNET_SERVER_EV_KEY_UP,           /**< Key output: carrier off */
+    CWNET_SERVER_EV_PTT_ON,           /**< PTT output: on */
+    CWNET_SERVER_EV_PTT_OFF,          /**< PTT output: off */
+    CWNET_SERVER_EV_FAULT,            /**< value = cwnet_server_fault_t */
+} cwnet_server_event_type_t;
+
+/**
+ * @brief One event with the instant it belongs to
+ *
+ * @note at_ms is the instant the thing happened, which for a keying edge
+ *       is the instant it was scheduled for, not the instant of the call.
+ */
+typedef struct {
+    cwnet_server_event_type_t type;
+    int client_idx;   /**< 1..max_clients, CWNET_SERVER_NOBODY, or 0 when it fits no client */
+    int32_t value;    /**< Per type: reason, RTT, peak, B */
+    int32_t peak_ms;  /**< CWNET_SERVER_EV_LATENCY only: the peak-hold after the sample */
+    int64_t at_ms;
+} cwnet_server_event_t;
+
+/**
+ * @brief Events of one call, oldest first
+ *
+ * If it fills, the rest is lost rather than the state machine stalling:
+ * events are diagnostics, the state is the truth. The count of dropped
+ * events is kept so the daemon can say so.
+ */
+typedef struct {
+    cwnet_server_event_t ev[CWNET_SERVER_MAX_EVENTS];
+    size_t count;
+    size_t dropped;
+} cwnet_server_result_t;
+
+/*===========================================================================*/
+/* Configuration                                                             */
+/*===========================================================================*/
+
+/**
+ * @brief Send data to one client
+ *
+ * @param client_idx Client index, 1 and up
+ * @param data       Bytes to send
+ * @param len        Length
+ * @param user_data  Caller's context
+ * @return Bytes sent, or negative on error. Anything but a full write
+ *         closes that client (a partial write would break the framing).
+ */
+typedef int (*cwnet_server_send_cb_t)(int client_idx, const uint8_t *data,
+                                       size_t len, void *user_data);
+
+/**
+ * @brief The daemon's knobs. cwnet_server_cfg_defaults() fills the defaults.
+ */
+typedef struct {
+    uint16_t max_clients;          /**< Clients served at once (default 4) */
+    uint32_t ping_interval_ms;     /**< PING cadence per client (default 2000) */
+    uint32_t handshake_timeout_ms; /**< Accept to CONNECT (default 5000) */
+    uint32_t idle_timeout_ms;      /**< Silence from the holder mid-over (default 5000) */
+    uint32_t over_max_ms;          /**< Ceiling on one over (default 120000) */
+    uint32_t buffer_floor_ms;      /**< Floor under B (default 50) */
+    uint32_t buffer_ceiling_ms;    /**< Link eligibility ceiling (default 1000) */
+    cwnet_play_cfg_t play;         /**< PTT lead and tail for the playback engine */
+
+    cwnet_server_send_cb_t send_cb; /**< Required */
+    void *user_data;
+} cwnet_server_cfg_t;
+
+/*===========================================================================*/
+/* Context                                                                   */
+/*===========================================================================*/
+
+/** One connection's slot. Read through the accessors, not by hand. */
+typedef struct {
+    bool in_use;
+    bool confirmed;                 /**< CONNECT accepted: READY */
+    bool unfit_notified;            /**< Already told this link is not fit */
+    char name[CWNET_SERVER_NAME_LEN]; /**< Announced name: callsign, or "NoCall #n" */
+    char username[CWNET_SERVER_NAME_LEN]; /**< From the CONNECT, for the welcome only */
+    cwnet_frame_parser_t parser;
+
+    int64_t accepted_at_ms;
+    int64_t next_ping_at_ms;
+    bool ping_pending;
+    uint8_t ping_id;
+    int32_t ping_t0_ms;             /**< t0 of the pending request, 31-bit */
+    uint32_t ping_misses;           /**< Requests unanswered in a row */
+
+    int32_t latency_ms;             /**< Last gated RTT, -1 until one lands */
+    int32_t latency_peak_ms;        /**< Peak-hold of it, -1 until one lands */
+} cwnet_server_client_t;
+
+/**
+ * @brief The server. Allocated by the caller, never by us.
+ */
+typedef struct {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_client_t client[CWNET_SERVER_MAX_CLIENTS];
+
+    cwnet_play_t play;              /**< The key holder's bytes become edges here */
+
+    int key_holder;                 /**< 1.. , or CWNET_SERVER_NOBODY */
+    uint32_t buffer_ms;             /**< B of the over in progress */
+    int64_t over_started_at_ms;     /**< When the key was taken */
+    int64_t holder_last_byte_ms;    /**< Last MORSE byte from the holder */
+
+    uint32_t morse_ignored;         /**< Bytes dropped because the sender had no key */
+} cwnet_server_t;
+
+/*===========================================================================*/
+/* API                                                                       */
+/*===========================================================================*/
+
+/**
+ * @brief Fill a configuration with the defaults
+ *
+ * send_cb and user_data are left alone: they are the caller's.
+ */
+void cwnet_server_cfg_defaults(cwnet_server_cfg_t *cfg);
+
+/**
+ * @brief Set up a server. No client is connected and the key is free.
+ *
+ * @param srv Server, not NULL
+ * @param cfg Configuration; NULL takes the defaults, but then nothing can
+ *            be sent. max_clients is clamped to CWNET_SERVER_MAX_CLIENTS,
+ *            and a zero timeout or interval takes its default.
+ * @return false if srv is NULL
+ */
+bool cwnet_server_init(cwnet_server_t *srv, const cwnet_server_cfg_t *cfg);
+
+/**
+ * @brief A TCP connection was accepted
+ *
+ * @param srv    Server
+ * @param now_ms Now
+ * @param out    Events, cleared first; may be NULL
+ * @return The client index to use from here on, or CWNET_SERVER_NO_SLOT
+ *         when every slot is taken. In that case an event says so and the
+ *         caller closes the socket at once: the accept never blocks (R1).
+ */
+int cwnet_server_on_connected(cwnet_server_t *srv, int64_t now_ms,
+                               cwnet_server_result_t *out);
+
+/**
+ * @brief Bytes arrived from one client
+ *
+ * Handles fragmentation; an oversized fragmented frame is skipped without
+ * losing the framing (R14). A parse error closes the client (R15).
+ *
+ * @param srv        Server
+ * @param client_idx Index from cwnet_server_on_connected()
+ * @param data       Received bytes
+ * @param len        How many
+ * @param now_ms     Now: it timestamps the MORSE bytes for the engine
+ * @param out        Events, cleared first; may be NULL
+ */
+void cwnet_server_on_data(cwnet_server_t *srv, int client_idx,
+                           const uint8_t *data, size_t len,
+                           int64_t now_ms, cwnet_server_result_t *out);
+
+/**
+ * @brief A client's socket died
+ *
+ * Frees the slot, and releases the key if that client held it. Calling it
+ * for a slot the core has already closed itself is a no-op.
+ */
+void cwnet_server_on_disconnected(cwnet_server_t *srv, int client_idx,
+                                   int64_t now_ms, cwnet_server_result_t *out);
+
+/**
+ * @brief Everything that is due at or before now_ms
+ *
+ * The PINGs, the timeouts, the safety nets, and the playback engine's key
+ * and PTT edges.
+ *
+ * @param out Events, cleared first; may be NULL
+ */
+void cwnet_server_poll(cwnet_server_t *srv, int64_t now_ms,
+                        cwnet_server_result_t *out);
+
+/**
+ * @brief Instant of the next thing the server has to do
+ *
+ * The daemon waits on its sockets until then. Covers the playback
+ * deadlines, the PING cadence, the handshake timeout and the safety nets.
+ *
+ * @return false when nothing is scheduled.
+ */
+bool cwnet_server_next_deadline(const cwnet_server_t *srv, int64_t *out_ms);
+
+/*===========================================================================*/
+/* Reading the state                                                         */
+/*===========================================================================*/
+
+/** @return the client index holding the key, or CWNET_SERVER_NOBODY */
+int cwnet_server_key_holder(const cwnet_server_t *srv);
+
+/** @return the name announced for a client, "" if the slot is free or unconfirmed */
+const char *cwnet_server_client_name(const cwnet_server_t *srv, int client_idx);
+
+/** @return true when the slot holds a client that has completed its CONNECT */
+bool cwnet_server_client_ready(const cwnet_server_t *srv, int client_idx);
+
+/** @return connected clients, confirmed or not */
+size_t cwnet_server_client_count(const cwnet_server_t *srv);
+
+/** @return last gated RTT in ms for a client, -1 if unknown */
+int32_t cwnet_server_client_latency_ms(const cwnet_server_t *srv, int client_idx);
+
+/** @return peak-hold RTT in ms for a client, -1 if unknown */
+int32_t cwnet_server_client_peak_ms(const cwnet_server_t *srv, int client_idx);
+
+/** @return B of the over in progress, 0 when the key is free */
+uint32_t cwnet_server_buffer_ms(const cwnet_server_t *srv);
+
+/** @return key state on the output */
+bool cwnet_server_key_down(const cwnet_server_t *srv);
+
+/** @return PTT state on the output */
+bool cwnet_server_ptt_on(const cwnet_server_t *srv);
+
+/** @return MORSE bytes the playback engine could not hold */
+uint32_t cwnet_server_play_dropped(const cwnet_server_t *srv);
+
+/** @return MORSE bytes dropped because their sender did not hold the key */
+uint32_t cwnet_server_morse_ignored(const cwnet_server_t *srv);

--- a/components/keyer_cwnet/include/cwnet_server.h
+++ b/components/keyer_cwnet/include/cwnet_server.h
@@ -260,7 +260,6 @@ typedef struct {
     cwnet_play_t play;              /**< The key holder's bytes become edges here */
 
     int key_holder;                 /**< 1.. , or CWNET_SERVER_NOBODY */
-    uint32_t buffer_ms;             /**< B of the over in progress */
     int64_t over_started_at_ms;     /**< When the key was taken */
     int64_t holder_last_byte_ms;    /**< Last MORSE byte from the holder */
 

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -260,20 +260,13 @@ static void handle_ping(cwnet_client_t *client,
             break;
 
         case CWNET_PING_RESPONSE_2:
-            /* Update latency measurement */
+            /* Update latency measurement. cwnet_ping_peak_hold_update()
+             * gates the sample to 0..2000 ms (CwNet.c:1437) before either
+             * the instant latency or the peak-hold see it. */
             {
                 int32_t latency = cwnet_ping_calc_latency(&ping);
-                if (latency >= 0) {
+                if (cwnet_ping_peak_hold_update(&client->latency_peak_ms, latency)) {
                     client->latency_ms = latency;
-                    /* CwNet.c:1442-1447: jump to a new peak, otherwise drop
-                     * by a tenth of the gap. Integer division: a gap under
-                     * 10 ms no longer descends, and that is what the
-                     * reference shows. */
-                    if (client->latency_peak_ms < 0 || latency >= client->latency_peak_ms) {
-                        client->latency_peak_ms = latency;
-                    } else {
-                        client->latency_peak_ms -= (client->latency_peak_ms - latency) / 10;
-                    }
                     RT_DEBUG(&g_bg_log_stream, now_us, "RTT=%" PRId32 "ms pk=%" PRId32 "ms",
                              latency, client->latency_peak_ms);
                 }

--- a/components/keyer_cwnet/src/cwnet_client.c
+++ b/components/keyer_cwnet/src/cwnet_client.c
@@ -59,13 +59,6 @@ static int32_t get_local_time(cwnet_client_t *client) {
 /*===========================================================================*/
 
 /**
- * @brief Build command byte from category and command
- */
-static inline uint8_t make_cmd_byte(cwnet_frame_category_t cat, cwnet_cmd_t cmd) {
-    return (uint8_t)((cat << 6) | (cmd & 0x3F));
-}
-
-/**
  * @brief Build and send CONNECT frame
  *
  * CONNECT frame format (94 bytes total):
@@ -76,35 +69,38 @@ static inline uint8_t make_cmd_byte(cwnet_frame_category_t cat, cwnet_cmd_t cmd)
  *   - payload[88-91]: permissions (4 bytes, uint32 LE)
  */
 static cwnet_client_err_t send_connect(cwnet_client_t *client) {
-    /* Frame: cmd(1) + len(1) + payload(92) = 94 bytes */
-    uint8_t frame[2 + CWNET_CONNECT_PAYLOAD_LEN];
-    memset(frame, 0, sizeof(frame));
-
-    /* Command byte: CONNECT with short payload */
-    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_CONNECT);
-    frame[1] = CWNET_CONNECT_PAYLOAD_LEN;  /* 92 */
+    uint8_t payload[CWNET_CONNECT_PAYLOAD_LEN];
+    memset(payload, 0, sizeof(payload));
 
     /* Username field (44 bytes, null-terminated, zero-padded) */
     _Static_assert(sizeof(((cwnet_client_t *)0)->username) <= CWNET_CONNECT_USERNAME_LEN,
                    "username buffer must fit in connect frame field");
     size_t username_len = strlen(client->username);
-    memcpy(&frame[2], client->username, username_len);
+    memcpy(&payload[0], client->username, username_len);
 
     /* Callsign field (44 bytes). The server keeps it as the name it announces
      * with the key (CwNet.c:1295) and strips TRANSMIT if it is empty. */
     _Static_assert(sizeof(((cwnet_client_t *)0)->callsign) <= CWNET_CONNECT_CALLSIGN_LEN,
                    "callsign buffer must fit in connect frame field");
-    memcpy(&frame[2 + CWNET_CONNECT_USERNAME_LEN], client->callsign, strlen(client->callsign));
+    memcpy(&payload[CWNET_CONNECT_USERNAME_LEN], client->callsign, strlen(client->callsign));
 
     /* Permissions field (4 bytes) - leave as zero */
+
+    /* Frame: cmd(1) + len(1) + payload(92) = 94 bytes */
+    uint8_t frame[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t frame_len = 0;
+    if (!cwnet_frame_build((uint8_t)CWNET_CMD_CONNECT, payload, sizeof(payload),
+                            frame, sizeof(frame), &frame_len)) {
+        return CWNET_CLIENT_ERR_PROTOCOL;
+    }
 
     int64_t now_us = esp_timer_get_time();
     RT_DEBUG(&g_bg_log_stream, now_us,
              "CONNECT: cmd=0x%02X user=\"%s\"",
              frame[0], client->username);
 
-    int sent = send_frame(client, frame, sizeof(frame));
-    if (sent < 0 || (size_t)sent != sizeof(frame)) {
+    int sent = send_frame(client, frame, frame_len);
+    if (sent < 0 || (size_t)sent != frame_len) {
         RT_ERROR(&g_bg_log_stream, now_us, "CONNECT send failed: %d", sent);
         return CWNET_CLIENT_ERR_SEND_FAILED;
     }
@@ -130,12 +126,14 @@ static cwnet_client_err_t send_ping_response(cwnet_client_t *client,
 
     /* Frame: cmd(1) + len(1) + payload(16) - short block */
     uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE];
-    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_PING);
-    frame[1] = CWNET_PING_PAYLOAD_SIZE;
-    memcpy(&frame[2], payload, CWNET_PING_PAYLOAD_SIZE);
+    size_t frame_len = 0;
+    if (!cwnet_frame_build((uint8_t)CWNET_CMD_PING, payload, sizeof(payload),
+                            frame, sizeof(frame), &frame_len)) {
+        return CWNET_CLIENT_ERR_PROTOCOL;
+    }
 
-    int sent = send_frame(client, frame, sizeof(frame));
-    if (sent < 0 || (size_t)sent != sizeof(frame)) {
+    int sent = send_frame(client, frame, frame_len);
+    if (sent < 0 || (size_t)sent != frame_len) {
         int64_t now_us = esp_timer_get_time();
         RT_ERROR(&g_bg_log_stream, now_us, "PING RSP1 send failed: %d", sent);
         return CWNET_CLIENT_ERR_SEND_FAILED;
@@ -169,7 +167,7 @@ static cwnet_client_err_t send_morse(cwnet_client_t *client,
                                      bool key_down,
                                      int32_t wait_ms,
                                      int32_t *encoded_ms) {
-    uint8_t frame[2 + CWNET_MORSE_MAX_EVENTS];
+    uint8_t events[CWNET_MORSE_MAX_EVENTS];
     size_t n = 0;
     int32_t remaining = wait_ms > 0 ? wait_ms : 0;
     int32_t total = 0;
@@ -181,16 +179,19 @@ static cwnet_client_err_t send_morse(cwnet_client_t *client,
         if (key_down) {
             b |= 0x80u;
         }
-        frame[2 + n] = b;
+        events[n] = b;
         n++;
         total += cwstream_decode_timestamp(b);
         remaining -= chunk;
     } while (remaining > 0 && n < CWNET_MORSE_MAX_EVENTS);
 
-    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_MORSE);
-    frame[1] = (uint8_t)n;
+    uint8_t frame[2 + CWNET_MORSE_MAX_EVENTS];
+    size_t frame_len = 0;
+    if (!cwnet_frame_build((uint8_t)CWNET_CMD_MORSE, events, n,
+                            frame, sizeof(frame), &frame_len)) {
+        return CWNET_CLIENT_ERR_PROTOCOL;
+    }
 
-    size_t frame_len = 2 + n;
     int sent = send_frame(client, frame, frame_len);
     if (sent < 0 || (size_t)sent != frame_len) {
         return CWNET_CLIENT_ERR_SEND_FAILED;
@@ -292,16 +293,18 @@ static void handle_ping(cwnet_client_t *client,
  * CwNet.c:1000-1007: the payload is the C string with its terminator.
  */
 static cwnet_client_err_t send_rig_string(cwnet_client_t *client, const char *text) {
-    size_t len = strlen(text) + 1;
+    size_t len = strlen(text) + 1;  /* trailing NUL included, CwNet.c:1000-1007 */
     uint8_t frame[2 + 32];
     if (len > sizeof(frame) - 2) {
         return CWNET_CLIENT_ERR_INVALID_ARG;
     }
-    frame[0] = make_cmd_byte(CWNET_FRAME_CAT_SHORT_PAYLOAD, CWNET_CMD_RIG_STRING);
-    frame[1] = (uint8_t)len;
-    memcpy(&frame[2], text, len);
-    int sent = send_frame(client, frame, 2 + len);
-    if (sent < 0 || (size_t)sent != 2 + len) {
+    size_t frame_len = 0;
+    if (!cwnet_frame_build((uint8_t)CWNET_CMD_RIG_STRING, (const uint8_t *)text, len,
+                            frame, sizeof(frame), &frame_len)) {
+        return CWNET_CLIENT_ERR_PROTOCOL;
+    }
+    int sent = send_frame(client, frame, frame_len);
+    if (sent < 0 || (size_t)sent != frame_len) {
         return CWNET_CLIENT_ERR_SEND_FAILED;
     }
     return CWNET_CLIENT_OK;
@@ -660,6 +663,16 @@ void cwnet_client_on_data(cwnet_client_t *client,
                 /* Parse error - skip one byte to try to resync */
                 cwnet_frame_parser_reset(&client->parser);
                 offset++;  /* Skip one byte and try again */
+                break;
+
+            case CWNET_PARSE_SKIPPED:
+                /* Fragmented frame declared more than the parser's internal
+                 * buffer (R14): fully consumed and discarded already, so
+                 * framing stays in sync without resyncing byte-by-byte. */
+                RT_WARN(&g_bg_log_stream, now_us,
+                        "FRAME: skipped, too large fragmented (cmd=0x%02X)",
+                        result.command);
+                offset += result.bytes_consumed;
                 break;
         }
     }

--- a/components/keyer_cwnet/src/cwnet_frame.c
+++ b/components/keyer_cwnet/src/cwnet_frame.c
@@ -156,13 +156,36 @@ cwnet_parse_result_t cwnet_frame_parse(cwnet_frame_parser_t *parser,
                          * below the first time fragmentation is seen, before
                          * any byte of it is buffered, so payload_received
                          * only ever becomes nonzero here when the whole
-                         * thing fits CWNET_FRAME_PARSER_BUF_SIZE. */
+                         * thing fits CWNET_FRAME_PARSER_BUF_SIZE. This branch
+                         * is therefore unreachable today, verified by review;
+                         * it stays as a fail-closed guard rather than being
+                         * "simplified" away, because this parser runs on
+                         * firmware already flashed and a future change to the
+                         * buffering logic above must not silently reopen it
+                         * into an overflow. If it is ever false, the correct
+                         * response is CWNET_PARSE_SKIPPED with no payload
+                         * (the framing stays in sync, R14's SKIPPED state
+                         * exists exactly for this): never a payload whose
+                         * declared length is longer than what was actually
+                         * copied, which a caller trusting payload_len would
+                         * read out of bounds, and never CWNET_PARSE_ERROR,
+                         * which would resync the client's parser inside the
+                         * payload instead of at the next frame boundary. */
                         size_t copy_len = needed;
                         if (parser->payload_received + copy_len <= CWNET_FRAME_PARSER_BUF_SIZE) {
                             memcpy(&parser->payload_buf[parser->payload_received],
                                    &data[pos], copy_len);
+                            result.payload = parser->payload_buf;
+                        } else {
+                            pos += needed;
+                            result.status = CWNET_PARSE_SKIPPED;
+                            result.command = cwnet_frame_get_command(parser->command);
+                            result.payload_len = 0;
+                            result.payload = NULL;
+                            result.bytes_consumed = pos;
+                            cwnet_frame_parser_reset(parser);
+                            return result;
                         }
-                        result.payload = parser->payload_buf;
                     }
 
                     pos += needed;

--- a/components/keyer_cwnet/src/cwnet_frame.c
+++ b/components/keyer_cwnet/src/cwnet_frame.c
@@ -150,7 +150,13 @@ cwnet_parse_result_t cwnet_frame_parse(cwnet_frame_parser_t *parser,
                         /* All payload in current buffer - return pointer directly */
                         result.payload = &data[pos];
                     } else {
-                        /* Payload was fragmented - copy remainder to internal buffer */
+                        /* Payload was fragmented and completes now - copy the
+                         * remainder to the internal buffer. Always fits: a
+                         * payload too large to buffer is diverted to SKIP
+                         * below the first time fragmentation is seen, before
+                         * any byte of it is buffered, so payload_received
+                         * only ever becomes nonzero here when the whole
+                         * thing fits CWNET_FRAME_PARSER_BUF_SIZE. */
                         size_t copy_len = needed;
                         if (parser->payload_received + copy_len <= CWNET_FRAME_PARSER_BUF_SIZE) {
                             memcpy(&parser->payload_buf[parser->payload_received],
@@ -166,8 +172,17 @@ cwnet_parse_result_t cwnet_frame_parse(cwnet_frame_parser_t *parser,
                     result.bytes_consumed = pos;
                     cwnet_frame_parser_reset(parser);
                     return result;
+                } else if (parser->payload_len > CWNET_FRAME_PARSER_BUF_SIZE) {
+                    /* This call does not carry the rest of the payload, and
+                     * its declared length would never fit the buffer even
+                     * fully assembled (R14): consume what is here and switch
+                     * to SKIP for the remainder, instead of overflowing
+                     * payload_buf or losing frame sync with an ERROR. */
+                    parser->payload_received = (uint16_t)(parser->payload_received + remaining);
+                    pos += remaining;
+                    parser->state = CWNET_PARSER_STATE_SKIP;
                 } else {
-                    /* Partial payload - buffer it */
+                    /* Partial payload that still fits - buffer it */
                     size_t copy_len = remaining;
                     if (parser->payload_received + copy_len <= CWNET_FRAME_PARSER_BUF_SIZE) {
                         memcpy(&parser->payload_buf[parser->payload_received],
@@ -179,9 +194,85 @@ cwnet_parse_result_t cwnet_frame_parse(cwnet_frame_parser_t *parser,
                 }
                 break;
             }
+
+            case CWNET_PARSER_STATE_SKIP: {
+                /* Discard a fragmented payload too large to buffer (R14).
+                 * Consume exactly its declared length -- never more, never
+                 * less -- so framing never drifts into what would have been
+                 * the payload. Never touches payload_buf. */
+                size_t remaining = len - pos;
+                size_t needed = (size_t)(parser->payload_len - parser->payload_received);
+                size_t consume = remaining < needed ? remaining : needed;
+
+                pos += consume;
+                parser->payload_received = (uint16_t)(parser->payload_received + consume);
+
+                if (parser->payload_received >= parser->payload_len) {
+                    result.status = CWNET_PARSE_SKIPPED;
+                    result.command = cwnet_frame_get_command(parser->command);
+                    result.payload_len = 0;
+                    result.payload = NULL;
+                    result.bytes_consumed = pos;
+                    cwnet_frame_parser_reset(parser);
+                    return result;
+                }
+                /* Stay in SKIP state, return NEED_MORE */
+                break;
+            }
         }
     }
 
     result.bytes_consumed = pos;
     return result;
+}
+
+bool cwnet_frame_build(uint8_t cmd,
+                        const uint8_t *payload, size_t payload_len,
+                        uint8_t *out_buf, size_t out_buf_size,
+                        size_t *out_len) {
+    if (out_buf == NULL || out_len == NULL) {
+        return false;
+    }
+    if (payload_len > 0 && payload == NULL) {
+        return false;
+    }
+    if (payload_len > 0xFFFFu) {
+        /* Does not fit a 16-bit length field */
+        return false;
+    }
+
+    cwnet_frame_category_t cat;
+    size_t header_len;
+    if (payload_len == 0) {
+        cat = CWNET_FRAME_CAT_NO_PAYLOAD;
+        header_len = 1;
+    } else if (payload_len <= 0xFFu) {
+        cat = CWNET_FRAME_CAT_SHORT_PAYLOAD;
+        header_len = 2;
+    } else {
+        cat = CWNET_FRAME_CAT_LONG_PAYLOAD;
+        header_len = 3;
+    }
+
+    size_t total_len = header_len + payload_len;
+    if (out_buf_size < total_len) {
+        /* Reject without writing */
+        return false;
+    }
+
+    out_buf[0] = (uint8_t)(((unsigned)cat << 6) | (cmd & CWNET_CMD_MASK_COMMAND));
+
+    if (cat == CWNET_FRAME_CAT_SHORT_PAYLOAD) {
+        out_buf[1] = (uint8_t)payload_len;
+    } else if (cat == CWNET_FRAME_CAT_LONG_PAYLOAD) {
+        out_buf[1] = (uint8_t)(payload_len & 0xFFu);
+        out_buf[2] = (uint8_t)((payload_len >> 8) & 0xFFu);
+    }
+
+    if (payload_len > 0) {
+        memcpy(&out_buf[header_len], payload, payload_len);
+    }
+
+    *out_len = total_len;
+    return true;
 }

--- a/components/keyer_cwnet/src/cwnet_ping.c
+++ b/components/keyer_cwnet/src/cwnet_ping.c
@@ -140,3 +140,114 @@ int32_t cwnet_ping_calc_latency(const cwnet_ping_t *response) {
     /* RTT = t2 - t0 */
     return response->t2_ms - response->t0_ms;
 }
+
+/*===========================================================================*/
+/* PING Building: initiator side                                            */
+/*===========================================================================*/
+
+bool cwnet_ping_build_request(uint8_t id,
+                               int32_t t0_ms,
+                               uint8_t *buffer,
+                               size_t buf_len) {
+    if (buffer == NULL || buf_len < CWNET_PING_PAYLOAD_SIZE) {
+        return false;
+    }
+
+    memset(buffer, 0, CWNET_PING_PAYLOAD_SIZE);
+
+    /* Type = REQUEST */
+    buffer[0] = (uint8_t)CWNET_PING_REQUEST;
+
+    /* id (CwNet.c:2256: the client's index) */
+    buffer[1] = id;
+
+    /* Reserved bytes 2-3 stay zero */
+
+    /* t0 (little-endian) */
+    uint32_t t0 = (uint32_t)t0_ms;
+    buffer[4] = (uint8_t)(t0 & 0xFF);
+    buffer[5] = (uint8_t)((t0 >> 8) & 0xFF);
+    buffer[6] = (uint8_t)((t0 >> 16) & 0xFF);
+    buffer[7] = (uint8_t)((t0 >> 24) & 0xFF);
+
+    /* t1, t2 slots (bytes 8-15) stay zero, already zeroed by memset */
+
+    return true;
+}
+
+bool cwnet_ping_build_response2(const cwnet_ping_t *response_1,
+                                 uint8_t *buffer,
+                                 size_t buf_len,
+                                 int32_t our_time_ms) {
+    if (response_1 == NULL || buffer == NULL || buf_len < CWNET_PING_PAYLOAD_SIZE) {
+        return false;
+    }
+
+    /* Can only build a RESPONSE_2 from a RESPONSE_1 */
+    if (response_1->type != CWNET_PING_RESPONSE_1) {
+        return false;
+    }
+
+    memset(buffer, 0, CWNET_PING_PAYLOAD_SIZE);
+
+    /* Type = RESPONSE_2 */
+    buffer[0] = (uint8_t)CWNET_PING_RESPONSE_2;
+
+    /* Preserve ID */
+    buffer[1] = response_1->id;
+
+    /* Reserved bytes 2-3 stay zero */
+
+    /* t0 = preserve from the RESPONSE_1 (little-endian) */
+    uint32_t t0 = (uint32_t)response_1->t0_ms;
+    buffer[4] = (uint8_t)(t0 & 0xFF);
+    buffer[5] = (uint8_t)((t0 >> 8) & 0xFF);
+    buffer[6] = (uint8_t)((t0 >> 16) & 0xFF);
+    buffer[7] = (uint8_t)((t0 >> 24) & 0xFF);
+
+    /* t1 = preserve from the RESPONSE_1 (little-endian) */
+    uint32_t t1 = (uint32_t)response_1->t1_ms;
+    buffer[8] = (uint8_t)(t1 & 0xFF);
+    buffer[9] = (uint8_t)((t1 >> 8) & 0xFF);
+    buffer[10] = (uint8_t)((t1 >> 16) & 0xFF);
+    buffer[11] = (uint8_t)((t1 >> 24) & 0xFF);
+
+    /* t2 = our time (little-endian) */
+    uint32_t t2 = (uint32_t)our_time_ms;
+    buffer[12] = (uint8_t)(t2 & 0xFF);
+    buffer[13] = (uint8_t)((t2 >> 8) & 0xFF);
+    buffer[14] = (uint8_t)((t2 >> 16) & 0xFF);
+    buffer[15] = (uint8_t)((t2 >> 24) & 0xFF);
+
+    return true;
+}
+
+/*===========================================================================*/
+/* Peak-hold                                                                 */
+/*===========================================================================*/
+
+/* CwNet.c:1437: "realistic" window, in microseconds there (0 <= i32 <
+ * 2000000); here it gates the wire-computed millisecond latency directly. */
+#define CWNET_PING_LATENCY_GATE_MIN_MS 0
+#define CWNET_PING_LATENCY_GATE_MAX_MS 2000
+
+bool cwnet_ping_peak_hold_update(int32_t *peak_ms, int32_t latency_ms) {
+    if (peak_ms == NULL) {
+        return false;
+    }
+
+    if (latency_ms < CWNET_PING_LATENCY_GATE_MIN_MS ||
+        latency_ms >= CWNET_PING_LATENCY_GATE_MAX_MS) {
+        return false;
+    }
+
+    /* CwNet.c:1442-1447: jump to a new peak, otherwise drop by a tenth of
+     * the gap. Integer division: a gap under 10 ms no longer descends. */
+    if (*peak_ms < 0 || latency_ms >= *peak_ms) {
+        *peak_ms = latency_ms;
+    } else {
+        *peak_ms -= (*peak_ms - latency_ms) / 10;
+    }
+
+    return true;
+}

--- a/components/keyer_cwnet/src/cwnet_ping.c
+++ b/components/keyer_cwnet/src/cwnet_ping.c
@@ -51,6 +51,17 @@ int32_t cwnet_timer_read_synced_ms(const cwnet_timer_t *timer,
 /* PING Parsing                                                              */
 /*===========================================================================*/
 
+/**
+ * @brief Write a 31-bit wire timestamp little-endian, as the reference does
+ */
+static void put_le32(uint8_t *dst, int32_t value) {
+    uint32_t v = (uint32_t)value;
+    dst[0] = (uint8_t)(v & 0xFFu);
+    dst[1] = (uint8_t)((v >> 8) & 0xFFu);
+    dst[2] = (uint8_t)((v >> 16) & 0xFFu);
+    dst[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
 bool cwnet_ping_parse(cwnet_ping_t *ping,
                       const uint8_t *payload,
                       size_t len) {
@@ -104,18 +115,10 @@ bool cwnet_ping_build_response(const cwnet_ping_t *request,
     /* Reserved bytes 2-3 stay zero */
 
     /* t0 = preserve from request (little-endian) */
-    uint32_t t0 = (uint32_t)request->t0_ms;
-    buffer[4] = (uint8_t)(t0 & 0xFF);
-    buffer[5] = (uint8_t)((t0 >> 8) & 0xFF);
-    buffer[6] = (uint8_t)((t0 >> 16) & 0xFF);
-    buffer[7] = (uint8_t)((t0 >> 24) & 0xFF);
+    put_le32(&buffer[4], request->t0_ms);
 
     /* t1 = our time (little-endian) */
-    uint32_t t1 = (uint32_t)our_time_ms;
-    buffer[8] = (uint8_t)(t1 & 0xFF);
-    buffer[9] = (uint8_t)((t1 >> 8) & 0xFF);
-    buffer[10] = (uint8_t)((t1 >> 16) & 0xFF);
-    buffer[11] = (uint8_t)((t1 >> 24) & 0xFF);
+    put_le32(&buffer[8], our_time_ms);
 
     /* t2 = 0 (will be filled by server) */
     /* Already zeroed by memset */
@@ -164,11 +167,7 @@ bool cwnet_ping_build_request(uint8_t id,
     /* Reserved bytes 2-3 stay zero */
 
     /* t0 (little-endian) */
-    uint32_t t0 = (uint32_t)t0_ms;
-    buffer[4] = (uint8_t)(t0 & 0xFF);
-    buffer[5] = (uint8_t)((t0 >> 8) & 0xFF);
-    buffer[6] = (uint8_t)((t0 >> 16) & 0xFF);
-    buffer[7] = (uint8_t)((t0 >> 24) & 0xFF);
+    put_le32(&buffer[4], t0_ms);
 
     /* t1, t2 slots (bytes 8-15) stay zero, already zeroed by memset */
 
@@ -199,25 +198,13 @@ bool cwnet_ping_build_response2(const cwnet_ping_t *response_1,
     /* Reserved bytes 2-3 stay zero */
 
     /* t0 = preserve from the RESPONSE_1 (little-endian) */
-    uint32_t t0 = (uint32_t)response_1->t0_ms;
-    buffer[4] = (uint8_t)(t0 & 0xFF);
-    buffer[5] = (uint8_t)((t0 >> 8) & 0xFF);
-    buffer[6] = (uint8_t)((t0 >> 16) & 0xFF);
-    buffer[7] = (uint8_t)((t0 >> 24) & 0xFF);
+    put_le32(&buffer[4], response_1->t0_ms);
 
     /* t1 = preserve from the RESPONSE_1 (little-endian) */
-    uint32_t t1 = (uint32_t)response_1->t1_ms;
-    buffer[8] = (uint8_t)(t1 & 0xFF);
-    buffer[9] = (uint8_t)((t1 >> 8) & 0xFF);
-    buffer[10] = (uint8_t)((t1 >> 16) & 0xFF);
-    buffer[11] = (uint8_t)((t1 >> 24) & 0xFF);
+    put_le32(&buffer[8], response_1->t1_ms);
 
     /* t2 = our time (little-endian) */
-    uint32_t t2 = (uint32_t)our_time_ms;
-    buffer[12] = (uint8_t)(t2 & 0xFF);
-    buffer[13] = (uint8_t)((t2 >> 8) & 0xFF);
-    buffer[14] = (uint8_t)((t2 >> 16) & 0xFF);
-    buffer[15] = (uint8_t)((t2 >> 24) & 0xFF);
+    put_le32(&buffer[12], our_time_ms);
 
     return true;
 }

--- a/components/keyer_cwnet/src/cwnet_play.c
+++ b/components/keyer_cwnet/src/cwnet_play.c
@@ -113,7 +113,11 @@ static void arm_from_byte(cwnet_play_t *play, uint8_t cmd, int64_t base_ms) {
     play->pending_key_down = is_split_chunk(cmd, play->key_down)
                                  ? play->key_down
                                  : ((cmd & KEY_BIT) != 0u);
-    play->prev_byte_key_down = (cmd & KEY_BIT) != 0u;
+    /* The state this byte actually leaves on the key, not the bit it carries:
+     * a chunk of a split wait carries the state the wait ENDS in, and taking
+     * its raw bit makes two chunks of a long key-down look like the two
+     * key-up bytes that end an over. */
+    play->prev_byte_key_down = play->pending_key_down;
     play->have_prev_byte = true;
     play->deadline_ms = base_ms + wait_ms;
     play->state = CWNET_PLAY_RUNNING;
@@ -183,6 +187,15 @@ static void do_deadline(cwnet_play_t *play, int64_t at_ms, cwnet_play_result_t *
      * The second one is not waited out: its time is silence, and the sooner
      * the key is free the sooner the other end can come back. */
     if (play->have_prev_byte && !play->prev_byte_key_down && ((cmd & KEY_BIT) == 0u)) {
+        /* Whatever brought us here, the engine does not come to rest with the
+         * key down: a stuck carrier is the worst outcome this module has
+         * (ARCHITECTURE.md 8.1). Free it before closing, at this instant. */
+        if (play->key_down) {
+            play->key_down = false;
+            emit(out, CWNET_PLAY_EV_KEY_UP, at_ms);
+            ptt_off_no_later_than(play, at_ms + (int64_t)play->cfg.ptt_tail_ms);
+        }
+        play->pending_key_down = false;
         emit(out, CWNET_PLAY_EV_END_OF_OVER, at_ms);
         play->state = CWNET_PLAY_CLOSING;
         play->have_prev_byte = false;

--- a/components/keyer_cwnet/src/cwnet_play.c
+++ b/components/keyer_cwnet/src/cwnet_play.c
@@ -1,0 +1,401 @@
+/**
+ * @file cwnet_play.c
+ * @brief Playback of a remote client's MORSE bytes into key edges and PTT
+ *
+ * The rules and the reasons are in cwnet_play.h. Nothing here reads a clock
+ * or writes a log: the caller passes the instant in and reads the events
+ * out (KTD10).
+ */
+
+#include "cwnet_play.h"
+#include "cwnet_timestamp.h"
+
+#include <string.h>
+
+/** Key state lives in bit 7 of a MORSE byte; the wait is the rest */
+#define KEY_BIT 0x80u
+#define WAIT_MASK 0x7Fu
+
+/** Largest wait one byte can carry: the encoder's split marker */
+#define WAIT_MAX_CODE 0x7Fu
+
+/** Room a single action may need in the result before it starts */
+#define EVENTS_PER_ACTION 4u
+
+/** Bound on the actions one tick may perform, so a bad state cannot spin */
+#define TICK_GUARD (2 * CWNET_PLAY_FIFO_SIZE + 8)
+
+/*===========================================================================*/
+/* Events                                                                    */
+/*===========================================================================*/
+
+static void emit(cwnet_play_result_t *out, cwnet_play_event_type_t type, int64_t at_ms) {
+    if (out->count < CWNET_PLAY_MAX_EVENTS) {
+        out->ev[out->count].type = type;
+        out->ev[out->count].at_ms = at_ms;
+        out->count++;
+    }
+}
+
+/*===========================================================================*/
+/* FIFO                                                                      */
+/*===========================================================================*/
+
+static bool fifo_pop(cwnet_play_t *play, uint8_t *cmd, int64_t *received_at_ms) {
+    if (play->fifo.count == 0) {
+        return false;
+    }
+    *cmd = play->fifo.cmd[play->fifo.tail];
+    *received_at_ms = play->fifo.received_at_ms[play->fifo.tail];
+    play->fifo.tail = (uint16_t)((play->fifo.tail + 1u) % CWNET_PLAY_FIFO_SIZE);
+    play->fifo.count--;
+    return true;
+}
+
+/*===========================================================================*/
+/* PTT                                                                       */
+/*===========================================================================*/
+
+/**
+ * @brief Drop the PTT at at_ms, or keep an earlier drop already scheduled
+ */
+static void ptt_off_no_later_than(cwnet_play_t *play, int64_t at_ms) {
+    if (!play->ptt_on) {
+        return;
+    }
+    if (play->ptt_off_pending && play->ptt_off_at_ms <= at_ms) {
+        return;
+    }
+    play->ptt_off_pending = true;
+    play->ptt_off_at_ms = at_ms;
+}
+
+/**
+ * @brief Raise the PTT a lead ahead of a key-down that is already scheduled
+ *
+ * The lead is possible only because the edge is known B ms before it has to
+ * happen (KTD5); it was clamped to B when the over was armed.
+ */
+static void schedule_ptt_on(cwnet_play_t *play, int64_t key_down_at_ms) {
+    if (!play->pending_key_down || play->ptt_on || play->ptt_on_pending) {
+        return;
+    }
+    play->ptt_on_pending = true;
+    play->ptt_on_at_ms = key_down_at_ms - (int64_t)play->lead_ms;
+}
+
+/*===========================================================================*/
+/* Consuming bytes                                                           */
+/*===========================================================================*/
+
+/**
+ * @brief True when a byte is a chunk of a wait too long for one byte
+ *
+ * The encoder splits a wait above CWSTREAM_MAX_WAIT_MS into chunks that all
+ * carry the state the wait ends in, every chunk but the last with the 7-bit
+ * field at its maximum (CwStreamEnc.c:135-146). Such a chunk carries no edge
+ * of its own: it only spends its time in the state the key is already in, so
+ * the edge lands after the sum.
+ */
+static bool is_split_chunk(uint8_t cmd, bool key_down_now) {
+    bool byte_key_down = (cmd & KEY_BIT) != 0u;
+    return ((cmd & WAIT_MASK) == WAIT_MAX_CODE) && (byte_key_down != key_down_now);
+}
+
+/**
+ * @brief Take one byte and put its deadline on the timeline
+ *
+ * @param base_ms Instant the byte's wait is measured from
+ */
+static void arm_from_byte(cwnet_play_t *play, uint8_t cmd, int64_t base_ms) {
+    int64_t wait_ms = (int64_t)cwstream_decode_timestamp(cmd);
+
+    play->pending_key_down = is_split_chunk(cmd, play->key_down)
+                                 ? play->key_down
+                                 : ((cmd & KEY_BIT) != 0u);
+    play->prev_byte_key_down = (cmd & KEY_BIT) != 0u;
+    play->have_prev_byte = true;
+    play->deadline_ms = base_ms + wait_ms;
+    play->state = CWNET_PLAY_RUNNING;
+    schedule_ptt_on(play, play->deadline_ms);
+}
+
+/**
+ * @brief Anchor an over on its first byte: reception + its wait + B
+ *
+ * B delays the start of the over and nothing else; from there the timeline
+ * runs on the encoded waits alone.
+ */
+static void arm_if_idle(cwnet_play_t *play) {
+    if (play->state != CWNET_PLAY_IDLE || play->fifo.count == 0) {
+        return;
+    }
+    uint8_t cmd = 0;
+    int64_t received_at_ms = 0;
+    (void)fifo_pop(play, &cmd, &received_at_ms);
+    play->have_prev_byte = false;
+    arm_from_byte(play, cmd, received_at_ms + (int64_t)play->buffer_ms);
+}
+
+/**
+ * @brief Give up the over: key up if it was down, and say why
+ */
+static void underrun(cwnet_play_t *play, int64_t at_ms, cwnet_play_result_t *out) {
+    if (play->key_down) {
+        play->key_down = false;
+        emit(out, CWNET_PLAY_EV_KEY_UP, at_ms);
+        ptt_off_no_later_than(play, at_ms + (int64_t)play->cfg.ptt_tail_ms);
+        emit(out, CWNET_PLAY_EV_UNDERRUN, at_ms);
+    }
+    /* The bytes that follow restart as a new over with the same B (R8) */
+    play->state = CWNET_PLAY_IDLE;
+    play->have_prev_byte = false;
+}
+
+/**
+ * @brief Everything the engine does when a keying deadline comes due
+ */
+static void do_deadline(cwnet_play_t *play, int64_t at_ms, cwnet_play_result_t *out) {
+    if (play->pending_key_down != play->key_down) {
+        play->key_down = play->pending_key_down;
+        if (play->key_down) {
+            if (!play->ptt_on) {   /* no lead was scheduled: never key without PTT */
+                play->ptt_on = true;
+                play->ptt_on_pending = false;
+                emit(out, CWNET_PLAY_EV_PTT_ON, at_ms);
+            }
+            play->ptt_off_pending = false;
+            emit(out, CWNET_PLAY_EV_KEY_DOWN, at_ms);
+        } else {
+            emit(out, CWNET_PLAY_EV_KEY_UP, at_ms);
+            ptt_off_no_later_than(play, at_ms + (int64_t)play->cfg.ptt_tail_ms);
+        }
+    }
+
+    uint8_t cmd = 0;
+    int64_t received_at_ms = 0;
+    if (!fifo_pop(play, &cmd, &received_at_ms)) {
+        underrun(play, at_ms, out);
+        return;
+    }
+
+    /* Two key-up bytes in a row are the reference's end of transmission.
+     * The second one is not waited out: its time is silence, and the sooner
+     * the key is free the sooner the other end can come back. */
+    if (play->have_prev_byte && !play->prev_byte_key_down && ((cmd & KEY_BIT) == 0u)) {
+        emit(out, CWNET_PLAY_EV_END_OF_OVER, at_ms);
+        play->state = CWNET_PLAY_CLOSING;
+        play->have_prev_byte = false;
+        if (!play->ptt_on && !play->ptt_on_pending) {
+            emit(out, CWNET_PLAY_EV_OVER_FINISHED, at_ms);
+            play->state = CWNET_PLAY_IDLE;
+        }
+        return;
+    }
+
+    arm_from_byte(play, cmd, at_ms);
+}
+
+/*===========================================================================*/
+/* Scheduling                                                                */
+/*===========================================================================*/
+
+typedef enum {
+    ACT_NONE = 0,
+    ACT_PTT_ON,    /* first, so the PTT never trails the carrier */
+    ACT_DEADLINE,
+    ACT_PTT_OFF,   /* last, so a key-down at the same instant cancels it */
+} action_t;
+
+static action_t next_action(const cwnet_play_t *play, int64_t *at_ms) {
+    action_t best = ACT_NONE;
+    int64_t best_at = 0;
+
+    if (play->ptt_on_pending) {
+        best = ACT_PTT_ON;
+        best_at = play->ptt_on_at_ms;
+    }
+    if (play->state == CWNET_PLAY_RUNNING) {
+        if (best == ACT_NONE || play->deadline_ms < best_at) {
+            best = ACT_DEADLINE;
+            best_at = play->deadline_ms;
+        }
+    }
+    if (play->ptt_off_pending) {
+        if (best == ACT_NONE || play->ptt_off_at_ms < best_at) {
+            best = ACT_PTT_OFF;
+            best_at = play->ptt_off_at_ms;
+        }
+    }
+    *at_ms = best_at;
+    return best;
+}
+
+static void do_ptt_off(cwnet_play_t *play, int64_t at_ms, cwnet_play_result_t *out) {
+    play->ptt_off_pending = false;
+    play->ptt_on = false;
+    emit(out, CWNET_PLAY_EV_PTT_OFF, at_ms);
+    if (play->state == CWNET_PLAY_CLOSING) {
+        emit(out, CWNET_PLAY_EV_OVER_FINISHED, at_ms);
+        play->state = CWNET_PLAY_IDLE;
+        play->have_prev_byte = false;
+    }
+}
+
+/*===========================================================================*/
+/* Public interface                                                          */
+/*===========================================================================*/
+
+void cwnet_play_init(cwnet_play_t *play, const cwnet_play_cfg_t *cfg) {
+    if (play == NULL) {
+        return;
+    }
+    memset(play, 0, sizeof(*play));
+    if (cfg != NULL) {
+        play->cfg = *cfg;
+    } else {
+        play->cfg.ptt_lead_ms = 0u;
+        play->cfg.ptt_tail_ms = CWNET_PLAY_DEFAULT_PTT_TAIL_MS;
+    }
+    play->state = CWNET_PLAY_IDLE;
+}
+
+void cwnet_play_start_over(cwnet_play_t *play, uint32_t buffer_ms) {
+    if (play == NULL) {
+        return;
+    }
+    play->buffer_ms = buffer_ms;
+    play->lead_ms = (play->cfg.ptt_lead_ms > buffer_ms) ? buffer_ms : play->cfg.ptt_lead_ms;
+    play->fifo.tail = 0;
+    play->fifo.count = 0;
+    play->state = CWNET_PLAY_IDLE;
+    /* A PTT raised in anticipation of an over we are throwing away must not
+     * survive it; a PTT already up is the caller's to release. */
+    play->ptt_on_pending = false;
+    play->have_prev_byte = false;
+    play->prev_byte_key_down = false;
+    play->pending_key_down = play->key_down;
+    play->deadline_ms = 0;
+}
+
+bool cwnet_play_push(cwnet_play_t *play, uint8_t cmd, int64_t now_ms) {
+    if (play == NULL) {
+        return false;
+    }
+    if (play->fifo.count >= CWNET_PLAY_FIFO_SIZE) {
+        play->dropped++;
+        return false;
+    }
+    uint16_t head = (uint16_t)((play->fifo.tail + play->fifo.count) % CWNET_PLAY_FIFO_SIZE);
+    play->fifo.cmd[head] = cmd;
+    play->fifo.received_at_ms[head] = now_ms;
+    play->fifo.count++;
+    arm_if_idle(play);
+    return true;
+}
+
+bool cwnet_play_next_deadline(const cwnet_play_t *play, int64_t *out_ms) {
+    if (play == NULL || out_ms == NULL) {
+        return false;
+    }
+    int64_t at_ms = 0;
+    if (next_action(play, &at_ms) == ACT_NONE) {
+        return false;
+    }
+    *out_ms = at_ms;
+    return true;
+}
+
+void cwnet_play_tick(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out) {
+    cwnet_play_result_t sink;
+    if (out == NULL) {
+        out = &sink;
+    }
+    out->count = 0;
+    if (play == NULL) {
+        return;
+    }
+
+    for (int guard = 0; guard < TICK_GUARD; guard++) {
+        arm_if_idle(play);
+
+        int64_t at_ms = 0;
+        action_t act = next_action(play, &at_ms);
+        if (act == ACT_NONE || at_ms > now_ms) {
+            return;
+        }
+        if ((CWNET_PLAY_MAX_EVENTS - out->count) < EVENTS_PER_ACTION) {
+            return;   /* the rest stays scheduled: the caller ticks again */
+        }
+
+        switch (act) {
+            case ACT_PTT_ON:
+                play->ptt_on_pending = false;
+                play->ptt_on = true;
+                emit(out, CWNET_PLAY_EV_PTT_ON, at_ms);
+                break;
+            case ACT_DEADLINE:
+                do_deadline(play, at_ms, out);
+                break;
+            case ACT_PTT_OFF:
+                do_ptt_off(play, at_ms, out);
+                break;
+            default:
+                return;
+        }
+    }
+}
+
+void cwnet_play_force_release(cwnet_play_t *play, int64_t now_ms, cwnet_play_result_t *out) {
+    cwnet_play_result_t sink;
+    if (out == NULL) {
+        out = &sink;
+    }
+    out->count = 0;
+    if (play == NULL) {
+        return;
+    }
+
+    play->fifo.tail = 0;
+    play->fifo.count = 0;
+    play->have_prev_byte = false;
+    play->state = CWNET_PLAY_CLOSING;
+
+    if (play->key_down) {
+        play->key_down = false;
+        emit(out, CWNET_PLAY_EV_KEY_UP, now_ms);
+    }
+    play->pending_key_down = false;
+
+    /* A PTT raised only in anticipation of a key-down that will never come */
+    if (!play->ptt_on) {
+        play->ptt_on_pending = false;
+    }
+
+    if (play->ptt_on) {
+        ptt_off_no_later_than(play, now_ms + (int64_t)play->cfg.ptt_tail_ms);
+    } else {
+        emit(out, CWNET_PLAY_EV_OVER_FINISHED, now_ms);
+        play->state = CWNET_PLAY_IDLE;
+    }
+}
+
+bool cwnet_play_key_down(const cwnet_play_t *play) {
+    return (play != NULL) && play->key_down;
+}
+
+bool cwnet_play_ptt_on(const cwnet_play_t *play) {
+    return (play != NULL) && play->ptt_on;
+}
+
+bool cwnet_play_over_open(const cwnet_play_t *play) {
+    if (play == NULL) {
+        return false;
+    }
+    return play->state != CWNET_PLAY_IDLE || play->key_down || play->ptt_on ||
+           play->ptt_on_pending || play->ptt_off_pending;
+}
+
+uint32_t cwnet_play_dropped(const cwnet_play_t *play) {
+    return (play == NULL) ? 0u : play->dropped;
+}

--- a/components/keyer_cwnet/src/cwnet_play.c
+++ b/components/keyer_cwnet/src/cwnet_play.c
@@ -380,6 +380,10 @@ void cwnet_play_force_release(cwnet_play_t *play, int64_t now_ms, cwnet_play_res
     }
 }
 
+uint32_t cwnet_play_buffer_ms(const cwnet_play_t *play) {
+    return (play == NULL) ? 0u : play->buffer_ms;
+}
+
 bool cwnet_play_key_down(const cwnet_play_t *play) {
     return (play != NULL) && play->key_down;
 }

--- a/components/keyer_cwnet/src/cwnet_server.c
+++ b/components/keyer_cwnet/src/cwnet_server.c
@@ -216,7 +216,6 @@ static void release_key(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result
         return;
     }
     srv->key_holder = CWNET_SERVER_NOBODY;
-    srv->buffer_ms = 0u;
     announce_key(srv, now_ms, out);
 }
 
@@ -560,7 +559,6 @@ static bool take_key(cwnet_server_t *srv, int client_idx, int64_t now_ms,
     }
 
     srv->key_holder = client_idx;
-    srv->buffer_ms = buffer_ms;
     srv->over_started_at_ms = now_ms;
     srv->holder_last_byte_ms = now_ms;
     cwnet_play_start_over(&srv->play, buffer_ms);
@@ -909,7 +907,9 @@ int32_t cwnet_server_client_peak_ms(const cwnet_server_t *srv, int client_idx) {
 }
 
 uint32_t cwnet_server_buffer_ms(const cwnet_server_t *srv) {
-    return (srv == NULL) ? 0u : srv->buffer_ms;
+    /* The playback engine owns B; asking it beats keeping a second copy in
+     * step with it. */
+    return (srv == NULL) ? 0u : cwnet_play_buffer_ms(&srv->play);
 }
 
 bool cwnet_server_key_down(const cwnet_server_t *srv) {

--- a/components/keyer_cwnet/src/cwnet_server.c
+++ b/components/keyer_cwnet/src/cwnet_server.c
@@ -1,0 +1,924 @@
+/**
+ * @file cwnet_server.c
+ * @brief The station server's core. Rules and reasons in cwnet_server.h.
+ *
+ * Nothing here reads a clock, touches a socket or writes a log (KTD1,
+ * KTD10): the instant comes in as an argument, the bytes go out through
+ * the send callback, and what happened comes back in the result.
+ *
+ * The peer's bytes are never C strings. The CONNECT's two fields are
+ * copied for their fixed 44 bytes and terminated here; a rig-control
+ * string must carry its NUL inside its payload or the client is closed;
+ * a PING goes through cwnet_ping_parse(), which refuses a short payload.
+ */
+
+#include "cwnet_server.h"
+
+#include "cwnet_client.h"   /* command codes, CONNECT layout, permission bits */
+
+#include <stdio.h>
+#include <string.h>
+
+/** Frame the server builds: the CONNECT echo is the longest at 2 + 92 */
+#define TX_FRAME_MAX (2u + 128u)
+
+/** Longest rig-control string we look at; the rest cannot match a command */
+#define RIG_STRING_MAX 128u
+
+/** What the reference announces when nobody has the key (CwNet.c:449) */
+#define NOBODY_NAME "-- nobody --"
+
+/** The index byte of a TX_INFO when nobody has the key: -1 as a byte */
+#define NOBODY_INDEX_BYTE 0xFFu
+
+/** The 31-bit range the reference puts on the wire (CwNet.c:2254) */
+#define WIRE_CLOCK_MASK 0x7FFFFFFF
+
+/** Bound on how many times one call drives the playback engine */
+#define PLAY_GUARD 64
+
+/*===========================================================================*/
+/* Events                                                                    */
+/*===========================================================================*/
+
+static void emit(cwnet_server_result_t *out, cwnet_server_event_type_t type,
+                 int client_idx, int32_t value, int32_t peak_ms, int64_t at_ms) {
+    if (out == NULL) {
+        return;
+    }
+    if (out->count >= CWNET_SERVER_MAX_EVENTS) {
+        out->dropped++;
+        return;
+    }
+    cwnet_server_event_t *ev = &out->ev[out->count++];
+    ev->type = type;
+    ev->client_idx = client_idx;
+    ev->value = value;
+    ev->peak_ms = peak_ms;
+    ev->at_ms = at_ms;
+}
+
+static void result_clear(cwnet_server_result_t *out) {
+    if (out != NULL) {
+        out->count = 0;
+        out->dropped = 0;
+    }
+}
+
+/*===========================================================================*/
+/* Slots                                                                     */
+/*===========================================================================*/
+
+static bool index_in_range(const cwnet_server_t *srv, int client_idx) {
+    return client_idx >= CWNET_SERVER_FIRST_CLIENT &&
+           client_idx < CWNET_SERVER_FIRST_CLIENT + (int)srv->cfg.max_clients;
+}
+
+static cwnet_server_client_t *slot(cwnet_server_t *srv, int client_idx) {
+    if (srv == NULL || !index_in_range(srv, client_idx)) {
+        return NULL;
+    }
+    cwnet_server_client_t *c = &srv->client[client_idx - CWNET_SERVER_FIRST_CLIENT];
+    return c->in_use ? c : NULL;
+}
+
+static const cwnet_server_client_t *slot_const(const cwnet_server_t *srv, int client_idx) {
+    if (srv == NULL || !index_in_range(srv, client_idx)) {
+        return NULL;
+    }
+    const cwnet_server_client_t *c = &srv->client[client_idx - CWNET_SERVER_FIRST_CLIENT];
+    return c->in_use ? c : NULL;
+}
+
+/*===========================================================================*/
+/* Sending                                                                   */
+/*===========================================================================*/
+
+static void close_client(cwnet_server_t *srv, int client_idx,
+                         cwnet_server_close_reason_t reason,
+                         int64_t now_ms, cwnet_server_result_t *out);
+
+/**
+ * @brief Put one frame on a client's wire
+ *
+ * A short write breaks the framing, so it counts as a failure and the
+ * caller closes that client.
+ *
+ * @return false when the send callback did not take the whole frame
+ */
+static bool send_frame(cwnet_server_t *srv, int client_idx, uint8_t cmd,
+                       const uint8_t *payload, size_t payload_len) {
+    uint8_t frame[TX_FRAME_MAX];
+    size_t frame_len = 0;
+    if (!cwnet_frame_build(cmd, payload, payload_len, frame, sizeof(frame), &frame_len)) {
+        return false;
+    }
+    if (srv->cfg.send_cb == NULL) {
+        return false;
+    }
+    int sent = srv->cfg.send_cb(client_idx, frame, frame_len, srv->cfg.user_data);
+    return sent >= 0 && (size_t)sent == frame_len;
+}
+
+/**
+ * @brief A frame, and the client closed if it could not go out
+ */
+static bool send_or_close(cwnet_server_t *srv, int client_idx, uint8_t cmd,
+                          const uint8_t *payload, size_t payload_len,
+                          int64_t now_ms, cwnet_server_result_t *out) {
+    if (send_frame(srv, client_idx, cmd, payload, payload_len)) {
+        return true;
+    }
+    close_client(srv, client_idx, CWNET_SERVER_CLOSE_SEND_FAILED, now_ms, out);
+    return false;
+}
+
+/**
+ * @brief "Text the receiver should print somewhere", trailing NUL included
+ *
+ * CwNet.c:749-756: CwNet_SendTextToPrint() sends strlen + 1.
+ */
+static void send_print(cwnet_server_t *srv, int client_idx, const char *text,
+                       int64_t now_ms, cwnet_server_result_t *out) {
+    size_t len = strlen(text) + 1u;
+    if (len > TX_FRAME_MAX - 2u) {
+        return;
+    }
+    (void)send_or_close(srv, client_idx, (uint8_t)CWNET_SERVER_CMD_PRINT,
+                        (const uint8_t *)text, len, now_ms, out);
+}
+
+/*===========================================================================*/
+/* Who has the key: the TX_INFO                                              */
+/*===========================================================================*/
+
+/**
+ * @brief The name a client is announced under
+ *
+ * The callsign it sent, or "NoCall #n" when it sent none: the reference's
+ * CwNet_GetClientCallOrInfo() (CwNet.c:432-452), which never reveals a
+ * user name to the other clients.
+ */
+static const char *announced_name(const cwnet_server_t *srv, int client_idx) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    return (c != NULL && c->name[0] != '\0') ? c->name : NOBODY_NAME;
+}
+
+/**
+ * @brief The TX_INFO payload for the current holder: index byte, name, NUL
+ */
+static size_t build_tx_info(const cwnet_server_t *srv, uint8_t *payload, size_t size) {
+    const char *name = NOBODY_NAME;
+    uint8_t index_byte = (uint8_t)NOBODY_INDEX_BYTE;
+    if (srv->key_holder != CWNET_SERVER_NOBODY) {
+        index_byte = (uint8_t)srv->key_holder;
+        name = announced_name(srv, srv->key_holder);
+    }
+    size_t name_len = strlen(name) + 1u;   /* the NUL goes on the wire */
+    if (name_len + 1u > size) {
+        name_len = size - 1u;
+    }
+    payload[0] = index_byte;
+    memcpy(payload + 1, name, name_len);
+    payload[name_len] = 0u;   /* a truncated name still ends where it says */
+    return name_len + 1u;
+}
+
+/**
+ * @brief Tell every confirmed client who has the key now
+ *
+ * A client whose send fails is closed here. That client cannot be the
+ * holder — the holder was set or cleared before this call — so the close
+ * cannot come back into this function for a second announcement.
+ */
+static void announce_key(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result_t *out) {
+    uint8_t payload[CWNET_SERVER_NAME_LEN + 1];
+    size_t len = build_tx_info(srv, payload, sizeof(payload));
+
+    emit(out, CWNET_SERVER_EV_KEY_HOLDER, srv->key_holder, 0, 0, now_ms);
+
+    for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
+        int idx = CWNET_SERVER_FIRST_CLIENT + i;
+        cwnet_server_client_t *c = slot(srv, idx);
+        if (c == NULL || !c->confirmed) {
+            continue;
+        }
+        (void)send_or_close(srv, idx, (uint8_t)CWNET_CMD_TX_INFO, payload, len, now_ms, out);
+    }
+}
+
+/*===========================================================================*/
+/* The playback engine                                                       */
+/*===========================================================================*/
+
+static void release_key(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result_t *out) {
+    if (srv->key_holder == CWNET_SERVER_NOBODY) {
+        return;
+    }
+    srv->key_holder = CWNET_SERVER_NOBODY;
+    srv->buffer_ms = 0u;
+    announce_key(srv, now_ms, out);
+}
+
+static void map_play_events(cwnet_server_t *srv, const cwnet_play_result_t *pr,
+                            cwnet_server_result_t *out) {
+    for (size_t i = 0; i < pr->count; i++) {
+        const cwnet_play_event_t *ev = &pr->ev[i];
+        switch (ev->type) {
+            case CWNET_PLAY_EV_KEY_DOWN:
+                emit(out, CWNET_SERVER_EV_KEY_DOWN, srv->key_holder, 0, 0, ev->at_ms);
+                break;
+            case CWNET_PLAY_EV_KEY_UP:
+                emit(out, CWNET_SERVER_EV_KEY_UP, srv->key_holder, 0, 0, ev->at_ms);
+                break;
+            case CWNET_PLAY_EV_PTT_ON:
+                emit(out, CWNET_SERVER_EV_PTT_ON, srv->key_holder, 0, 0, ev->at_ms);
+                break;
+            case CWNET_PLAY_EV_PTT_OFF:
+                emit(out, CWNET_SERVER_EV_PTT_OFF, srv->key_holder, 0, 0, ev->at_ms);
+                break;
+            case CWNET_PLAY_EV_UNDERRUN:
+                emit(out, CWNET_SERVER_EV_FAULT, srv->key_holder,
+                     (int32_t)CWNET_SERVER_FAULT_UNDERRUN, 0, ev->at_ms);
+                break;
+            case CWNET_PLAY_EV_OVER_FINISHED:
+                /* The marker was played and the PTT is down: the key is free
+                 * again (R6). Announcing is the last thing the over does. */
+                release_key(srv, ev->at_ms, out);
+                break;
+            case CWNET_PLAY_EV_END_OF_OVER:
+            default:
+                break;
+        }
+    }
+}
+
+/**
+ * @brief Let the engine do everything due at or before now_ms
+ */
+static void run_play(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result_t *out) {
+    for (int guard = 0; guard < PLAY_GUARD; guard++) {
+        cwnet_play_result_t pr;
+        cwnet_play_tick(&srv->play, now_ms, &pr);
+        if (pr.count == 0u) {
+            return;
+        }
+        map_play_events(srv, &pr, out);
+    }
+}
+
+/**
+ * @brief A safety net fired: key up now, PTT down at the tail, key free
+ */
+static void force_release(cwnet_server_t *srv, cwnet_server_fault_t why,
+                          int64_t now_ms, cwnet_server_result_t *out) {
+    cwnet_play_result_t pr;
+    cwnet_play_force_release(&srv->play, now_ms, &pr);
+    map_play_events(srv, &pr, out);
+    emit(out, CWNET_SERVER_EV_FAULT, srv->key_holder, (int32_t)why, 0, now_ms);
+    release_key(srv, now_ms, out);
+}
+
+/*===========================================================================*/
+/* Closing a client                                                          */
+/*===========================================================================*/
+
+static void close_client(cwnet_server_t *srv, int client_idx,
+                         cwnet_server_close_reason_t reason,
+                         int64_t now_ms, cwnet_server_result_t *out) {
+    cwnet_server_client_t *c = slot(srv, client_idx);
+    if (c == NULL) {
+        return;
+    }
+    bool had_key = (srv->key_holder == client_idx);
+
+    memset(c, 0, sizeof(*c));
+    c->in_use = false;
+
+    emit(out, CWNET_SERVER_EV_CLIENT_CLOSED, client_idx, (int32_t)reason, 0, now_ms);
+
+    if (had_key) {
+        /* Its over dies with it: key up at once, PTT down at the tail (R6) */
+        force_release(srv, CWNET_SERVER_FAULT_HOLDER_GONE, now_ms, out);
+    }
+}
+
+/*===========================================================================*/
+/* CONNECT                                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief Copy one fixed-width CONNECT field and terminate it here
+ *
+ * The peer's 44 bytes may carry no NUL at all: reading them as a C string
+ * would run off the payload.
+ */
+static void copy_field(char *dst, size_t dst_size, const uint8_t *src, size_t field_len) {
+    size_t n = (field_len < dst_size - 1u) ? field_len : dst_size - 1u;
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+static void handle_connect(cwnet_server_t *srv, int client_idx,
+                           const uint8_t *payload, size_t payload_len,
+                           int64_t now_ms, cwnet_server_result_t *out) {
+    cwnet_server_client_t *c = slot(srv, client_idx);
+    if (c == NULL) {
+        return;
+    }
+    if (payload_len != CWNET_CONNECT_PAYLOAD_LEN) {
+        /* "Un CONNECT di lunghezza diversa chiude la connessione" (R2) */
+        close_client(srv, client_idx, CWNET_SERVER_CLOSE_BAD_CONNECT, now_ms, out);
+        return;
+    }
+    if (c->confirmed) {
+        /* One log-in per connection. A second one would move a callsign
+         * under an over in progress; the reference has no such case. */
+        return;
+    }
+
+    copy_field(c->username, sizeof(c->username), payload, CWNET_CONNECT_USERNAME_LEN);
+    copy_field(c->name, sizeof(c->name), payload + CWNET_CONNECT_USERNAME_LEN,
+               CWNET_CONNECT_CALLSIGN_LEN);
+    if (c->name[0] <= ' ') {
+        /* No callsign: announced as the reference does, never as the user
+         * name (CwNet.c:441-444) */
+        (void)snprintf(c->name, sizeof(c->name), "NoCall #%d", client_idx);
+    }
+
+    /* The echo: the record back with the permissions filled in. Everybody
+     * may talk, transmit and control the rig (KTD6). */
+    uint8_t echo[CWNET_CONNECT_PAYLOAD_LEN];
+    memcpy(echo, payload, CWNET_CONNECT_PAYLOAD_LEN);
+    uint32_t permissions = CWNET_PERMISSION_TALK | CWNET_PERMISSION_TRANSMIT |
+                           CWNET_PERMISSION_CTRL_RIG;
+    echo[CWNET_CONNECT_PERMISSIONS_OFFSET + 0] = (uint8_t)(permissions & 0xFFu);
+    echo[CWNET_CONNECT_PERMISSIONS_OFFSET + 1] = (uint8_t)((permissions >> 8) & 0xFFu);
+    echo[CWNET_CONNECT_PERMISSIONS_OFFSET + 2] = (uint8_t)((permissions >> 16) & 0xFFu);
+    echo[CWNET_CONNECT_PERMISSIONS_OFFSET + 3] = (uint8_t)((permissions >> 24) & 0xFFu);
+
+    c->confirmed = true;
+    c->next_ping_at_ms = now_ms + (int64_t)srv->cfg.ping_interval_ms;
+
+    if (!send_or_close(srv, client_idx, (uint8_t)CWNET_CMD_CONNECT, echo, sizeof(echo),
+                       now_ms, out)) {
+        return;
+    }
+
+    char welcome[CWNET_SERVER_NAME_LEN + 64];
+    (void)snprintf(welcome, sizeof(welcome),
+                   "Welcome %s. You may talk, transmit and control the rig.",
+                   c->username);
+    send_print(srv, client_idx, welcome, now_ms, out);
+    if (slot(srv, client_idx) == NULL) {
+        return;
+    }
+
+    /* Then the state of the key as it stands (R2) */
+    uint8_t tx_info[CWNET_SERVER_NAME_LEN + 1];
+    size_t tx_info_len = build_tx_info(srv, tx_info, sizeof(tx_info));
+    if (!send_or_close(srv, client_idx, (uint8_t)CWNET_CMD_TX_INFO, tx_info, tx_info_len,
+                       now_ms, out)) {
+        return;
+    }
+
+    emit(out, CWNET_SERVER_EV_CLIENT_READY, client_idx, 0, 0, now_ms);
+}
+
+/*===========================================================================*/
+/* PING                                                                      */
+/*===========================================================================*/
+
+static int32_t wire_clock(int64_t now_ms) {
+    return (int32_t)(uint32_t)((uint64_t)now_ms & (uint64_t)WIRE_CLOCK_MASK);
+}
+
+static void handle_ping(cwnet_server_t *srv, int client_idx,
+                        const uint8_t *payload, size_t payload_len,
+                        int64_t now_ms, cwnet_server_result_t *out) {
+    cwnet_server_client_t *c = slot(srv, client_idx);
+    cwnet_ping_t ping;
+    if (c == NULL || !cwnet_ping_parse(&ping, payload, payload_len)) {
+        return;   /* a wrong length is not a framing error: ignore it */
+    }
+
+    uint8_t buf[CWNET_PING_PAYLOAD_SIZE];
+
+    if (ping.type == CWNET_PING_REQUEST) {
+        /* The other end may ping us too; answer as the reference does */
+        if (cwnet_ping_build_response(&ping, buf, sizeof(buf), wire_clock(now_ms))) {
+            (void)send_or_close(srv, client_idx, (uint8_t)CWNET_CMD_PING, buf, sizeof(buf),
+                                now_ms, out);
+        }
+        return;
+    }
+    if (ping.type != CWNET_PING_RESPONSE_1) {
+        return;   /* RESPONSE_2 belongs to the initiator, and that is us */
+    }
+
+    /* Only the answer to THIS connection's pending request counts: the
+     * peak-hold belongs to the connection, not to the id. */
+    if (!c->ping_pending || ping.id != c->ping_id || ping.t0_ms != c->ping_t0_ms) {
+        return;
+    }
+
+    int32_t t2 = wire_clock(now_ms);
+    if (!cwnet_ping_build_response2(&ping, buf, sizeof(buf), t2)) {
+        return;
+    }
+    if (!send_or_close(srv, client_idx, (uint8_t)CWNET_CMD_PING, buf, sizeof(buf),
+                       now_ms, out)) {
+        return;
+    }
+
+    c->ping_pending = false;
+    c->ping_misses = 0u;
+
+    int32_t latency = t2 - ping.t0_ms;
+    if (cwnet_ping_peak_hold_update(&c->latency_peak_ms, latency)) {
+        c->latency_ms = latency;
+        if ((uint32_t)c->latency_peak_ms <= srv->cfg.buffer_ceiling_ms) {
+            c->unfit_notified = false;   /* the link came back: say so again if it goes */
+        }
+        emit(out, CWNET_SERVER_EV_LATENCY, client_idx, latency, c->latency_peak_ms, now_ms);
+    }
+}
+
+/*===========================================================================*/
+/* Rig-control strings                                                       */
+/*===========================================================================*/
+
+static const char *skip_spaces(const char *p) {
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    return p;
+}
+
+/**
+ * @brief The code a rig-control string is answered with
+ *
+ * Nothing is applied (R10): "set_ptt" is acknowledged and dropped, because
+ * the PTT follows the keying that is played (KTD5). Everything else is a
+ * function this daemon does not have.
+ */
+static int rig_result_for(const char *cmd) {
+    /* The reference's parser does not need the "long command" backslash
+     * either (CwNet.c:2015) */
+    const char *p = skip_spaces(cmd);
+    if (*p == '\\') {
+        p++;
+    }
+    static const char set_ptt[] = "set_ptt";
+    size_t n = sizeof(set_ptt) - 1u;
+    if (strncmp(p, set_ptt, n) != 0) {
+        return CWNET_SERVER_RPRT_NO_FUNC;
+    }
+    p += n;
+    if (*p == '\0' || *p == '\n' || *p == '\r') {
+        return CWNET_SERVER_RPRT_BAD_ARG;   /* the command, with no argument */
+    }
+    if (*p != ' ' && *p != '\t') {
+        return CWNET_SERVER_RPRT_NO_FUNC;   /* "set_pttx", a different word */
+    }
+    p = skip_spaces(p);
+    if (*p != '0' && *p != '1') {
+        return CWNET_SERVER_RPRT_BAD_ARG;
+    }
+    p++;
+    if (*p != '\0' && *p != '\n' && *p != '\r' && *p != ' ') {
+        return CWNET_SERVER_RPRT_BAD_ARG;
+    }
+    return CWNET_SERVER_RPRT_OK;
+}
+
+static void handle_rig_string(cwnet_server_t *srv, int client_idx,
+                              const uint8_t *payload, size_t payload_len,
+                              int64_t now_ms, cwnet_server_result_t *out) {
+    /* The NUL has to be inside the payload; without it there is no string
+     * here, only bytes, and reading on would leave the buffer. */
+    if (payload_len == 0u || memchr(payload, 0, payload_len) == NULL) {
+        close_client(srv, client_idx, CWNET_SERVER_CLOSE_BAD_STRING, now_ms, out);
+        return;
+    }
+
+    char cmd[RIG_STRING_MAX];
+    size_t n = (payload_len < sizeof(cmd)) ? payload_len : sizeof(cmd) - 1u;
+    memcpy(cmd, payload, n);
+    cmd[n] = '\0';
+
+    char resp[24];
+    int len = snprintf(resp, sizeof(resp), "RPRT %d\n", rig_result_for(cmd));
+    if (len <= 0) {
+        return;
+    }
+    (void)send_or_close(srv, client_idx, (uint8_t)CWNET_CMD_RIG_STRING,
+                        (const uint8_t *)resp, (size_t)len + 1u, now_ms, out);
+}
+
+/*===========================================================================*/
+/* MORSE and the key                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief Try to give the free key to a client
+ *
+ * @return true when it took it. False means the link is not fit: it gets a
+ *         PRINT saying so and nothing of its is played (R7).
+ */
+static bool take_key(cwnet_server_t *srv, int client_idx, int64_t now_ms,
+                     cwnet_server_result_t *out) {
+    cwnet_server_client_t *c = slot(srv, client_idx);
+    if (c == NULL) {
+        return false;
+    }
+    int32_t peak = c->latency_peak_ms;
+
+    if (peak >= 0 && (uint32_t)peak > srv->cfg.buffer_ceiling_ms) {
+        emit(out, CWNET_SERVER_EV_LINK_UNFIT, client_idx, peak, peak, now_ms);
+        if (!c->unfit_notified) {
+            c->unfit_notified = true;
+            char msg[96];
+            (void)snprintf(msg, sizeof(msg),
+                           "Link not fit to transmit: %d ms, ceiling %u ms",
+                           (int)peak, (unsigned)srv->cfg.buffer_ceiling_ms);
+            send_print(srv, client_idx, msg, now_ms, out);
+        }
+        return false;
+    }
+
+    /* B: the peak-hold over the floor, fixed for the over. A client with no
+     * measurement yet plays at the floor rather than not at all. */
+    uint32_t buffer_ms = srv->cfg.buffer_floor_ms;
+    if (peak > 0 && (uint32_t)peak > buffer_ms) {
+        buffer_ms = (uint32_t)peak;
+    }
+
+    srv->key_holder = client_idx;
+    srv->buffer_ms = buffer_ms;
+    srv->over_started_at_ms = now_ms;
+    srv->holder_last_byte_ms = now_ms;
+    cwnet_play_start_over(&srv->play, buffer_ms);
+
+    emit(out, CWNET_SERVER_EV_OVER_BUFFER, client_idx, (int32_t)buffer_ms, 0, now_ms);
+    announce_key(srv, now_ms, out);
+    return true;
+}
+
+static void handle_morse(cwnet_server_t *srv, int client_idx,
+                         const uint8_t *payload, size_t payload_len,
+                         int64_t now_ms, cwnet_server_result_t *out) {
+    if (payload_len == 0u) {
+        return;
+    }
+    if (srv->key_holder == CWNET_SERVER_NOBODY) {
+        (void)take_key(srv, client_idx, now_ms, out);
+    }
+    if (srv->key_holder != client_idx) {
+        /* Somebody else is on the key, or this link is not fit: dropped
+         * without a word, as the reference does (CwNet.c:2895) */
+        srv->morse_ignored += (uint32_t)payload_len;
+        return;
+    }
+
+    srv->holder_last_byte_ms = now_ms;
+    for (size_t i = 0; i < payload_len; i++) {
+        /* A byte the engine cannot hold is dropped and counted there */
+        (void)cwnet_play_push(&srv->play, payload[i], now_ms);
+    }
+}
+
+/*===========================================================================*/
+/* Frame dispatch                                                            */
+/*===========================================================================*/
+
+static void dispatch(cwnet_server_t *srv, int client_idx,
+                     const cwnet_parse_result_t *frame,
+                     int64_t now_ms, cwnet_server_result_t *out) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    if (c == NULL) {
+        return;
+    }
+    const uint8_t *payload = frame->payload;
+    size_t payload_len = frame->payload_len;
+
+    if (frame->command == CWNET_CMD_CONNECT) {
+        handle_connect(srv, client_idx, payload, payload_len, now_ms, out);
+        return;
+    }
+    if (!c->confirmed) {
+        /* Nothing but the CONNECT counts before the log-in */
+        return;
+    }
+
+    switch (frame->command) {
+        case CWNET_CMD_PING:
+            handle_ping(srv, client_idx, payload, payload_len, now_ms, out);
+            break;
+        case CWNET_CMD_RIG_STRING:
+            handle_rig_string(srv, client_idx, payload, payload_len, now_ms, out);
+            break;
+        case CWNET_CMD_MORSE:
+            handle_morse(srv, client_idx, payload, payload_len, now_ms, out);
+            break;
+        default:
+            /* CI-V, spectrum, audio, anything else: ignored (R15) */
+            break;
+    }
+}
+
+/*===========================================================================*/
+/* API                                                                       */
+/*===========================================================================*/
+
+void cwnet_server_cfg_defaults(cwnet_server_cfg_t *cfg) {
+    if (cfg == NULL) {
+        return;
+    }
+    cfg->max_clients = (uint16_t)CWNET_SERVER_DEFAULT_MAX_CLIENTS;
+    cfg->ping_interval_ms = CWNET_SERVER_DEFAULT_PING_INTERVAL_MS;
+    cfg->handshake_timeout_ms = CWNET_SERVER_DEFAULT_HANDSHAKE_MS;
+    cfg->idle_timeout_ms = CWNET_SERVER_DEFAULT_IDLE_MS;
+    cfg->over_max_ms = CWNET_SERVER_DEFAULT_OVER_MAX_MS;
+    cfg->buffer_floor_ms = CWNET_SERVER_DEFAULT_BUFFER_FLOOR_MS;
+    cfg->buffer_ceiling_ms = CWNET_SERVER_DEFAULT_BUFFER_CEILING_MS;
+    cfg->play.ptt_lead_ms = 0u;
+    cfg->play.ptt_tail_ms = CWNET_PLAY_DEFAULT_PTT_TAIL_MS;
+    cfg->send_cb = NULL;
+    cfg->user_data = NULL;
+}
+
+bool cwnet_server_init(cwnet_server_t *srv, const cwnet_server_cfg_t *cfg) {
+    if (srv == NULL) {
+        return false;
+    }
+    memset(srv, 0, sizeof(*srv));
+    cwnet_server_cfg_defaults(&srv->cfg);
+    if (cfg != NULL) {
+        srv->cfg = *cfg;
+    }
+    if (srv->cfg.max_clients == 0u || srv->cfg.max_clients > CWNET_SERVER_MAX_CLIENTS) {
+        srv->cfg.max_clients = (uint16_t)CWNET_SERVER_MAX_CLIENTS;
+    }
+    if (srv->cfg.ping_interval_ms == 0u) {
+        srv->cfg.ping_interval_ms = CWNET_SERVER_DEFAULT_PING_INTERVAL_MS;
+    }
+    if (srv->cfg.handshake_timeout_ms == 0u) {
+        srv->cfg.handshake_timeout_ms = CWNET_SERVER_DEFAULT_HANDSHAKE_MS;
+    }
+    if (srv->cfg.idle_timeout_ms == 0u) {
+        srv->cfg.idle_timeout_ms = CWNET_SERVER_DEFAULT_IDLE_MS;
+    }
+    if (srv->cfg.over_max_ms == 0u) {
+        srv->cfg.over_max_ms = CWNET_SERVER_DEFAULT_OVER_MAX_MS;
+    }
+    cwnet_play_init(&srv->play, &srv->cfg.play);
+    srv->key_holder = CWNET_SERVER_NOBODY;
+    return true;
+}
+
+int cwnet_server_on_connected(cwnet_server_t *srv, int64_t now_ms,
+                               cwnet_server_result_t *out) {
+    result_clear(out);
+    if (srv == NULL) {
+        return CWNET_SERVER_NO_SLOT;
+    }
+    for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
+        cwnet_server_client_t *c = &srv->client[i];
+        if (c->in_use) {
+            continue;
+        }
+        int idx = CWNET_SERVER_FIRST_CLIENT + i;
+        memset(c, 0, sizeof(*c));
+        c->in_use = true;
+        c->accepted_at_ms = now_ms;
+        c->latency_ms = -1;
+        c->latency_peak_ms = -1;
+        c->ping_id = (uint8_t)idx;
+        cwnet_frame_parser_init(&c->parser);
+        return idx;
+    }
+    /* Past the limit: the caller closes it at once, and the accept never
+     * blocks on our account (R1) */
+    emit(out, CWNET_SERVER_EV_CLIENT_CLOSED, 0, (int32_t)CWNET_SERVER_CLOSE_NO_SLOT,
+         0, now_ms);
+    return CWNET_SERVER_NO_SLOT;
+}
+
+void cwnet_server_on_data(cwnet_server_t *srv, int client_idx,
+                           const uint8_t *data, size_t len,
+                           int64_t now_ms, cwnet_server_result_t *out) {
+    result_clear(out);
+    if (srv == NULL || data == NULL || len == 0u || slot(srv, client_idx) == NULL) {
+        return;
+    }
+
+    size_t offset = 0;
+    while (offset < len) {
+        cwnet_server_client_t *c = slot(srv, client_idx);
+        if (c == NULL) {
+            return;   /* a frame closed this client */
+        }
+        cwnet_parse_result_t frame = cwnet_frame_parse(&c->parser, data + offset,
+                                                        len - offset);
+        switch (frame.status) {
+            case CWNET_PARSE_OK:
+                offset += frame.bytes_consumed;
+                dispatch(srv, client_idx, &frame, now_ms, out);
+                c = slot(srv, client_idx);
+                if (c != NULL) {
+                    cwnet_frame_parser_reset(&c->parser);
+                }
+                break;
+
+            case CWNET_PARSE_SKIPPED:
+                /* Too long to buffer and fragmented: consumed, framing kept (R14) */
+                offset += frame.bytes_consumed;
+                cwnet_frame_parser_reset(&c->parser);
+                break;
+
+            case CWNET_PARSE_NEED_MORE:
+                offset = len;
+                break;
+
+            case CWNET_PARSE_ERROR:
+            default:
+                /* "un errore di parse chiude la connessione del client" (R15) */
+                close_client(srv, client_idx, CWNET_SERVER_CLOSE_PARSE_ERROR, now_ms, out);
+                return;
+        }
+    }
+
+    run_play(srv, now_ms, out);
+}
+
+void cwnet_server_on_disconnected(cwnet_server_t *srv, int client_idx,
+                                   int64_t now_ms, cwnet_server_result_t *out) {
+    result_clear(out);
+    if (srv == NULL) {
+        return;
+    }
+    close_client(srv, client_idx, CWNET_SERVER_CLOSE_PEER, now_ms, out);
+}
+
+void cwnet_server_poll(cwnet_server_t *srv, int64_t now_ms,
+                        cwnet_server_result_t *out) {
+    result_clear(out);
+    if (srv == NULL) {
+        return;
+    }
+
+    for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
+        int idx = CWNET_SERVER_FIRST_CLIENT + i;
+        cwnet_server_client_t *c = slot(srv, idx);
+        if (c == NULL) {
+            continue;
+        }
+
+        if (!c->confirmed) {
+            if (now_ms - c->accepted_at_ms >= (int64_t)srv->cfg.handshake_timeout_ms) {
+                close_client(srv, idx, CWNET_SERVER_CLOSE_HANDSHAKE, now_ms, out);
+            }
+            continue;
+        }
+
+        if (now_ms < c->next_ping_at_ms) {
+            continue;
+        }
+        if (c->ping_pending) {
+            c->ping_misses++;
+            if (c->ping_misses >= CWNET_SERVER_PING_MISSES) {
+                close_client(srv, idx, CWNET_SERVER_CLOSE_PING_TIMEOUT, now_ms, out);
+                continue;
+            }
+        }
+        int32_t t0 = wire_clock(now_ms);
+        uint8_t buf[CWNET_PING_PAYLOAD_SIZE];
+        if (!cwnet_ping_build_request((uint8_t)idx, t0, buf, sizeof(buf))) {
+            continue;
+        }
+        if (!send_or_close(srv, idx, (uint8_t)CWNET_CMD_PING, buf, sizeof(buf), now_ms, out)) {
+            continue;
+        }
+        c->ping_pending = true;
+        c->ping_id = (uint8_t)idx;
+        c->ping_t0_ms = t0;
+        c->next_ping_at_ms = now_ms + (int64_t)srv->cfg.ping_interval_ms;
+    }
+
+    /* Safety nets on the over in progress (R6) */
+    if (srv->key_holder != CWNET_SERVER_NOBODY) {
+        if (now_ms - srv->over_started_at_ms >= (int64_t)srv->cfg.over_max_ms) {
+            force_release(srv, CWNET_SERVER_FAULT_OVER_TOO_LONG, now_ms, out);
+        } else if (now_ms - srv->holder_last_byte_ms >= (int64_t)srv->cfg.idle_timeout_ms) {
+            force_release(srv, CWNET_SERVER_FAULT_IDLE, now_ms, out);
+        }
+    }
+
+    run_play(srv, now_ms, out);
+}
+
+static void deadline_min(int64_t candidate, bool *have, int64_t *best) {
+    if (!*have || candidate < *best) {
+        *have = true;
+        *best = candidate;
+    }
+}
+
+bool cwnet_server_next_deadline(const cwnet_server_t *srv, int64_t *out_ms) {
+    if (srv == NULL || out_ms == NULL) {
+        return false;
+    }
+    bool have = false;
+    int64_t best = 0;
+
+    int64_t play_at = 0;
+    if (cwnet_play_next_deadline(&srv->play, &play_at)) {
+        deadline_min(play_at, &have, &best);
+    }
+
+    for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
+        const cwnet_server_client_t *c = &srv->client[i];
+        if (!c->in_use) {
+            continue;
+        }
+        if (!c->confirmed) {
+            deadline_min(c->accepted_at_ms + (int64_t)srv->cfg.handshake_timeout_ms,
+                         &have, &best);
+        } else {
+            deadline_min(c->next_ping_at_ms, &have, &best);
+        }
+    }
+
+    if (srv->key_holder != CWNET_SERVER_NOBODY) {
+        deadline_min(srv->over_started_at_ms + (int64_t)srv->cfg.over_max_ms, &have, &best);
+        deadline_min(srv->holder_last_byte_ms + (int64_t)srv->cfg.idle_timeout_ms,
+                     &have, &best);
+    }
+
+    if (have) {
+        *out_ms = best;
+    }
+    return have;
+}
+
+/*===========================================================================*/
+/* Reading the state                                                         */
+/*===========================================================================*/
+
+int cwnet_server_key_holder(const cwnet_server_t *srv) {
+    return (srv == NULL) ? CWNET_SERVER_NOBODY : srv->key_holder;
+}
+
+const char *cwnet_server_client_name(const cwnet_server_t *srv, int client_idx) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    return (c == NULL) ? "" : c->name;
+}
+
+bool cwnet_server_client_ready(const cwnet_server_t *srv, int client_idx) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    return c != NULL && c->confirmed;
+}
+
+size_t cwnet_server_client_count(const cwnet_server_t *srv) {
+    if (srv == NULL) {
+        return 0u;
+    }
+    size_t n = 0;
+    for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
+        if (srv->client[i].in_use) {
+            n++;
+        }
+    }
+    return n;
+}
+
+int32_t cwnet_server_client_latency_ms(const cwnet_server_t *srv, int client_idx) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    return (c == NULL) ? -1 : c->latency_ms;
+}
+
+int32_t cwnet_server_client_peak_ms(const cwnet_server_t *srv, int client_idx) {
+    const cwnet_server_client_t *c = slot_const(srv, client_idx);
+    return (c == NULL) ? -1 : c->latency_peak_ms;
+}
+
+uint32_t cwnet_server_buffer_ms(const cwnet_server_t *srv) {
+    return (srv == NULL) ? 0u : srv->buffer_ms;
+}
+
+bool cwnet_server_key_down(const cwnet_server_t *srv) {
+    return (srv != NULL) && cwnet_play_key_down(&srv->play);
+}
+
+bool cwnet_server_ptt_on(const cwnet_server_t *srv) {
+    return (srv != NULL) && cwnet_play_ptt_on(&srv->play);
+}
+
+uint32_t cwnet_server_play_dropped(const cwnet_server_t *srv) {
+    return (srv == NULL) ? 0u : cwnet_play_dropped(&srv->play);
+}
+
+uint32_t cwnet_server_morse_ignored(const cwnet_server_t *srv) {
+    return (srv == NULL) ? 0u : srv->morse_ignored;
+}

--- a/components/keyer_cwnet/src/cwnet_server.c
+++ b/components/keyer_cwnet/src/cwnet_server.c
@@ -272,10 +272,15 @@ static void run_play(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result_t 
  */
 static void force_release(cwnet_server_t *srv, cwnet_server_fault_t why,
                           int64_t now_ms, cwnet_server_result_t *out) {
+    /* Taken before the engine runs: a release with no PTT raised finishes
+     * the over inside that call, which frees the key. The fault has to name
+     * the client that lost it, not the emptiness left behind. */
+    int holder = srv->key_holder;
+
     cwnet_play_result_t pr;
     cwnet_play_force_release(&srv->play, now_ms, &pr);
     map_play_events(srv, &pr, out);
-    emit(out, CWNET_SERVER_EV_FAULT, srv->key_holder, (int32_t)why, 0, now_ms);
+    emit(out, CWNET_SERVER_EV_FAULT, holder, (int32_t)why, 0, now_ms);
     release_key(srv, now_ms, out);
 }
 

--- a/components/keyer_cwnet/src/cwnet_server.c
+++ b/components/keyer_cwnet/src/cwnet_server.c
@@ -187,14 +187,17 @@ static size_t build_tx_info(const cwnet_server_t *srv, uint8_t *payload, size_t 
 /**
  * @brief Tell every confirmed client who has the key now
  *
- * A client whose send fails is closed here. That client cannot be the
- * holder — the holder was set or cleared before this call — so the close
- * cannot come back into this function for a second announcement.
+ * The payload is built inside the loop, once per client, because the loop
+ * can change what it has to say. A send that fails closes the client it was
+ * writing to, and take_key() sets the holder BEFORE announcing it, so that
+ * client may well be the holder: closing it releases the key and announces
+ * the release from in here. One payload built ahead of the loop would then
+ * go on being sent, after the fact, to every client the loop had not
+ * reached yet — and each of those would keep a holder the server no longer
+ * has, with nothing further coming to correct it. Each client is told the
+ * state as it stands when its own frame leaves.
  */
 static void announce_key(cwnet_server_t *srv, int64_t now_ms, cwnet_server_result_t *out) {
-    uint8_t payload[CWNET_SERVER_NAME_LEN + 1];
-    size_t len = build_tx_info(srv, payload, sizeof(payload));
-
     emit(out, CWNET_SERVER_EV_KEY_HOLDER, srv->key_holder, 0, 0, now_ms);
 
     for (int i = 0; i < (int)srv->cfg.max_clients; i++) {
@@ -203,6 +206,8 @@ static void announce_key(cwnet_server_t *srv, int64_t now_ms, cwnet_server_resul
         if (c == NULL || !c->confirmed) {
             continue;
         }
+        uint8_t payload[CWNET_SERVER_NAME_LEN + 1];
+        size_t len = build_tx_info(srv, payload, sizeof(payload));
         (void)send_or_close(srv, idx, (uint8_t)CWNET_CMD_TX_INFO, payload, len, now_ms, out);
     }
 }
@@ -437,6 +442,9 @@ static void handle_ping(cwnet_server_t *srv, int client_idx,
 
     c->ping_pending = false;
     c->ping_misses = 0u;
+    /* An answer came back. Whether the sample survives the gate below is a
+     * different question, and take_key() needs both answers apart. */
+    c->ping_answered = true;
 
     int32_t latency = t2 - ping.t0_ms;
     if (cwnet_ping_peak_hold_update(&c->latency_peak_ms, latency)) {
@@ -538,14 +546,32 @@ static bool take_key(cwnet_server_t *srv, int client_idx, int64_t now_ms,
     }
     int32_t peak = c->latency_peak_ms;
 
-    if (peak >= 0 && (uint32_t)peak > srv->cfg.buffer_ceiling_ms) {
-        emit(out, CWNET_SERVER_EV_LINK_UNFIT, client_idx, peak, peak, now_ms);
+    /* A peak of -1 has two meanings and only one of them is innocent. The
+     * peak-hold takes a sample only if it lands inside the gate's window
+     * (cwnet_ping.h); a link whose every answer is slower than that never
+     * records one, so it would present itself exactly like a client that
+     * has only just connected and play at the floor. That is the link the
+     * ceiling exists for. Answered but never measurable is not fit. */
+    bool never_measurable = (peak < 0) && c->ping_answered;
+
+    if (never_measurable || (peak >= 0 && (uint32_t)peak > srv->cfg.buffer_ceiling_ms)) {
+        /* Once per refusal, exactly as often as the PRINT. A refused client
+         * does not stop sending, and one event per rejected byte fills the
+         * result's array with the same line and costs the daemon the events
+         * it needs. The flag is re-armed when a sample brings the peak back
+         * under the ceiling, in handle_ping(). */
         if (!c->unfit_notified) {
             c->unfit_notified = true;
-            char msg[96];
-            (void)snprintf(msg, sizeof(msg),
-                           "Link not fit to transmit: %d ms, ceiling %u ms",
-                           (int)peak, (unsigned)srv->cfg.buffer_ceiling_ms);
+            emit(out, CWNET_SERVER_EV_LINK_UNFIT, client_idx, peak, peak, now_ms);
+            char measured[96];
+            const char *msg = "Link not fit to transmit: no PING answered inside "
+                              "the measurement window";
+            if (!never_measurable) {
+                (void)snprintf(measured, sizeof(measured),
+                               "Link not fit to transmit: %d ms, ceiling %u ms",
+                               (int)peak, (unsigned)srv->cfg.buffer_ceiling_ms);
+                msg = measured;
+            }
             send_print(srv, client_idx, msg, now_ms, out);
         }
         return false;

--- a/docs/plans/2026-09-08-2158-feat-station-daemon-plan.md
+++ b/docs/plans/2026-09-08-2158-feat-station-daemon-plan.md
@@ -1,0 +1,500 @@
+---
+title: Daemon di stazione CWNet - Plan
+type: feat
+date: 2026-09-08
+topic: station-daemon
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+deepened: 2026-09-08
+---
+
+# Daemon di stazione CWNet - Plan
+
+## Goal Capsule
+
+- **Objective.** L'OM che manipola da remoto arriva sul tasto del rig di stazione attraverso un server nostro: la sua manipolazione esce con i tempi che ha mandato, il PTT segue quella manipolazione, e ogni client connesso sa chi è sulla chiave.
+- **Means.** Un daemon in C su PC Linux o Mac, con il core del server puro e host-testabile sopra il codec di `keyer_cwnet` (KTD1, KTD2).
+- **Autorità.** [STRATEGY.md](../../STRATEGY.md), Positioning e track "CWNet, i due capi"; la Decision [#60](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/60); la Work [#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64). Sui byte del filo decide la cattura del client DL4YHF del 2026-09-05 (`test_host/cwnet_fixtures.h`); il sorgente del riferimento dice cosa guardare, non cosa è vero.
+- **Profilo di esecuzione.** Codice C11 su host, provato dalla suite `test_host` in CI nelle due varianti. Il passo di banco con la scatola (R18) lo esegue il maintainer, non la CI.
+- **Stop conditions.** Una issue `blocking` che copra questo lavoro: oggi nessuna ([#65](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/65) blocca la sola GUI, fuori da questo piano). Evidenza che una decisione di sessione non regge: fermarsi e riportarla, non aggirarla.
+- **Tail ownership.** La PR chiude [#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64) solo per la parte host della sua condizione; il passo di banco resta aperto sulla issue finché il maintainer non lo esegue e lo scrive.
+
+---
+
+## Product Contract
+
+### Summary
+
+Un programma C, `cwnetd`, che ascolta sulla porta CWNet e fa da server a chiunque si connetta: eco del CONNECT con permessi pieni, PING da iniziatore, annuncio di chi ha la chiave, riproduzione del MORSE ricevuto dopo un buffer dimensionato sulla latenza misurata, PTT derivato dalla manipolazione riprodotta, arbitrato della chiave fra più client. Il core del server vive in `components/keyer_cwnet/` come macchina a stati pura, pilotata da callback come il client, e la suite host lo fa parlare con la cattura del client DL4YHF pinnando i byte che manda. Intorno al core: un layer POSIX condivisibile con il client host, un'uscita virtuale per tasto e PTT, righe di stato su stdout.
+
+### Problem Frame
+
+Il lato stazione non ha un server nostro. Esiste solo `tools/cwnet/cwnet_echo.py`, un eco in Python per il loop del banco: non manipola niente e non porta policy. Il programma DL4YHF in modalità server porta policy sue, lette nel suo sorgente e registrate in [#60](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/60): PTT tenuto 500 ms, chiave ceduta a cronometro di 1 s che oscilla durante l'over, `set_ptt` applicato all'arrivo. Il maintainer ha deciso che i due capi sono nostri e le policy si decidono una volta sola.
+
+### Key Decisions
+
+- **Il server è un daemon su PC di stazione, in C, in questo repo.** *(session-settled: user-directed — scelto sopra il server sulla scatola, raccomandazione 2 di #60, e sopra il solo client: le policy di stazione non entrano nel path RT della scatola.)* Governa R1, R17.
+- **Il programma DL4YHF è riferimento del filo, non del prodotto.** *(session-settled: user-directed — scelto sopra il copiare le sue policy di stazione: sono opinabili e i due capi sono nostri.)* Governa R6, R7, R8, R9, R10.
+- **Tutti possono connettersi e manipolare; conta sapere chi trasmette.** *(session-settled: user-directed — scelto sopra la lista utenti con permessi del riferimento: «deve essere una cosa semplice come nel riferimento, l'importante è sapere CHI trasmette».)* Governa R2, R3, R5.
+- **Repo unico, per ora.** *(session-settled: user-approved — scelto sopra un repo del daemon: ciò che i due capi condividono è la conoscenza del filo, e sta qui.)* Governa R17.
+- **Oltre 1000 ms di peak-hold il link è non idoneo: lo scambio veloce dopo la TX viene prima della copertura di un link lento.** *(session-settled: user-directed — scelto sopra un tetto alto a 1500 ms e sopra nessun tetto: con due secondi di buffer il corrispondente sta già rispondendo quando il PTT scende, e la lentezza dello scambio dopo la TX è la critica principale che gli utenti fanno al programma originale.)* Governa R7, R12.
+- **Niente GUI in questo piano.** La GUI è la Decision [#65](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/65), `blocking` per la sola GUI. Lo stato esce su stdout così l'opzione della pagina resta aperta. Governa R12.
+- **Niente audio, CI-V né spettro dentro CWNet; niente scatola come server.** Boundaries di STRATEGY.md. Governa R15.
+
+### Actors
+
+- A1. **L'OM remoto**: il client della scatola oggi, il client host di [#68](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/68) domani. Manda CONNECT, MORSE, `set_ptt`; risponde ai PING; legge TX_INFO.
+- A2. **La stazione**: il PC con il daemon, il rig, l'operatore che legge stdout.
+- A3. **Il tester**: fa girare il loop del banco senza scatola e con la scatola, legge le righe di stato e l'uscita virtuale.
+
+### Key Flows
+
+- F1. **Connessione.** A1 apre il TCP e manda il CONNECT. Il daemon manda l'eco con i permessi, il PRINT di benvenuto e il TX_INFO corrente, poi parte il PING ogni 2 s. A1 è READY all'eco. Covered by R1, R2, R3, R4.
+- F2. **Un over.** Il primo byte MORSE di A1 prende la chiave se è libera; TX_INFO a tutti. I byte entrano nella FIFO del titolare con l'ora di ricezione. La riproduzione parte al primo byte, ritardata del buffer B, e riproduce le attese codificate. Il PTT sale al primo key-down riprodotto e scende alla coda dopo l'ultimo key-up riprodotto. Il marker di fine over riprodotto e il PTT sceso rilasciano la chiave; TX_INFO «nobody» a tutti. Covered by R6, R7, R9.
+- F3. **Due client.** Il MORSE di chi non ha la chiave è scartato in silenzio, nessun annuncio. Quando il titolare rilascia, il prossimo byte di chiunque prende la chiave. Covered by R6.
+- F4. **Caduta a metà over.** Il TCP del titolare si chiude, o non arriva più niente: la chiave si rilascia con tasto su forzato e PTT giù dopo la coda; TX_INFO «nobody». Covered by R6, R16.
+- F5. **Jitter.** La FIFO si svuota prima del prossimo fronte: tasto su subito, riga di fault, il PTT scende alla coda. I byte successivi ripartono come un over nuovo con lo stesso B. Covered by R8.
+
+### Requirements
+
+**Connessione e protocollo**
+
+- R1. Il daemon ascolta su una porta TCP, default 7355, e serve più client insieme (default 4); una connessione oltre il limite viene accettata e chiusa subito, senza bloccare l'accept.
+- R2. A un CONNECT valido risponde con l'eco dei 92 byte con il campo permessi a TALK, TRANSMIT e CTRL_RIG (0x07), poi un PRINT di benvenuto, poi il TX_INFO dello stato corrente. Un CONNECT di lunghezza diversa chiude la connessione.
+- R3. Ogni cambio del titolare della chiave è annunciato a tutti i client con un TX_INFO: byte indice del client (da 1) e nominativo con NUL; indice 0xFF e `-- nobody --` quando è libera; `NoCall #n` quando il nominativo nel CONNECT è vuoto. I byte coincidono con `ref_tx_info_moritz` e `ref_tx_info_nobody`.
+- R4. Il daemon è l'iniziatore del PING verso ogni client ogni 2 s: REQUEST con `t0` dal suo orologio a 31 bit e id uguale all'indice del client; alla RESPONSE_1 risponde con la RESPONSE_2 che porta `t2`. La latenza è `t2 - t0`; un valore fuori da 0..2000 ms è scartato, né latenza né peak-hold lo vedono; il peak-hold sale subito e scende di un decimo dello scarto, come il riferimento.
+- R5. Ogni stringa di controllo radio 0x06 riceve una risposta: `set_ptt 0|1` riceve `RPRT 0`; ogni altra stringa un codice negativo. Nessuna stringa viene applicata (R10).
+
+**Chiave, riproduzione, PTT**
+
+- R6. Il primo byte MORSE mentre la chiave è libera la prende; il MORSE degli altri client è scartato in silenzio. La chiave resta al titolare per tutto l'over e si rilascia quando il marker di fine over è stato riprodotto e il PTT è sceso. Reti di sicurezza, ciascuna con rilascio, tasto su forzato e PTT giù alla coda: chiusura del TCP del titolare; nessun byte per un tempo di inattività (default 5 s); un over più lungo di un tetto (default 120 s).
+- R7. La riproduzione parte al primo byte di un over, ritardata di B; B è il peak-hold del titolare sopra un pavimento (default 50 ms), fissato al momento in cui prende la chiave e invariato per l'over. Il tetto di idoneità è 1000 ms: un client il cui peak-hold lo supera quando manda il primo byte MORSE non prende la chiave e non viene riprodotto; riceve un PRINT che dice il link non idoneo e il valore misurato, e stdout scrive una riga. Ogni fronte esce dopo l'attesa codificata nel byte, senza accumulo di errore; un'attesa spezzata su più byte con lo stesso stato esce come attese consecutive.
+- R8. Se al momento di un fronte la FIFO è vuota, il tasto va su subito e viene scritta una riga di fault; il tasto non resta mai nello stato pendente. I byte successivi ripartono come un over nuovo con lo stesso B.
+- R9. Il PTT sale con il primo key-down riprodotto, anticipato di un lead configurabile (default 0 ms, mai oltre B), e scende una coda dopo l'ultimo key-up riprodotto (default 100 ms, il valore della scatola). Ogni rilascio della chiave lo abbassa al più tardi alla coda.
+- R10. Le stringhe `set_ptt` del client non muovono il PTT.
+
+**Uscite e stato**
+
+- R11. Tasto e PTT passano da un'interfaccia di uscita con un backend virtuale che scrive ogni fronte come riga con l'istante in ms. Il trasporto fisico è fuori da questo piano (Scope Boundaries).
+- R12. Lo stato esce su stdout a righe: connessione e disconnessione con nominativo e indirizzo, cambio del titolare, latenza e peak-hold per client, PTT, fault, B scelto a ogni over. Le stringhe che vengono dal client escono con i byte di controllo e le sequenze di escape rimossi; una stdout che non drena non ferma il loop.
+- R13. La configurazione è da riga di comando con default uguali al riferimento o alla scatola: indirizzo di ascolto (default tutte le interfacce IPv4, il confine di fiducia è la LAN o la VPN; IPv6 fuori scopo) e porta, client massimi, pavimento di B e tetto di idoneità del link, coda e lead del PTT, inattività e tetto dell'over, timeout di handshake, backend di uscita.
+
+**Robustezza**
+
+- R14. Il parser dei frame consuma per intero un frame frammentato la cui lunghezza dichiarata supera il buffer interno, resta in sincronia e lo restituisce con uno stato «saltato», payload nullo e lunghezza zero: mai un puntatore con lunghezza oltre il buffer, mai un errore che faccia perdere il framing. Vale anche sulla scatola.
+- R15. Comandi non gestiti (CI-V, spettro, audio) sono ignorati; un errore di parse chiude la connessione del client.
+- R16. Un client che non risponde a tre PING consecutivi viene chiuso; un client che non completa il CONNECT entro il timeout di handshake (default 5 s) viene chiuso.
+
+**Build, CI, banco**
+
+- R17. Il daemon compila con CMake su Linux e macOS con le stesse flag strette di `test_host`; la CI compila il daemon su Ubuntu e macOS e fa girare i test del core nelle due varianti della suite host.
+- R18. Il daemon completa un over con il client della scatola nel loop del banco, con `tools/cwnet/keyer_sim.c` come stimolo, seguendo una procedura scritta nel README di `tools/cwnet/`.
+
+### Acceptance Examples
+
+- AE1. Covers R2. **Given** un CONNECT con username `Moritz`, nominativo `Moritz`, permessi 0. **When** il core lo riceve. **Then** i primi byte inviati sono `ref_connect_echo`, poi un frame PRINT, poi `ref_tx_info_nobody`.
+- AE2. Covers R6, R7, R9, F2. **Given** un client READY, B = 50 ms, coda 100 ms, orologio simulato. **When** riceve i byte di `ref_first_over` (sessione 12, la lettera A a 25 WPM). **Then** l'uscita virtuale riceve key-down a t+50, key-up a +48, key-down a +48, key-up a +144; il PTT sale con il primo key-down e scende 100 ms dopo l'ultimo key-up; `RPRT 0` esce due volte; `ref_tx_info_moritz` esce al primo byte MORSE e `ref_tx_info_nobody` dopo il rilascio.
+- AE3. Covers R6, F3. **Given** due client READY, il primo con la chiave. **When** il secondo manda un byte MORSE. **Then** nessun fronte in uscita per quel byte e nessun TX_INFO.
+- AE4. Covers R4. **Given** un client READY all'istante t0. **When** passano 2 s. **Then** esce una REQUEST `[0, idx, 0, 0, t0, 0, 0]`; alla RESPONSE_1 `[1, idx, 0, 0, t0, t1, 0]` esce `[2, idx, 0, 0, t0, t1, t2]` e la latenza è `t2 - t0`.
+- AE5. Covers R6, F4. **Given** il titolare a metà over con il tasto giù riprodotto. **When** il suo TCP si chiude. **Then** il tasto va su, il PTT scende dopo la coda, `ref_tx_info_nobody` esce a tutti gli altri.
+- AE6. Covers R8, F5. **Given** una FIFO con un solo key-down. **When** scade l'attesa e nessun byte è arrivato. **Then** il tasto va su e una riga di fault viene emessa; il PTT scende alla coda.
+- AE8. Covers R7, R12. **Given** un client READY con peak-hold a 1200 ms e la chiave libera. **When** manda il primo byte MORSE. **Then** nessun fronte in uscita, la chiave resta libera e nessun TX_INFO esce; il client riceve un PRINT con «link non idoneo» e il valore; stdout ne scrive una riga.
+- AE7. Covers R14. **Given** un frame lungo con lunghezza dichiarata 300 consegnato in due frammenti, seguito da un PING. **When** il parser li riceve. **Then** il primo esce con stato «saltato», payload nullo e lunghezza zero; il PING esce intatto; sotto ASan nessuna lettura fuori dal buffer.
+
+### Success Criteria
+
+- La suite host pinna i byte del daemon dove il client li guarda: eco del CONNECT, TX_INFO, PING, `RPRT`.
+- Il loop senza scatola chiude: un client di prova in Python manda `ref_first_over` al daemon e l'uscita virtuale mostra i fronti attesi.
+- Lo scarto fra gli istanti dei fronti sull'uscita virtuale e le attese codificate è misurato sul Mac e su Linux e scritto nel README, senza rivendicare una metrica.
+- Il tempo di scambio dopo la TX, dall'ultimo key-up del client al PTT giù in stazione (B più la coda), è scritto nel README accanto al jitter: è la grandezza che gli utenti del programma originale criticano.
+
+### Scope Boundaries
+
+- Nessuna GUI: Decision [#65](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/65).
+- Nessun operatore locale del server (indice 0, «The Sysop» del riferimento).
+- Nessun rilancio del MORSE agli altri client: il riferimento non lo fa (H6 smentita il 2026-09-05).
+- Nessun server HTTP, nessun audio, CI-V o spettro.
+- Nessun target Windows per il daemon; il client host di [#68](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/68) ne condivide solo il layer di piattaforma.
+- Nessuna lista utenti né permessi differenziati.
+
+#### Deferred to Follow-Up Work
+
+- **Uscita fisica verso il rig** (linee di controllo di una seriale USB o altro): Decision da aprire, `blocking` per il solo backend fisico. La ricerca (Sources) dice che il timer di latenza FTDI e la schedulazione USB dominano il jitter. Due criteri entrano nella Decision, qualunque sia il trasporto: lo stato di riposo del trasporto è tasto su e PTT giù anche se il daemon muore (SIGKILL, crash), e un tetto al key-down continuo vive fuori dal processo del daemon.
+- **File di configurazione dichiarativo** accanto alle flag, quando i parametri crescono.
+- **Unit systemd e launchd**: il daemon gira in foreground e non forka; le unit arrivano con il deploy di stazione.
+- **Il bug del parser dei frame** (R14) è un difetto già sulla scatola: issue Work a parte, chiusa dalla U1.
+- `tools/cwnet/cwnet_echo.py` annuncia lo username in TX_INFO, il riferimento annuncia il nominativo: correzione leggera in U7.
+
+### Dependencies / Assumptions
+
+- Il codec di `keyer_cwnet` compila per host senza modifiche: già vero in `test_host/CMakeLists.txt`.
+- La cattura del 2026-09-05 resta il riferimento dei byte; le fixture in `test_host/cwnet_fixtures.h` bastano per AE1-AE5. Il CONNECT lato client si ricostruisce dai campi, non da una fixture.
+- Il default della porta del client della scatola in `parameters.yaml` è 7355 dal 2026-09-08, come il riferimento.
+- Il client della scatola diventa READY all'eco del CONNECT e manipola solo con TRANSMIT nell'eco (`cwnet_client.c`, `handle_connect_echo` e `cwnet_client_send_key_event`).
+
+### Sources / Research
+
+- Riferimento DL4YHF, letto nel sorgente pubblicato (`Remote_CW_Keyer_Sources.zip`, sha256 `d960d6b9…`): CONNECT lato server `CwNet.c:1275-1332`; PING `CwNet.c:1339-1526` e cadenza `CwNet.c:2236-2262`; TX_INFO `CwNet.c:432-452`, `760-775`, `2389-2394`; MORSE e presa della chiave `CwNet.c:2875-2903`; cessione a 1 s `CwNet.c:346-390`, `3545-3552`; `set_ptt` come PTT manuale `CwNet.c:4085-4110`, `KeyerThread.c:2238-2262`; riproduzione con ritardo di latenza `KeyerThread.c:2836-2981`, che parte al primo byte e non alla soglia di riempimento descritta nel commento; coda PTT `KeyerThread.c:2318-2340`; gate 0..2 s sull'RTT `CwNet.c:1436-1437`.
+- Nostro client: `components/keyer_cwnet/include/cwnet_client.h` (commento di testa sul filo), `src/cwnet_client.c` (`handle_ping`, `handle_tx_info`, `handle_morse`, `rx_*`), `src/cwnet_frame.c` (parser, difetto di R14), `cwnet_client_on_data` (su errore di parse salta un byte e riprova: un errore sui frame lunghi farebbe risincronizzare dentro il payload), `src/cwnet_socket.c` (il layer di piattaforma della scatola, da rifare in POSIX).
+- Seme e strumenti: `tools/cwnet/cwnet_echo.py`, `tools/cwnet/keyer_sim.c`, `tools/cwnet/README.md`.
+- Metodo: [reference-source-as-differential-oracle](../solutions/architecture-patterns/reference-source-as-differential-oracle.md), [differential-oracle-count-is-not-a-gradient](../solutions/architecture-patterns/differential-oracle-count-is-not-a-gradient.md).
+- Esterni, per KTD7 e KTD9: `clock_gettime(CLOCK_MONOTONIC)` su macOS 10.12+; `poll()` con timeout alla prossima scadenza e `TCP_NODELAY` (Rigtorp, "Tips for Using the Sockets API"); `SIGPIPE` ignorato a livello di processo; niente `daemon()` sotto launchd e systemd; FTDI AN232B-04 sul timer di latenza; `TIOCMBIS`/`TIOCMBIC` per le linee di controllo; il seam winsock (`SOCKET`, `closesocket`, `ioctlsocket`, `WSAPoll` difettoso prima di Windows 10 2004).
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Core del server come macchina a stati pura in `keyer_cwnet`.** `cwnet_server.[ch]` non tocca socket né orologio: riceve byte per client con `on_data`, tempo con una callback, e manda con una callback per client; gli eventi (titolare, latenza, fault) escono in una struttura di risultato, non in log. *(session-settled: user-approved — scelto sopra un daemon monolitico: è l'unico modo di far parlare il core con la cattura nella suite host, e replica il disegno di `cwnet_client_t`.)* Governa R1-R6, R15, R16.
+- KTD2. **Il codec si estende, non si copia.** Costruttori di frame in `cwnet_frame.[ch]`; REQUEST, RESPONSE_2, gate dell'RTT e peak-hold in `cwnet_ping.[ch]`, usati anche dal client. Il gate è un cambiamento di comportamento sulla scatola, oggi filtra solo i negativi: si pinna con un test del client. `cwnet_server.c` e `cwnet_play.c` restano fuori dalle SRCS del componente ESP-IDF: sono host-only e non devono portare `esp_timer` né `RT_*`. Ogni tocco a `keyer_cwnet/` porta un test host che pinna il riferimento (Definition of done). Governa R3, R4, R14.
+- KTD3. **Riproduzione come nel codice del riferimento, non nel suo commento.** Parte al primo byte ritardato di B; B fissato all'over. Sull'underrun il tasto va su: «corrupted CW timing is worse than silence» (ARCHITECTURE.md 8.1). Motore in un modulo suo, `cwnet_play.[ch]`, con orologio iniettato. Governa R7, R8.
+- KTD4. **Chiave tenuta per l'over, con reti di sicurezza.** Rilascio a fine over riprodotto e PTT giù; inattività, tetto e chiusura TCP forzano il rilascio. Il cronometro di 1 s del riferimento, che oscilla l'annuncio, non viene copiato. Governa R6.
+- KTD5. **PTT dalla manipolazione riprodotta.** Coda uguale a quella della scatola, lead opzionale possibile perché il fronte è noto B ms prima; `set_ptt` solo riscontrato. *(session-settled: user-approved — scelto sopra l'applicazione all'arrivo del riferimento: disallineata dalla riproduzione, e un client che muore lascia la stazione in TX.)* Governa R9, R10.
+- KTD6. **Permessi fissi 0x07 nell'eco.** Nessuna lista utenti; nominativo vuoto annunciato come `NoCall #n`. Istanzia la Key Decision «tutti possono». Governa R2, R3, R5.
+- KTD7. **Un thread, scadenze assolute.** `poll()` sui socket con timeout alla prossima scadenza di riproduzione; `CLOCK_MONOTONIC`; `TCP_NODELAY`; `SIGPIPE` ignorato; foreground, nessun fork; stdout non bloccante con scarto delle righe quando il lettore non drena; scadenze in ms a 64 bit, i 31 bit restano sul filo. Ricerca esterna load-bearing (Sources). Governa R1, R7, R12.
+- KTD8. **Directory `host/` per i programmi host, layer di piattaforma condiviso.** `host/platform/` (socket, orologio) scritto per essere riusato dal client host di [#68](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/68), con il seam winsock nei nomi delle funzioni; `host/cwnetd/` il daemon; `host/CMakeLists.txt` il build. *(session-settled: user-approved — scelto sopra `tools/cwnet/`: il banco è strumento, il daemon è prodotto.)* Governa R1, R17.
+- KTD9. **Uscita tasto e PTT dietro un'interfaccia.** Una struttura di funzioni con backend virtuale su stdout; il backend fisico arriva con la sua Decision. Governa R11.
+- KTD10. **Il core non logga.** Nessun `RT_*` né `log_stream` nel core del server e nel motore di riproduzione: gli eventi tornano al chiamante, il daemon li stampa. Il daemon non linka `cwnet_client.c`. Governa R12.
+- KTD11. **Il parser si indurisce sul posto, senza perdere il framing.** `cwnet_frame.c` consuma il frame frammentato oltre il buffer e lo restituisce «saltato»; l'errore resta riservato alla categoria 11. Un errore farebbe perdere il framing al client della scatola, che risincronizza saltando un byte e leggerebbe il payload come frame. Niente fork del codec per il daemon. Governa R14, R15.
+- KTD12. **Configurazione da flag.** Default del riferimento e della scatola; il file arriva quando serve. Governa R13.
+- KTD13. **CI: un job per `host/`.** Build su `ubuntu-latest` e `macos-latest` più un test di loopback; i test del core restano nella suite host esistente. Governa R17.
+
+### High-Level Technical Design
+
+Componenti e chi possiede cosa:
+
+```mermaid
+flowchart TB
+  subgraph keyer_cwnet[components/keyer_cwnet - codec condiviso con la scatola]
+    F[cwnet_frame: parser + costruttori]
+    P[cwnet_ping: parse, REQUEST, RESPONSE_1/2, peak-hold]
+    T[cwnet_timestamp: codec 7 bit]
+    S[cwnet_server: client, CONNECT, TX_INFO, chiave, RIG_STRING]
+    Y[cwnet_play: FIFO, buffer B, fronti, PTT]
+  end
+  subgraph host[host/ - solo PC]
+    PL[platform: sock, clock]
+    D[cwnetd: main, poll, flag, stdout]
+    O[key_output: virtuale oggi, fisico domani]
+  end
+  D --> PL
+  D --> S
+  D --> Y
+  Y --> O
+  S --> F
+  S --> P
+  Y --> T
+  S -. eventi .-> D
+```
+
+Un over, dal primo byte al rilascio:
+
+```mermaid
+sequenceDiagram
+  participant C as Client (scatola)
+  participant S as cwnet_server
+  participant Y as cwnet_play
+  participant O as key_output
+  C->>S: MORSE 0x80 (key down, attesa 0)
+  S->>C: TX_INFO idx+nominativo (a tutti)
+  S->>Y: byte + ora di ricezione, B fissato
+  C->>S: RIG_STRING set_ptt 1
+  S->>C: RPRT 0
+  Note over Y: attende B
+  Y->>O: PTT on, key down
+  C->>S: MORSE 0x24, 0xA4, 0x3C
+  Y->>O: key up +48, key down +48, key up +144
+  C->>S: RIG_STRING set_ptt 0
+  S->>C: RPRT 0
+  C->>S: MORSE 0x60 (fine over)
+  Y->>O: PTT off dopo la coda
+  Y->>S: over finito
+  S->>C: TX_INFO 0xFF nobody (a tutti)
+```
+
+Stati della chiave nel server:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Libera
+  Libera --> Tenuta: primo byte MORSE di un client
+  Tenuta --> InChiusura: fine over riprodotto
+  InChiusura --> Libera: PTT giù
+  Tenuta --> Libera: TCP chiuso / inattività / tetto over (tasto su forzato, PTT giù alla coda)
+```
+
+Pseudo-schema del motore di riproduzione, direzionale:
+
+```text
+al primo byte di un over: deadline = ricezione + B; stato_pendente = bit7
+a ogni deadline raggiunta:
+  applica stato_pendente all'uscita; aggiorna PTT
+  se FIFO vuota: se stato applicato è key-down -> tasto su, fault (R8); fine
+  prossimo byte -> deadline += attesa_decodificata; stato_pendente = bit7
+fine over = due key-up consecutivi riprodotti
+```
+
+### Output Structure
+
+```text
+host/
+  CMakeLists.txt            # build del daemon e del test di loopback, flag di test_host
+  CLAUDE.md                 # brief del modulo (rigenerabile con map-tree)
+  platform/
+    sock.h  sock.c          # listen/accept/nonblocking/send/recv/close, poll; seam winsock nei nomi
+    clock.h clock.c         # ms monotoni a 31 bit e us
+  cwnetd/
+    main.c                  # flag, loop poll, wiring core+play+output, stdout
+    key_output.h key_output.c   # interfaccia + backend virtuale
+    README.md               # uso, loop senza scatola, misura del jitter
+  tests/
+    loopback_test.c         # connessione locale end-to-end con byte di fixture
+components/keyer_cwnet/
+  include/cwnet_frame.h   src/cwnet_frame.c       # costruttori, parser che salta (U1)
+  include/cwnet_ping.h    src/cwnet_ping.c        # REQUEST, RESPONSE_2, gate, peak-hold (U2)
+  include/cwnet_server.h  src/cwnet_server.c
+  include/cwnet_play.h    src/cwnet_play.c
+test_host/
+  test_cwnet_frame_parser.c  test_cwnet_ping.c   # estesi
+  test_cwnet_server.c  test_cwnet_play.c
+tools/cwnet/
+  cwnet_send.py             # client di prova: CONNECT, PING, byte MORSE da fixture
+```
+
+### Assumptions
+
+- Il pavimento di B a 50 ms segue il riferimento. Il tetto di idoneità a 1000 ms è una Key Decision del maintainer, non un anti-avvelenamento: per quello bastano il gate 0..2000 ms sull'RTT e il peak-hold. Entrambi sono flag.
+- Tre PING senza risposta (6 s) chiudono il client: il riferimento non ha timeout; senza, un TCP semiaperto tiene la chiave finché non scatta l'inattività.
+- I codici negativi per le stringhe 0x06 diverse da `set_ptt` si scelgono all'implementazione dalla tabella dei codici del riferimento (`HamlibResultCodes.h` non è nell'archivio; i valori usati in `CwNet.c` lo sono).
+
+### Sequencing
+
+Fase A (codec, tutta nella suite host): U1, U2 in parallelo; U3 e U4 dopo, in parallelo fra loro. Fase B (programma host): U5 in parallelo alla fase A; U6 dopo U3, U4, U5; U7 e U8 dopo U6.
+
+### System-Wide Impact
+
+- `components/keyer_cwnet/src/cwnet_frame.c` e `cwnet_ping.c` girano anche sulla scatola, su Core 1, dentro `cwnet_client.c` via `cwnet_socket.c` e `main/bg_task.c`. I costruttori non cambiano un byte sul filo; il parser cambia comportamento solo sui frame frammentati oltre il buffer (R14) e il gate dell'RTT è nuovo per il client (KTD2). Entrambi si pinnano nei test del client esistenti più due scenari nuovi (U1, U2).
+- Il peak-hold del client alimenta solo diagnostica: `cwnet_socket_get_latency_peak_ms` letto da `keyer_webui/src/api_system.c` e da `bg_task.c`. L'estrazione in `cwnet_ping.c` conserva la forma intera del calcolo.
+- `components/keyer_cwnet/CMakeLists.txt` elenca le SRCS in chiaro: i due file nuovi non vi entrano (KTD2). `test_host/CMakeLists.txt` e `test_main.c` si aggiornano a mano (U3, U4). `host/CMakeLists.txt` compila i sorgenti condivisi senza `test_host/stubs/`.
+- Nessun ciclo: `cwnet_server` usa `cwnet_frame` e `cwnet_ping`; `cwnet_play` usa `cwnet_timestamp`; il server chiama il motore, gli eventi tornano per valore. `test_host` linka client e server nello stesso binario: i simboli nuovi in `cwnet_ping.c` non devono collidere con quelli del client.
+- CI: il job esistente di `host-tests.yml` copre U1-U4; `firmware-build.yml` compila `keyer_cwnet` con le flag del componente e intercetta un file non gradito a ESP-IDF; il job nuovo `host-build` non ha bisogno del submodule né della deploy key (U8).
+- Documentazione: module map di `CLAUDE.md`, `host/CLAUDE.md`, `components/keyer_cwnet/CLAUDE.md` per i due moduli nuovi e lo stato «saltato» del parser, `tools/cwnet/README.md` per `cwnet_send.py`.
+
+### Risks & Dependencies
+
+| Rischio | Dove morde | Nel piano |
+|---|---|---|
+| Il parser indurito desincronizza il client della scatola | `cwnet_client_on_data` salta un byte su errore e leggerebbe il payload come frame | R14 e KTD11: si salta il frame, l'errore resta alla categoria riservata; AE7 lo pinna con un PING dopo il frame saltato |
+| Jitter del loop `poll()` contro dot da 20-48 ms | `host/cwnetd/main.c` | Misurato e scritto (Success Criteria, U7); nessuna soglia rivendicata; il backend fisico avrà il suo jitter USB in più |
+| stdout che non drena blocca il loop di temporizzazione | KTD9, U6 | stdout non bloccante con scarto (KTD7, R12) |
+| Wrap a 31 bit dei ms (24,8 giorni) nelle scadenze | U4, U5 | Scadenze a 64 bit; i 31 bit restano sul filo del PING (KTD7) |
+| RTT ostile o wrap avvelena B | U2, R7 | Gate 0..2000 ms; un peak-hold oltre 1000 ms non gonfia B, rende il link non idoneo finché non scende |
+| RESPONSE_1 con id altrui sposta il peak-hold di un altro client | R4, U3 | Peak-hold legato alla connessione su cui arriva la risposta; id e `t0` diversi dalla richiesta pendente ignorati (U3) |
+| Peer non fidato: flood, handshake lasciato a metà, lettore lento, stringhe senza NUL, escape su stdout | U3, U5, U6 | Accetta e chiude oltre il limite (R1); timeout di handshake (R16); tetto ai byte non inviati per client con chiusura (U6); nessuna funzione di stringa sui byte grezzi, NUL richiesto nel payload (U3); sanificazione prima di stdout (R12) |
+| `cwnet_send.py` è nostro: prova il daemon contro la nostra idea del filo | U6, U7 | I byte del daemon si pinnano sulle fixture della cattura (AE1-AE5); il loop senza scatola è uno smoke test, il passo con la scatola (R18) è la prova |
+| Il passo di banco vuole il ferro e sta fuori dalla CI | R18 | Tail ownership: #64 resta aperta finché non è eseguito |
+| Il daemon muore con il tasto giù | backend fisico, fuori piano | Criteri scritti nella Decision sull'uscita fisica (Deferred) |
+
+---
+
+## Implementation Units
+
+### U1. Costruttori di frame e parser indurito
+
+- **Goal.** `cwnet_frame` costruisce i frame che il server manda e rifiuta i frame frammentati oltre il buffer.
+- **Requirements.** R3, R14 (KTD2, KTD11).
+- **Dependencies.** Nessuna.
+- **Files.** `components/keyer_cwnet/include/cwnet_frame.h`, `components/keyer_cwnet/src/cwnet_frame.c`, `test_host/test_cwnet_frame_parser.c`; `components/keyer_cwnet/src/cwnet_client.c` per usare i costruttori al posto della composizione inline.
+- **Approach.**
+  1. Un costruttore che scrive comando, categoria dalla lunghezza (0, corta, lunga) e payload in un buffer del chiamante, con la lunghezza scritta.
+  2. Nel parser, quando un frame frammentato dichiara più del buffer interno, i byte si consumano fino alla lunghezza dichiarata e il frame esce con uno stato «saltato», payload nullo; l'errore resta alla categoria riservata; il ramo «tutto nel buffer di ingresso» resta senza copia.
+  3. Il client sostituisce `make_cmd_byte` e le composizioni inline con il costruttore, senza cambiare un byte sul filo.
+- **Patterns to follow.** `cwnet_client.c`, `send_connect` e `send_rig_string`, per il payload con NUL; le fixture in `test_host/cwnet_fixtures.h` per i byte attesi.
+- **Test scenarios.**
+  - Il costruttore con payload vuoto produce il solo byte comando; con 92 byte produce `0x41 0x5C` e il payload; con 300 byte produce categoria lunga e lunghezza little-endian.
+  - Il costruttore con buffer troppo piccolo rifiuta senza scrivere.
+  - Covers AE7. Frame lungo con lunghezza 300 in due frammenti, poi un PING: il primo esce «saltato» con payload nullo e lunghezza zero e `bytes_consumed` coerente, il PING esce intatto, nessuna lettura fuori dal buffer sotto ASan.
+  - Frame di 256 byte esatti frammentato: ancora valido con il payload copiato.
+  - Frame lungo di 65535 byte consegnato in una sola lettura: valido, puntatore nel buffer di ingresso, nessuna copia.
+  - Categoria riservata: ancora errore; il client esistente risincronizza come oggi.
+  - I test esistenti del client passano invariati dopo la sostituzione dei costruttori (`test_client_tx_first_over_with_ptt_matches_reference_capture_whole`).
+- **Verification.** Suite host verde nelle due varianti; il test AE7 fallisce prima della modifica al parser e passa dopo.
+
+### U2. PING da iniziatore e peak-hold condiviso
+
+- **Goal.** `cwnet_ping` costruisce REQUEST e RESPONSE_2, filtra l'RTT e aggiorna il peak-hold per client e server.
+- **Requirements.** R4 (KTD2).
+- **Dependencies.** Nessuna.
+- **Files.** `components/keyer_cwnet/include/cwnet_ping.h`, `components/keyer_cwnet/src/cwnet_ping.c`, `test_host/test_cwnet_ping.c`, `components/keyer_cwnet/src/cwnet_client.c` (`handle_ping` usa la funzione condivisa).
+- **Approach.**
+  1. Costruttore della REQUEST: tipo 0, id, `t0`, slot 1 e 2 a zero.
+  2. Costruttore della RESPONSE_2 dalla RESPONSE_1: tipo 2, id e `t0`, `t1` copiati, `t2` dal chiamante.
+  3. Funzione di peak-hold su un valore per riferimento, con il gate 0..2000 ms davanti che scarta anche la latenza istantanea; il client la chiama al posto delle sue quattro righe: è un cambiamento sulla scatola, dichiarato nella PR.
+- **Patterns to follow.** Layout del payload in `cwnet_ping.h`; la REQUEST di `tools/cwnet/cwnet_echo.py`; `CwNet.c:2249-2258` e `:1436-1447` per i byte e il gate.
+- **Test scenarios.**
+  - Covers AE4. REQUEST con id 1 e t0 noto: 16 byte attesi; RESPONSE_2 costruita da una RESPONSE_1: `t0` e `t1` intatti, `t2` scritto.
+  - Peak-hold: 100 poi 200 sale a 200; poi 100 scende a 190; poi 185 resta 190 (scarto sotto 10 ms).
+  - Gate: RTT 2001 e RTT negativo (wrap a 31 bit fra `t0` e `t2`) non toccano né la latenza né il peak-hold, nel client come nel server.
+  - I test del client sulla latenza passano invariati (`test_client_latency_peak_holds_and_decays_like_the_reference`).
+- **Verification.** Suite host verde nelle due varianti.
+
+### U3. Core del server
+
+- **Goal.** `cwnet_server` porta un client dal CONNECT a READY, annuncia il titolare, arbitra la chiave, risponde ai PING e alle stringhe di controllo radio, consegna il MORSE del titolare al motore di riproduzione.
+- **Requirements.** R1 (tabella client), R2, R3, R4, R5, R6 (presa e reti di sicurezza), R15, R16 (KTD1, KTD4, KTD6, KTD10).
+- **Dependencies.** U1, U2, U4.
+- **Files.** `components/keyer_cwnet/include/cwnet_server.h`, `components/keyer_cwnet/src/cwnet_server.c`, `test_host/test_cwnet_server.c`, `test_host/CMakeLists.txt`, `test_host/test_main.c`; `components/keyer_cwnet/CMakeLists.txt` resta senza il file nuovo, con un commento che dice perché (KTD2).
+- **Approach.**
+  1. Tabella statica di client con indice da 1, stato (accettato, confermato), nominativo, parser di frame, cronometro del PING, peak-hold.
+  2. Callback iniettate: manda a un client, ora in ms; una struttura di risultato per pass con gli eventi (titolare cambiato, latenza, client chiuso, fault).
+  3. `on_connected`, `on_data`, `on_disconnected` per client e un `poll(now)` che fa i PING, i timeout e il rilascio.
+  4. La chiave: presa al primo byte MORSE se libera e se il peak-hold del client non supera il tetto di idoneità (R7); i byte del titolare vanno al motore di riproduzione (U4) con l'ora; gli altri si scartano; il rilascio arriva dal motore (over finito e PTT giù) o dalle reti di sicurezza.
+  5. TX_INFO a tutti i client confermati a ogni cambio, con i byte di R3.
+  6. Byte del peer mai trattati come stringhe C: i campi del CONNECT si copiano per 44 byte e si terminano, la stringa 0x06 deve avere il NUL dentro `payload_len` o il client si chiude; il PING passa da `cwnet_ping_parse`, che rifiuta le lunghezze sbagliate.
+  7. La RESPONSE_1 vale solo se id e `t0` coincidono con la richiesta pendente di quella connessione; il peak-hold è della connessione, non dell'id.
+  8. Oltre il limite di client: accetta e chiude; senza CONNECT entro il timeout di handshake: chiude.
+- **Patterns to follow.** `cwnet_client.h` per la forma dell'API e del contesto; `test_cwnet_client.c:22-94` per le callback finte; `CwNet.c:1275-1332` e `:2875-2903` per il comportamento del riferimento sui byte.
+- **Execution note.** Prima il test che alimenta il CONNECT e confronta l'eco con `ref_connect_echo`; poi il resto.
+- **Test scenarios.**
+  - Covers AE1. CONNECT di `Moritz`: eco uguale a `ref_connect_echo`, poi PRINT, poi `ref_tx_info_nobody`.
+  - CONNECT di 91 byte: connessione chiusa, nessun byte inviato.
+  - Nominativo vuoto: TX_INFO con `NoCall #1`.
+  - Covers AE3. Due client, il secondo manda MORSE: nessun byte al motore, nessun TX_INFO.
+  - Covers AE8. Peak-hold del client a 1200 ms al primo byte MORSE: chiave non presa, PRINT «link non idoneo» al client, nessun fronte; a 900 ms la chiave si prende e B vale 900.
+  - Covers AE4. A t+2000 esce la REQUEST; RESPONSE_1 → RESPONSE_2 e latenza aggiornata; tre REQUEST senza risposta chiudono il client.
+  - `set_ptt 1` → `RPRT 0`; stringa sconosciuta → codice negativo; nessun evento PTT.
+  - Frame CI-V e spettro ignorati; byte con categoria riservata → client chiuso.
+  - Il titolare si disconnette: rilascio, TX_INFO nobody agli altri.
+  - Nessun byte per 5 s con over aperto: rilascio forzato con evento di fault.
+  - CONNECT ricevuto in frammenti di un byte.
+  - CONNECT con i due campi di 44 byte senza NUL: nessuna lettura fuori dal payload sotto ASan, TX_INFO con nome troncato e terminato.
+  - Stringa 0x06 di 64 byte senza NUL: client chiuso, nessuna lettura fuori dal buffer.
+  - RESPONSE_1 con id di un altro client o `t0` diverso: ignorata, peak-hold invariato.
+  - Quinto client con limite 4: accettato e chiuso, gli altri quattro intatti.
+  - Un byte di CONNECT poi silenzio per il timeout di handshake: client chiuso.
+  - Frame MORSE di 65535 byte dal titolare: i primi 128 entrano nel motore, il resto è contato come scartato.
+- **Verification.** Suite host verde nelle due varianti; ogni byte atteso viene da una fixture o dal layout del riferimento citato.
+
+### U4. Motore di riproduzione e PTT
+
+- **Goal.** `cwnet_play` trasforma i byte MORSE del titolare in fronti di tasto e PTT agli istanti giusti, con buffer B, e segnala fine over, underrun e rilascio.
+- **Requirements.** R7, R8, R9, R10 (KTD3, KTD5, KTD10).
+- **Dependencies.** Nessuna sul codice (usa `cwnet_timestamp`); U3 lo consuma.
+- **Files.** `components/keyer_cwnet/include/cwnet_play.h`, `components/keyer_cwnet/src/cwnet_play.c`, `test_host/test_cwnet_play.c`, `test_host/CMakeLists.txt`, `test_host/test_main.c`; `components/keyer_cwnet/CMakeLists.txt` resta senza il file nuovo (KTD2).
+- **Approach.**
+  1. FIFO di 128 byte con ora di ricezione, come la `rx` del client; overflow scartato e contato.
+  2. `start_over(B)` fissa il buffer; `push(byte, now)`; `next_deadline()` restituisce l'istante del prossimo fronte; `tick(now)` applica i fronti dovuti e restituisce gli eventi: fronte tasto, PTT su/giù, fine over, underrun, over finito.
+  3. Schema del High-Level Technical Design: la scadenza avanza delle attese codificate, mai del tempo misurato; istanti e scadenze in ms a 64 bit, senza wrap.
+  4. PTT: su al primo key-down meno il lead; giù dopo la coda dall'ultimo key-up; `force_release()` per le reti di sicurezza di U3 con tasto su e PTT giù alla coda.
+- **Patterns to follow.** `cwnet_client.c`, `rx_pop` e `rx_has_end_of_over`; `KeyerThread.c:2887-2960` per il ritardo iniziale e l'avanzamento; `components/keyer_audio/src/ptt.c` per la coda.
+- **Execution note.** Test-first con orologio simulato: ogni scenario è una lista di byte in ingresso con i loro istanti e una lista di fronti attesi.
+- **Test scenarios.**
+  - Covers AE2. `ref_first_over` (solo i frame MORSE via `ref_morse_frames`) con B = 50: fronti a +50, +98, +146, +290; PTT su a +50 e giù a +390; fine over al byte `0x60`.
+  - Attesa spezzata (`0xFF 0xEA` dal caso C di `keyer_sim.c`): un solo fronte dopo la somma delle attese.
+  - Covers AE6. Un key-down poi FIFO vuota alla scadenza: tasto su, evento underrun, PTT giù alla coda.
+  - Byte in arrivo dopo l'underrun: nuovo over con lo stesso B.
+  - Lead 20 ms con B = 50: PTT su a +30, tasto a +50; lead oltre B viene limitato a B.
+  - FIFO piena: byte scartato e contato, nessun fronte spurio.
+  - `force_release` con tasto giù: tasto su subito, PTT giù dopo la coda, over chiuso.
+  - Frame a due eventi `ref_two_event_frames` a 20 ms di dot: fronti a +22 e +40 dal primo.
+- **Verification.** Suite host verde nelle due varianti; gli istanti attesi sono derivati a mano dalle attese codificate, non dal codice.
+
+### U5. Layer di piattaforma POSIX
+
+- **Goal.** `host/platform` offre socket TCP non bloccanti e orologio monotono a chi gira su PC, con nomi già pronti per winsock.
+- **Requirements.** R1, R17 (KTD7, KTD8).
+- **Dependencies.** Nessuna.
+- **Files.** `host/CMakeLists.txt`, `host/platform/sock.h`, `host/platform/sock.c`, `host/platform/clock.h`, `host/platform/clock.c`, `host/tests/loopback_test.c`.
+- **Approach.**
+  1. Handle opaco, `sock_init`/`sock_cleanup` vuoti su POSIX, `sock_listen`, `sock_accept` non bloccante (`accept` più `fcntl`, niente `accept4`), `sock_send` con gestione dell'invio parziale, `sock_recv`, `sock_close`, `sock_poll` sopra `poll()`, `sock_last_error`.
+  2. `TCP_NODELAY` e `SO_REUSEADDR` su ogni socket; `SIGPIPE` ignorato dal daemon.
+  3. `clock_now_ms` a 64 bit da `CLOCK_MONOTONIC`, con una funzione che ne ricava i 31 bit del filo; nessun `esp_timer` né stub di `test_host` nel build di `host/`.
+  4. CMake con le flag di `test_host/CMakeLists.txt` e un target di test con `ctest`.
+- **Patterns to follow.** `components/keyer_cwnet/src/cwnet_socket.c` per connect non bloccante e invio parziale; Sources per il seam winsock.
+- **Test scenarios.**
+  - Loopback: listen su porta effimera, connect, invio di `ref_connect_echo`, ricezione identica dall'altro capo.
+  - Invio parziale simulato con buffer di invio piccolo: il chiamante riceve il conteggio e riprende.
+  - Chiusura remota: `recv` segnala fine e il poll si sblocca.
+  - Orologio: due letture a 10 ms di distanza differiscono di 9..12 ms.
+- **Verification.** `ctest` verde su macOS e Linux; nessun warning con le flag strette.
+
+### U6. Il daemon `cwnetd`
+
+- **Goal.** Un eseguibile che collega server, riproduzione, uscita e piattaforma in un loop a scadenze, con flag e righe di stato.
+- **Requirements.** R1, R11, R12, R13, R16 (KTD7, KTD9, KTD10, KTD12).
+- **Dependencies.** U3, U4, U5.
+- **Files.** `host/cwnetd/main.c`, `host/cwnetd/key_output.h`, `host/cwnetd/key_output.c`, `host/CMakeLists.txt`, `tools/cwnet/cwnet_send.py`.
+- **Approach.**
+  1. Flag di R13 con i default; `--help` li stampa.
+  2. Loop: `sock_poll` con timeout alla prossima fra scadenza di riproduzione, PING e timeout; accept, `on_data`, `on_disconnected`; `server.poll(now)` e `play.tick(now)`; eventi su stdout come righe `chiave <k> <ms>` e `stato ...`.
+  3. Interfaccia di uscita con `set_key(bool, now)` e `set_ptt(bool, now)`; backend virtuale che stampa `key 1 123456` e `ptt 0 123556`.
+  4. SIGINT e SIGTERM chiudono i client e rilasciano l'uscita; stdout non bloccante, una riga che non entra si scarta e si conta.
+  6. Tetto ai byte non inviati per client: superato, il client si chiude senza fermare il loop. Le stringhe del client passano da una sanificazione che toglie byte di controllo ed escape prima di stdout.
+  5. `cwnet_send.py`: client di prova con stdlib che manda CONNECT, risponde ai PING e invia i byte di una fixture o di un file, stampando TX_INFO e RPRT ricevuti.
+- **Patterns to follow.** `tools/cwnet/cwnet_echo.py` per il client di prova e le flag; `cwnet_socket.c` per la macchina a stati del socket.
+- **Test scenarios.**
+  - Loop senza scatola: `cwnet_send.py` con `ref_first_over` contro il daemon con `--play-floor 50`: l'uscita virtuale mostra i quattro fronti e i due cambi di PTT; il client stampa `RPRT 0` due volte e i due TX_INFO.
+  - Due `cwnet_send.py` insieme: il secondo non produce fronti.
+  - Chiusura del client a metà over: riga di fault, tasto su, TX_INFO nobody.
+  - SIGINT con un client connesso: uscita pulita, nessun fronte lasciato giù.
+  - Nominativo con `ESC[2J` e byte di controllo: la riga su stdout li mostra escapati.
+  - Client che smette di leggere: gli altri ricevono PING e TX_INFO senza ritardo; il lettore lento viene chiuso al tetto.
+- **Verification.** Il loop senza scatola passa a mano su Mac e Linux; le righe di stato bastano a ricostruire un over senza altro strumento.
+
+### U7. Banco, misura e correzioni leggere
+
+- **Goal.** La procedura del loop con la scatola è scritta, il jitter dell'uscita virtuale è misurato, l'echo annuncia il nominativo.
+- **Requirements.** R18, Success Criteria (KTD3).
+- **Dependencies.** U6.
+- **Files.** `host/cwnetd/README.md`, `tools/cwnet/README.md`, `tools/cwnet/cwnet_echo.py`, `tools/cwnet/cwnet_send.py`.
+- **Approach.**
+  1. README: avvio del daemon, scatola che punta al PC, `keyer_sim.c` per gli attesi, confronto fra fronti dell'uscita virtuale e attese codificate.
+  2. Misura: `cwnet_send.py` manda una sequenza di 100 elementi; uno script confronta gli istanti dell'uscita con le attese e scrive media e massimo dello scarto nel README, su Mac e Linux.
+  3. `cwnet_echo.py` annuncia il nominativo del CONNECT, `NoCall #n` se vuoto.
+- **Test scenarios.**
+  - `cwnet_echo.py` con un CONNECT di `Moritz`: TX_INFO uguale a `ref_tx_info_moritz` dopo il primo byte MORSE.
+  - Il confronto dello scarto gira e produce due numeri.
+- **Verification.** README con procedura e numeri; il maintainer esegue il passo con la scatola e lo scrive su [#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64).
+
+### U8. CI e mappa dei moduli
+
+- **Goal.** La CI compila il daemon su Ubuntu e macOS e fa girare il test di loopback; la mappa dei moduli conosce `host/`.
+- **Requirements.** R17 (KTD13).
+- **Dependencies.** U5, U6.
+- **Files.** `.github/workflows/host-tests.yml`, `host/CLAUDE.md`, `CLAUDE.md` (module map), `test_host/CLAUDE.md` se il blocco treecode cambia.
+- **Approach.**
+  1. Nuovo job `host-build` con matrice `ubuntu-latest`, `macos-latest`: configure, build, `ctest` in `host/`; nessuna dipendenza dal submodule.
+  2. I test del core restano nel job esistente perché vivono in `test_host/`.
+  3. `host/CLAUDE.md` con `map-tree`; una riga nel module map di `CLAUDE.md`.
+- **Test scenarios.** Test expectation: none -- configurazione di CI e documentazione; la prova è il job verde.
+- **Verification.** Entrambi i job verdi sulla PR.
+
+---
+
+## Verification Contract
+
+| Cosa | Comando o gate | Unità | Segnale |
+|---|---|---|---|
+| Suite host, plain | `cd test_host && cmake -B build && cmake --build build && ./build/test_runner` | U1-U4 | tutti i test verdi, nessun test saltato |
+| Suite host, sanitizer | `cmake -B build -DCMAKE_C_FLAGS="-fsanitize=address,undefined"` poi build e run | U1-U4 | verde, AE7 senza report ASan |
+| Daemon e loopback | `cmake -S host -B host/build && cmake --build host/build && ctest --test-dir host/build` | U5, U6 | verde su macOS e Linux |
+| Loop senza scatola | `host/build/cwnetd` più `python3 tools/cwnet/cwnet_send.py` con `ref_first_over` | U6, U7 | fronti e PTT di AE2 sull'uscita virtuale |
+| CI host | `.github/workflows/host-tests.yml`, job esistente e `host-build` | tutte | verde su ogni push |
+| CI firmware | `.github/workflows/firmware-build.yml` | U1, U2 | `keyer_cwnet` compila con le flag del componente |
+| Banco con la scatola | procedura di `host/cwnetd/README.md` | U7 | un over completo, scritto su #64 |
+
+---
+
+## Definition of Done
+
+- Host tests verdi in entrambe le varianti; nessun test saltato, disabilitato o in quarantena.
+- Reference test: `test_cwnet_server.c` pinna `ref_connect_echo`, `ref_tx_info_moritz`, `ref_tx_info_nobody` e il layout del PING; `test_cwnet_play.c` pinna i fronti di `ref_first_over`; `test_cwnet_frame_parser.c` pinna i costruttori sulle intestazioni delle fixture.
+- RT path: nessuna modifica su Core 0. `cwnet_frame.c` e `cwnet_ping.c` cambiano e girano sulla scatola su Core 1; i test del client esistenti restano verdi.
+- Blocking issues aperte su questo lavoro: nessuna. La Decision sull'uscita fisica blocca solo il backend fisico, fuori da questo piano.
+- Per unità: la Verification della unità è vera; i test elencati esistono con i nomi che dicono cosa pinnano.
+- [#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64): la parte host della condizione è vera nell'albero; la parte di banco resta aperta sulla issue finché il maintainer non la esegue.
+- La issue Work sul parser (R14) è chiusa con `file:line` da U1.
+- Pulizia: nessun codice di tentativi abbandonati nel diff; `cwnet_echo.py` annuncia il nominativo.

--- a/host/CLAUDE.md
+++ b/host/CLAUDE.md
@@ -1,0 +1,66 @@
+<!-- BEGIN treecode (auto) — do not edit inside this block -->
+# host — POSIX platform layer and the station daemon (`cwnetd`)
+
+Responsibility: Everything the CWNet server side needs that is not the pure protocol
+core. Owns a small POSIX platform layer (non-blocking TCP sockets, a monotonic clock)
+and `cwnetd`, the daemon that drives `components/keyer_cwnet`'s host-only server core
+(`cwnet_server.c`, `cwnet_play.c`, KTD1/KTD2) against a real socket and a real clock. It
+must NOT duplicate protocol knowledge — the wire format, the state machine and the
+playback timing live in `keyer_cwnet` and are only linked in here, by path, in
+`host/CMakeLists.txt`.
+
+Key abstractions:
+- `platform/sock.h` / `sock.c` — non-blocking TCP sockets (`listen`/`accept`/`connect`/
+  `send`/`recv`/`poll`), POSIX today, written with a winsock seam in its names
+  (`sock_valid`, `sock_would_block`, ...) so a Windows port can implement the same
+  functions later without touching a caller.
+- `platform/clock.h` / `clock.c` — monotonic milliseconds as 64 bits
+  (`CLOCK_MONOTONIC`), plus the 31-bit wire width the ping timestamps carry.
+  Independent of `esp_timer` and of the `test_host` stubs.
+- `cwnetd/main.c` — the daemon: flag parsing, one thread with a `sock_poll()` loop that
+  waits for the *next* deadline the core names (not a fixed tick), wiring the server
+  core to the platform layer and to `key_output`, status lines on non-blocking stdout.
+- `cwnetd/key_output.h` / `key_output.c` — the seam behind which key and PTT edges
+  leave the daemon (R11): a struct of function pointers with one backend today,
+  `virtual`, which prints `key <0|1> <at_ms>` / `ptt <0|1> <at_ms>` lines.
+- `tests/loopback_test.c` — exercises `platform/` and nothing else: a real loopback
+  connection, a short write resumed, a remote close seen through the poll, the clock's
+  monotonicity and unit. The server core is proven in `test_host/`, against the
+  capture; the daemon end to end is proven by hand (`cwnetd/README.md`).
+
+Depends on: `components/keyer_cwnet`'s host-safe sources (`cwnet_frame.c`,
+`cwnet_ping.c`, `cwnet_timestamp.c`, `cwnet_play.c`, `cwnet_server.c`), listed by hand in
+`host/CMakeLists.txt` because they are deliberately absent from the ESP-IDF component's
+`SRCS` (KTD2: host-only). Nothing here is part of the firmware build.
+
+Used by: the maintainer's own station PC, run by hand or (later) under systemd/launchd
+— no unit files yet, that is Deferred work. `tools/cwnet/` (a separate module) exercises
+`cwnetd` as a client over the loop, without a box.
+
+What is NOT here, and why:
+- **No GUI.** How the operator sees daemon state is Decision #65, labelled `blocking`
+  for the GUI only. State goes to stdout as lines so that option stays open; do not add
+  a TUI, a served page, or a native window here until #65 is decided.
+- **No physical key/PTT backend.** `key_output` has one backend, `virtual`, on stdout.
+  A serial-line or GPIO backend behind the same two function pointers needs its own
+  Decision (KTD9) — not filed yet — because the rest-state and key-down-ceiling
+  guarantees on a real transmitter have to be decided before code claims them.
+- **No Windows build of the daemon.** `platform/sock.c`'s winsock seam is written to
+  make one possible, but nothing here builds it; the host Windows client is separate
+  work (issue #68).
+
+Conventions: Same strict flags as `test_host/CMakeLists.txt` (`-Wall -Wextra -Werror
+-Wconversion -Wsign-conversion -Wdouble-promotion -Wformat=2 -Wnull-dereference`), one
+bar for Linux and macOS both. `cwnetd/main.c` owns stdout and protocol knowledge stays
+out of it (KTD10: the core does not log) — it carries bytes in, edges out, and prints
+what the core reports.
+
+Gotchas:
+- `cwnet_client.c` is intentionally NOT linked into `cwnetd`: the daemon is the other
+  end of the wire (KTD10), not another client.
+- CI's `host-build` job (`.github/workflows/host-tests.yml`) builds and runs only this
+  tree; it needs neither the `keyer_iambic` submodule nor its deploy key, which is why
+  it is a job of its own rather than more steps on the existing `host-tests` job.
+- Build and test locally: `cmake -S host -B host/build && cmake --build host/build &&
+  ctest --test-dir host/build --output-on-failure`.
+<!-- END treecode (auto) -->

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -15,6 +15,10 @@ add_compile_options(
     -Wdouble-promotion
     -Wformat=2
     -Wnull-dereference
+    # keyer_cwnet's module brief promises these two for the whole component,
+    # and two of its files are compiled only here.
+    -Wshadow
+    -Wstrict-prototypes
     -g
 )
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+project(cwnetd_host C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Same strict flags as test_host/CMakeLists.txt (R17: one bar, Linux and
+# macOS both build the daemon with it).
+add_compile_options(
+    -Wall
+    -Wextra
+    -Werror
+    -Wconversion
+    -Wsign-conversion
+    -Wdouble-promotion
+    -Wformat=2
+    -Wnull-dereference
+    -g
+)
+
+# host/platform: non-blocking TCP sockets and a monotonic clock for anything
+# that runs on the station PC. No esp_timer, no test_host stub — independent
+# of the firmware build.
+add_library(host_platform STATIC
+    platform/sock.c
+    platform/clock.c
+)
+target_include_directories(host_platform PUBLIC platform)
+
+enable_testing()
+
+add_executable(loopback_test tests/loopback_test.c)
+target_link_libraries(loopback_test PRIVATE host_platform)
+
+add_test(NAME loopback_test COMMAND loopback_test)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -33,3 +33,24 @@ add_executable(loopback_test tests/loopback_test.c)
 target_link_libraries(loopback_test PRIVATE host_platform)
 
 add_test(NAME loopback_test COMMAND loopback_test)
+
+# cwnetd: the station daemon (U6). The core it drives — cwnet_server.c and
+# cwnet_play.c — is host-only by KTD2 and deliberately absent from the
+# ESP-IDF component's SRCS, so it is listed here by hand. cwnet_client.c is
+# NOT linked: the daemon is the other end of the wire (KTD10).
+set(CWNET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../components/keyer_cwnet)
+
+add_library(cwnet_core STATIC
+    ${CWNET_DIR}/src/cwnet_frame.c
+    ${CWNET_DIR}/src/cwnet_ping.c
+    ${CWNET_DIR}/src/cwnet_timestamp.c
+    ${CWNET_DIR}/src/cwnet_play.c
+    ${CWNET_DIR}/src/cwnet_server.c
+)
+target_include_directories(cwnet_core PUBLIC ${CWNET_DIR}/include)
+
+add_executable(cwnetd
+    cwnetd/main.c
+    cwnetd/key_output.c
+)
+target_link_libraries(cwnetd PRIVATE host_platform cwnet_core)

--- a/host/cwnetd/README.md
+++ b/host/cwnetd/README.md
@@ -1,0 +1,260 @@
+# cwnetd — daemon di stazione CWNet
+
+Server CWNet per PC (Linux o Mac): la manipolazione dell'OM remoto entra dal
+client (la scatola, o `tools/cwnet/cwnet_send.py` per un client di prova),
+esce con i tempi che il client ha mandato, il PTT segue la manipolazione
+riprodotta. Il core (`components/keyer_cwnet/src/cwnet_server.c`,
+`cwnet_play.c`) è lo stesso codec host-testato dalla suite `test_host`; qui
+intorno c'è solo il layer POSIX (`host/platform/`), l'uscita virtuale
+(`key_output.c`) e le righe di stato su stdout.
+
+Per l'architettura, vedi [components/keyer_cwnet/CLAUDE.md](../../components/keyer_cwnet/CLAUDE.md)
+e il piano [docs/plans/2026-09-08-2158-feat-station-daemon-plan.md](../../docs/plans/2026-09-08-2158-feat-station-daemon-plan.md).
+
+## Build
+
+```sh
+cmake -S host -B host/build
+cmake --build host/build
+# eseguibile: host/build/cwnetd
+# test (solo loopback dei socket, non il server): ctest --test-dir host/build
+```
+
+Stesse flag rigide di `test_host` (`-Wall -Wextra -Werror -Wconversion
+-Wsign-conversion ...`, vedi `host/CMakeLists.txt`): un bar solo, Linux e
+macOS.
+
+## Avvio
+
+```sh
+host/build/cwnetd --listen 0.0.0.0 --port 7355
+```
+
+`--listen 0.0.0.0` ascolta su tutte le interfacce: il confine di fiducia è
+la LAN o la VPN (WireGuard, `components/keyer_vpn`), non il processo — CWNet
+non ha autenticazione. La porta di default, 7355, è la stessa del
+riferimento e della scatola (`parameters.yaml`, `remote.server_port`).
+
+Ctrl-C (SIGINT) o SIGTERM chiudono i client e riportano l'uscita a riposo
+(tasto su, PTT spento) prima di uscire.
+
+## Flag
+
+```
+--listen ADDR       indirizzo IPv4 di ascolto (default 0.0.0.0)
+--port N            porta TCP (default 7355)
+--max-clients N     client serviti insieme, max 8 (default 4)
+--play-floor MS     pavimento del buffer B (default 50)
+--link-ceiling MS   peak-hold oltre cui il link non e' idoneo (default 1000)
+--ptt-tail MS       coda del PTT dopo l'ultimo key-up (default 100)
+--ptt-lead MS       anticipo del PTT sul primo key-down, mai oltre B (default 0)
+--idle MS           silenzio del titolare che rilascia la chiave (default 5000)
+--over-max MS       tetto di un over (default 120000)
+--handshake MS      tempo per completare il CONNECT (default 5000)
+--output BACKEND    uscita di tasto e PTT: virtual (default virtual)
+```
+
+(`host/build/cwnetd --help` è la fonte, questa tabella è solo per
+consultazione rapida — se divergono, fidati di `--help`.)
+
+I default sono quelli del riferimento e della scatola (R13): `--ptt-tail
+100` è "il valore della scatola" (R9), `--play-floor 50` il B minimo scelto
+per assorbire il jitter della LAN/VPN senza un ritardo percepibile.
+
+`--output` ha oggi un solo backend, `virtual`: il trasporto fisico (seriale
+o GPIO verso il rig) è dietro una Decision non ancora aperta (KTD9); quando
+lo sarà, un backend nuovo riempie gli stessi due puntatori a funzione di
+`key_output.h` e niente sopra cambia.
+
+## Come si legge una riga di stato
+
+Tutto esce su stdout, una riga per evento, mai bloccante: se stdout non
+tiene il passo la riga si scarta e la prossima che passa lo confessa
+(`stato stdout N righe scartate`) — "niente" e "non stavi leggendo" restano
+distinguibili.
+
+Vocabolario (client, connessioni):
+
+| Riga | Significato |
+|---|---|
+| `stato ascolto ADDR:PORTA max-clients N B>=X ms tetto Y ms coda Z ms lead W ms uscita BACKEND` | il daemon e' pronto; l'ultima parola prima di questa riga in stdout |
+| `stato accettato client N da IP:PORTA` | TCP accettata, in attesa del CONNECT |
+| `stato rifiutato da IP:PORTA: nessuno slot libero` | oltre `--max-clients`, chiusa subito (R1: l'accept non blocca mai) |
+| `stato connesso client N NOME da IP:PORTA` | CONNECT completato, il client e' READY |
+| `stato disconnesso client N NOME da IP:PORTA: MOTIVO` | TCP chiusa (dal peer, per timeout, per un lettore troppo lento, ...) |
+
+Vocabolario (chiave, link, over):
+
+| Riga | Significato |
+|---|---|
+| `stato chiave client N NOME` / `stato chiave libera` | chi tiene la chiave adesso (arbitrato, un titolare alla volta) |
+| `stato latenza client N X ms peak Y ms` | RTT dell'ultimo PING e il suo peak-hold |
+| `stato link non idoneo client N NOME: peak Y ms` | il peak-hold ha superato `--link-ceiling`: quel client non prende la chiave |
+| `stato over client N NOME B X ms` | un over e' iniziato, con il B calcolato per quella sessione |
+| `stato fault [client N NOME:] MOTIVO` | FAULT philosophy: timing corrotto, tasto su e si ferma (underrun, over troppo lungo, titolare muto oltre `--idle`, ...) |
+| `stato eventi persi N` | il core ha prodotto piu' eventi di quanti il buffer di lettura ne tenesse: nessun fronte si perde, solo la riga descrittiva |
+
+Uscita di tasto e PTT (`key_output.h`, backend `virtual`):
+
+```
+key 1 431839006        <- tasto giu', programmato per l'istante 431839006 (ms monotoni del processo)
+key 0 431839102        <- tasto su
+ptt 1 431838958         <- PTT acceso
+ptt 0 431839786         <- PTT spento
+```
+
+L'istante e' quello *programmato* (B piu' la somma delle attese decodificate
+dal filo), non quello in cui la riga e' stata scritta: cosi' un over si
+ricostruisce dalle righe da solo, ed e' il numero che la misura del jitter
+guarda dal di fuori (vedi sotto). Un fronte che non cambia stato non e' un
+fronte: non genera una riga (`key_output.h`).
+
+## Loop senza scatola
+
+Prova rapida, senza hardware: un client Python al posto della scatola.
+
+```sh
+host/build/cwnetd --listen 127.0.0.1 --port 17355 &
+python3 tools/cwnet/cwnet_send.py --host 127.0.0.1 --port 17355 --fixture first_over --verbose
+```
+
+Atteso sull'uscita virtuale (AE2, `ref_first_over`, B=50 ms di default):
+quattro fronti di tasto (giu' a +50, su a +98, giu' a +146, su a +290 dallo
+start dell'over) e due di PTT (acceso col primo key-down, spento 100 ms
+dopo l'ultimo key-up). Dettagli e altri scenari:
+[tools/cwnet/README.md](../../tools/cwnet/README.md).
+
+## Banco con la scatola (R18)
+
+Questo e' il passo che la CI non fa: lo esegue il maintainer, con la
+scatola vera (il keyer ESP32, con un tasto o un paddle collegato) come
+client. `tools/cwnet/keyer_sim.c` da' lo stimolo di riferimento —
+i byte che il *client ufficiale* manderebbe per una manipolazione nota —
+cosi' c'e' qualcosa di codificato contro cui confrontare i fronti veri.
+
+### 1. Compila e avvia il daemon sul PC
+
+```sh
+cmake -S host -B host/build && cmake --build host/build
+host/build/cwnetd --listen 0.0.0.0 --port 7355
+```
+
+Annota l'indirizzo IP del PC sulla stessa rete/VPN della scatola (LAN o
+WireGuard — non esporre `cwnetd` su Internet, CWNet non si autentica).
+
+### 2. Punta la scatola al daemon
+
+Dalla console seriale della scatola (USB-CDC, `components/keyer_usb`) o
+dalla sua web UI, sezione **Remote**:
+
+```
+set remote.server_host <IP del PC>
+set remote.server_port 7355
+set remote.username <un nome qualsiasi>
+set remote.cwnet_enabled true
+```
+
+`system.callsign` e' il nominativo che finisce nel CONNECT (il campo che
+`cwnet_echo.py` adesso annuncia — vedi `tools/cwnet/README.md`); se non
+l'hai gia' impostato:
+
+```
+set system.callsign <il tuo nominativo>
+```
+
+Questi parametri sono `runtime_change: reboot` (`parameters.yaml`): riavvia
+la scatola perche' si connetta con i nuovi valori.
+
+### 3. Conferma la connessione
+
+Sullo stdout di `cwnetd` deve comparire:
+
+```
+stato accettato client 1 da <IP scatola>:<porta>
+stato connesso client 1 <il tuo nominativo> da <IP scatola>:<porta>
+```
+
+Se non compare: verifica che la scatola e il PC si vedano sulla rete
+(ping), che la porta sia la stessa da entrambi i lati, e che
+`remote.cwnet_enabled` sia effettivamente `true` dopo il riavvio (`show
+remote.*` in console).
+
+### 4. Manipola e leggi i fronti
+
+Imposta la scatola a 25 WPM (`set keyer.wpm 25`, dot = 48 ms) e manda la
+lettera "A" (di-dah) con il paddle, poi lascia il tasto fermo.
+
+Sullo stdout di `cwnetd` deve comparire, nell'ordine, la stessa forma di
+AE2/`ref_first_over` (gia' pinnata da `test_cwnet_play.c`):
+
+```
+ptt 1 <t0>          <- PTT su col primo key-down
+key 1 <t0>          <- tasto giu' (il "di")
+key 0 <t0+48>        <- tasto su, ~48 ms dopo (un dot a 25 WPM)
+key 1 <t0+96>        <- tasto giu' (il "dah")
+key 0 <t0+240>        <- tasto su, ~144 ms dopo (un dash a 25 WPM)
+ptt 0 <t0+340>        <- PTT giu', 100 ms (--ptt-tail) dopo l'ultimo key-up
+```
+
+`keyer_sim.c` genera lo stesso stimolo in forma di byte (scenario A del suo
+`main()`: `run("A primo over, dot 48", ...)`, che stampa `80 24 A4 3C 60`);
+`decode7()` di quei byte da' le stesse attese, 48/48/144 ms. La mano non
+riproduce 48.000 ms esatti come `keyer_sim.c` — il confronto e' sulla
+*forma* (quattro fronti, gli intervalli vicini a 48/48/144 ms, PTT su col
+primo giu' e giu' 100 ms dopo l'ultimo su), non su uno scarto in
+millisecimi: quello lo fa la misura del jitter qui sotto, senza mano di
+mezzo.
+
+Per un confronto byte-esatto (non solo la forma), cattura il traffico
+grezzo mentre manipoli con `tools/cwnet/cwnet_tap.py` (o un pcap con
+`tools/cwnet/pcap_to_stream.py`) e decodificalo con `tools/cwnet/cwnet_dump.c`:
+i byte MORSE catturati devono decodificare alle stesse attese che
+`keyer_sim.c` scrive per lo scenario che hai riprodotto.
+
+### 5. Scrivi il risultato
+
+Il passo di banco chiude solo quando è scritto su
+[#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64): un
+commento con cosa è stato manipolato, le righe di stdout osservate (o uno
+snippet), e se la forma attesa regge.
+
+## Misura del jitter e del tempo di scambio
+
+`tools/cwnet/cwnet_jitter.py` fa il loop senza scatola con una sequenza
+lunga (`cwnet_send.py --fixture long`, 104 elementi, la lettera "V"
+ripetuta) e confronta ogni riga `key` con l'istante che porta scritto
+sopra — vedi la docstring dello script per il metodo esatto e perché serve
+una calibrazione fra i due orologi di processo. Non è una misura con
+l'oscilloscopio sul tasto vero (quella è il passo con la scatola sopra):
+è uno scarto misurato su una macchina, non una garanzia RT.
+
+```sh
+python3 tools/cwnet/cwnet_jitter.py --cwnetd host/build/cwnetd
+python3 tools/cwnet/cwnet_jitter.py --cwnetd host/build/cwnetd --handover
+```
+
+### Numeri misurati
+
+**macOS, Apple Silicon** — MacBook Pro 18,2 (Apple M1 Max), macOS 26.6.2
+(Darwin 25.6.0, arm64), Python 3 di sistema, 2026-09-10, `--play-floor 50
+--ptt-tail 100` (i default):
+
+| Misura | Valore |
+|---|---|
+| Scarto medio (jitter), 9 run da 104 fronti | fra 0.58 e 1.46 ms |
+| Scarto massimo, stesse 9 run | fra 1.4 e 4.8 ms |
+| Fronti ricevuti | 104/104 in ogni run |
+| Intervallo stazione: ultimo key-up -> PTT giu' (`--handover`) | 100 ms (= `--ptt-tail`, misurato su 5 run) |
+| Tempo di scambio dopo la TX (client -> PTT giu' in stazione) | B + coda = 50 + 100 = **150 ms** |
+
+Il tempo di scambio è la grandezza che interessa a chi usa il programma
+originale (il ritardo fra "l'operatore remoto lascia il tasto" e "il PTT di
+stazione scende"): è una somma di configurazione (B, il pavimento del
+buffer, più la coda del PTT), confermata sul loop misurando esattamente
+l'intervallo fra l'ultimo key-up e il PTT giù di una sessione che chiude
+l'over correttamente (`ref_first_over`).
+
+**Linux — mancante.** Questo worktree ha solo un Mac: nessun numero Linux
+in questa tabella, e nessuno stimato al suo posto. Chi ha un'immagine Linux
+a disposizione esegue `tools/cwnet/cwnet_jitter.py` li' e completa la
+tabella; nel frattempo la lacuna resta scritta qui, non nascosta.

--- a/host/cwnetd/key_output.c
+++ b/host/cwnetd/key_output.c
@@ -1,0 +1,91 @@
+/**
+ * @file key_output.c
+ * @brief The virtual backend of key_output.h: one line per edge.
+ */
+#include "key_output.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+/*===========================================================================*/
+/* Virtual backend                                                           */
+/*===========================================================================*/
+
+/*
+ * "key 1 123456" / "ptt 0 123556", the shape U6 asks for: state then the
+ * scheduled instant in monotonic milliseconds. Two fields and a name, so a
+ * shell pipeline can diff the deltas against the encoded waits without a
+ * parser (Success Criteria).
+ */
+static void virtual_line(key_output_t *out, const char *what, bool on, int64_t at_ms) {
+    char line[64];
+    (void)snprintf(line, sizeof(line), "%s %d %" PRId64, what, on ? 1 : 0, at_ms);
+    out->line(out->line_ctx, line);
+}
+
+static void virtual_key(key_output_t *out, bool down, int64_t at_ms) {
+    virtual_line(out, "key", down, at_ms);
+}
+
+static void virtual_ptt(key_output_t *out, bool on, int64_t at_ms) {
+    virtual_line(out, "ptt", on, at_ms);
+}
+
+/*===========================================================================*/
+/* Interface                                                                 */
+/*===========================================================================*/
+
+const char *key_output_backends(void) {
+    /* One for now. The physical transport is a Decision that is not open
+     * (KTD9, Deferred to Follow-Up Work), so there is nothing else to name. */
+    return "virtual";
+}
+
+bool key_output_open(key_output_t *out, const char *backend,
+                     key_output_line_fn line, void *line_ctx) {
+    if (out == NULL || backend == NULL || line == NULL) {
+        return false;
+    }
+    if (strcmp(backend, "virtual") != 0) {
+        return false;
+    }
+
+    memset(out, 0, sizeof(*out));
+    out->name = "virtual";
+    out->line = line;
+    out->line_ctx = line_ctx;
+    out->apply_key = virtual_key;
+    out->apply_ptt = virtual_ptt;
+    return true;
+}
+
+void key_output_set_key(key_output_t *out, bool down, int64_t at_ms) {
+    if (out == NULL || out->apply_key == NULL || out->key_down == down) {
+        return;
+    }
+    out->key_down = down;
+    out->apply_key(out, down, at_ms);
+}
+
+void key_output_set_ptt(key_output_t *out, bool on, int64_t at_ms) {
+    if (out == NULL || out->apply_ptt == NULL || out->ptt_on == on) {
+        return;
+    }
+    out->ptt_on = on;
+    out->apply_ptt(out, on, at_ms);
+}
+
+void key_output_release(key_output_t *out, int64_t at_ms) {
+    key_output_set_key(out, false, at_ms);
+    key_output_set_ptt(out, false, at_ms);
+}
+
+void key_output_close(key_output_t *out, int64_t at_ms) {
+    if (out == NULL) {
+        return;
+    }
+    key_output_release(out, at_ms);
+    out->apply_key = NULL;
+    out->apply_ptt = NULL;
+}

--- a/host/cwnetd/key_output.h
+++ b/host/cwnetd/key_output.h
@@ -1,0 +1,94 @@
+/**
+ * @file key_output.h
+ * @brief Where the played keying actually goes: key and PTT behind one seam.
+ *
+ * R11: "Tasto e PTT passano da un'interfaccia di uscita con un backend
+ * virtuale che scrive ogni fronte come riga con l'istante in ms."
+ *
+ * KTD9 puts the physical transport behind its own Decision, which is not
+ * open yet, so the only backend here is the virtual one: every edge becomes
+ * a line on stdout. A serial-line or GPIO backend later fills in the same
+ * two function pointers and nothing above this file changes.
+ *
+ * The instant carried by an edge is the instant it was *scheduled* for, not
+ * the instant the daemon noticed it: cwnet_play computes deadlines from the
+ * waits the sender encoded, and that is what the line has to show for the
+ * jitter measurement of the Success Criteria to mean anything.
+ *
+ * Two rules a backend must keep, both of them the FAULT philosophy applied
+ * to a transmitter:
+ *   - the rest state is key up and PTT off, and key_output_release() must
+ *     reach it from any state;
+ *   - an edge that does not change the state is not an edge: it is dropped
+ *     here, so a backend never sees a redundant write and the lines on
+ *     stdout are a clean list of transitions.
+ */
+#ifndef HOST_CWNETD_KEY_OUTPUT_H
+#define HOST_CWNETD_KEY_OUTPUT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * A backend's own text output. The daemon owns stdout (non-blocking, lines
+ * dropped rather than blocking the timing loop, KTD7), so a backend never
+ * writes to it directly: it hands a finished line to this and the daemon
+ * decides whether it fits. The line carries no newline.
+ */
+typedef void (*key_output_line_fn)(void *ctx, const char *line);
+
+typedef struct key_output {
+    const char *name;         /**< Backend name, as given to key_output_open() */
+    bool key_down;            /**< Key state as this interface last set it */
+    bool ptt_on;              /**< PTT state as this interface last set it */
+
+    key_output_line_fn line;  /**< Where a backend's lines go; never NULL */
+    void *line_ctx;
+
+    /** Backend hooks. Called only on an actual transition. */
+    void (*apply_key)(struct key_output *out, bool down, int64_t at_ms);
+    void (*apply_ptt)(struct key_output *out, bool on, int64_t at_ms);
+} key_output_t;
+
+/** Comma-separated list of the backends key_output_open() accepts, for --help. */
+const char *key_output_backends(void);
+
+/**
+ * @brief Wire up an output. Starts at rest: key up, PTT off.
+ *
+ * @param out      Interface, not NULL
+ * @param backend  Backend name; see key_output_backends()
+ * @param line     Line sink, not NULL
+ * @param line_ctx Passed back to @p line
+ * @return false on an unknown backend or a NULL argument; nothing is written.
+ */
+bool key_output_open(key_output_t *out, const char *backend,
+                     key_output_line_fn line, void *line_ctx);
+
+/** @brief Key edge at the instant it was scheduled for. No-op if unchanged. */
+void key_output_set_key(key_output_t *out, bool down, int64_t at_ms);
+
+/** @brief PTT edge at the instant it was scheduled for. No-op if unchanged. */
+void key_output_set_ptt(key_output_t *out, bool on, int64_t at_ms);
+
+/**
+ * @brief Back to rest: key up first, then PTT off.
+ *
+ * The order is the one a transmitter wants — never leave the key down while
+ * dropping the PTT. Idempotent, so a signal handler's path and the normal
+ * path can both call it.
+ */
+void key_output_release(key_output_t *out, int64_t at_ms);
+
+/** @brief Release and let the backend go. The interface is unusable after. */
+void key_output_close(key_output_t *out, int64_t at_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HOST_CWNETD_KEY_OUTPUT_H */

--- a/host/cwnetd/main.c
+++ b/host/cwnetd/main.c
@@ -1,0 +1,834 @@
+/**
+ * @file main.c
+ * @brief cwnetd: the CWNet station daemon.
+ *
+ * Everything the station side needs to be a server lives in the pure core
+ * (components/keyer_cwnet/cwnet_server.c and cwnet_play.c, KTD1). This file
+ * is the part that cannot be pure: sockets, the clock, the command line, and
+ * stdout. It owns no protocol knowledge at all — it carries bytes in, edges
+ * out, and prints what the core reports (KTD10: the core does not log).
+ *
+ * The loop (KTD7)
+ * ---------------
+ * One thread, absolute deadlines. sock_poll() waits until the *next*
+ * deadline the core names, never a fixed tick: a 10 ms tick would put up to
+ * 10 ms of jitter on every edge of a 20 ms dot, which is exactly the defect
+ * this program exists to avoid. CLOCK_MONOTONIC through clock_now_ms(),
+ * 64-bit milliseconds so nothing wraps; the 31-bit wire clock stays inside
+ * the core. TCP_NODELAY is host/platform's business. SIGPIPE is ignored
+ * process-wide here, because a client that dies mid-write must not kill the
+ * station. Foreground, no fork: systemd and launchd want it that way, and
+ * the unit files are Deferred work.
+ *
+ * Nothing in this loop may block on something a peer controls:
+ *   - stdout is non-blocking, and a line that does not fit is dropped and
+ *     counted rather than stalling the timing (R12);
+ *   - every client has a ceiling on unsent bytes; over it, that client is
+ *     closed and the others keep their PING and TX_INFO on time;
+ *   - text that came from a client is escaped before it reaches stdout, so
+ *     a callsign carrying ESC[2J cannot clear the operator's terminal.
+ *
+ * SIGINT and SIGTERM close the clients and put the output back to rest. The
+ * key is never left down on the way out.
+ */
+#include "key_output.h"
+
+#include "../platform/clock.h"
+#include "../platform/sock.h"
+
+#include "cwnet_server.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/*===========================================================================*/
+/* Sizes                                                                     */
+/*===========================================================================*/
+
+/** Default TCP port: the reference's, and parameters.yaml's since 2026-09-08 */
+#define CWNETD_DEFAULT_PORT 7355u
+
+/** listen(2) backlog. Past cfg.max_clients we accept and close at once (R1). */
+#define CWNETD_BACKLOG 8
+
+/** One read from a socket per pass round the FIFO */
+#define CWNETD_RECV_CHUNK 4096u
+
+/**
+ * Unsent bytes one client may accumulate before we give up on it.
+ *
+ * The server sends a client tens of bytes every two seconds (a PING, the odd
+ * TX_INFO); 16 KiB is minutes of backlog. A peer that has stopped reading
+ * for that long is not coming back, and holding its bytes any longer only
+ * costs the others. Not a flag: R13 lists the configuration, and this is a
+ * safety limit, not a knob an operator tunes. Overridable at compile time so
+ * the "reader stopped" path can be exercised without pushing a hundred
+ * kilobytes through a kernel socket buffer first.
+ */
+#ifndef CWNETD_OUT_CAP
+#define CWNETD_OUT_CAP 16384u
+#endif
+
+/** Longest status line. Kept well under PIPE_BUF: see status_line(). */
+#define CWNETD_LINE_MAX 256u
+
+/** "255.255.255.255:65535" and room to spare */
+#define CWNETD_PEER_LEN 32u
+
+/** A sanitised name: worst case four characters ("\xNN") per source byte */
+#define CWNETD_SAFE_NAME_LEN (CWNET_SERVER_NAME_LEN * 4u)
+
+/*===========================================================================*/
+/* State                                                                     */
+/*===========================================================================*/
+
+/**
+ * @brief One accepted connection: the socket the core does not know about.
+ *
+ * Indexed by the core's client index minus CWNET_SERVER_FIRST_CLIENT, so the
+ * two views never need a lookup table.
+ */
+typedef struct {
+    bool in_use;
+    sock_handle_t sock;
+    char peer[CWNETD_PEER_LEN];        /**< Address, for the status lines */
+    char name[CWNETD_SAFE_NAME_LEN];   /**< Announced name, already escaped */
+    uint8_t out[CWNETD_OUT_CAP];       /**< Bytes the core handed us, unsent */
+    size_t out_len;
+} conn_t;
+
+static conn_t g_conn[CWNET_SERVER_MAX_CLIENTS];
+static cwnet_server_t g_srv;
+static key_output_t g_out;
+
+/** Set by the signal handler; the loop reads it and stops. */
+static volatile sig_atomic_t g_stop = 0;
+
+/** Status lines stdout would not take, and how many of those we have said. */
+static unsigned long g_lines_dropped = 0;
+static unsigned long g_lines_reported = 0;
+
+/*===========================================================================*/
+/* stdout: never block the timing loop                                       */
+/*===========================================================================*/
+
+/* One write(2) of the whole line. On a pipe, a non-blocking write below
+ * PIPE_BUF either takes everything or takes nothing (POSIX), so a reader
+ * that stops leaves whole lines missing rather than half a line — hence
+ * CWNETD_LINE_MAX being small. */
+static bool write_line(const char *buf, size_t len) {
+    for (;;) {
+        ssize_t n = write(STDOUT_FILENO, buf, len);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        return (n >= 0) && ((size_t)n == len);
+    }
+}
+
+/**
+ * @brief One status line, dropped rather than blocking (R12, KTD7)
+ *
+ * Before a line goes out, any backlog of dropped ones is confessed: the
+ * operator has to be able to tell "nothing happened" from "you were not
+ * reading".
+ */
+static void status_line(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+static void status_line(const char *fmt, ...) {
+    char line[CWNETD_LINE_MAX];
+
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(line, sizeof(line) - 1u, fmt, ap);
+    va_end(ap);
+    if (n < 0) {
+        return;
+    }
+
+    size_t len = (size_t)n;
+    if (len > sizeof(line) - 2u) {
+        len = sizeof(line) - 2u; /* vsnprintf truncated: so do we */
+    }
+    line[len] = '\n';
+    len++;
+
+    if (g_lines_dropped != g_lines_reported) {
+        char note[CWNETD_LINE_MAX];
+        int m = snprintf(note, sizeof(note),
+                         "stato stdout %lu righe scartate\n", g_lines_dropped);
+        if (m > 0 && write_line(note, (size_t)m)) {
+            g_lines_reported = g_lines_dropped;
+        }
+    }
+
+    if (!write_line(line, len)) {
+        g_lines_dropped++;
+    }
+}
+
+/** The line sink key_output.h asks for. */
+static void output_line(void *ctx, const char *line) {
+    (void)ctx;
+    status_line("%s", line);
+}
+
+/**
+ * @brief Escape anything that came from a peer before it reaches a terminal
+ *
+ * Printable ASCII survives; everything else — control bytes, the ESC that
+ * starts a CSI sequence, high bytes — becomes "\xNN", and a backslash is
+ * doubled so the escaping is unambiguous. R12: "le stringhe che vengono dal
+ * client escono con i byte di controllo e le sequenze di escape rimossi".
+ * Removing ESC alone would not do: it is the byte that arms the sequence, so
+ * escaping it disarms the whole of it.
+ */
+static void sanitize(char *dst, size_t dst_size, const char *src) {
+    if (dst == NULL || dst_size == 0u) {
+        return;
+    }
+    size_t o = 0;
+    for (size_t i = 0; src != NULL && src[i] != '\0'; i++) {
+        unsigned char c = (unsigned char)src[i];
+        char esc[5];
+        size_t need;
+
+        if (c == (unsigned char)'\\') {
+            esc[0] = '\\';
+            esc[1] = '\\';
+            need = 2u;
+        } else if (c >= 0x20u && c < 0x7Fu) {
+            esc[0] = (char)c;
+            need = 1u;
+        } else {
+            (void)snprintf(esc, sizeof(esc), "\\x%02X", (unsigned)c);
+            need = 4u;
+        }
+
+        if (o + need + 1u > dst_size) {
+            break;
+        }
+        memcpy(dst + o, esc, need);
+        o += need;
+    }
+    dst[o] = '\0';
+}
+
+/*===========================================================================*/
+/* Connections                                                               */
+/*===========================================================================*/
+
+static conn_t *conn_of(int client_idx) {
+    int i = client_idx - CWNET_SERVER_FIRST_CLIENT;
+    if (i < 0 || i >= CWNET_SERVER_MAX_CLIENTS) {
+        return NULL;
+    }
+    return &g_conn[i];
+}
+
+/** Push out whatever the socket will take right now. Never blocks. */
+static void conn_flush(conn_t *c) {
+    while (c->out_len > 0u) {
+        int n = sock_send(c->sock, c->out, c->out_len);
+        if (n <= 0) {
+            /* Would block: the poll set asks for SOCK_POLLOUT and we come
+             * back. A hard error surfaces on the next recv() as a peer that
+             * has gone, which is the one place a close is decided. */
+            return;
+        }
+        size_t sent = (size_t)n;
+        if (sent >= c->out_len) {
+            c->out_len = 0;
+            return;
+        }
+        memmove(c->out, c->out + sent, c->out_len - sent);
+        c->out_len -= sent;
+    }
+}
+
+/**
+ * @brief The core's only way out (KTD1)
+ *
+ * Queue, then try to drain. Returning anything but @p len makes the core
+ * close this client, which is exactly what a peer over the ceiling deserves:
+ * the loop is not going to wait for it.
+ */
+static int send_cb(int client_idx, const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    conn_t *c = conn_of(client_idx);
+    if (c == NULL || !c->in_use) {
+        return -1;
+    }
+    if (len > sizeof(c->out) - c->out_len) {
+        status_line("stato client %d lettore fermo: %zu byte non inviati, chiudo",
+                    client_idx, c->out_len);
+        return -1;
+    }
+    memcpy(c->out + c->out_len, data, len);
+    c->out_len += len;
+    conn_flush(c);
+    return (int)len;
+}
+
+static void conn_drop(int client_idx) {
+    conn_t *c = conn_of(client_idx);
+    if (c == NULL || !c->in_use) {
+        return;
+    }
+    sock_close(&c->sock);
+    c->in_use = false;
+    c->out_len = 0;
+}
+
+/*===========================================================================*/
+/* Naming what the core reports                                              */
+/*===========================================================================*/
+
+static const char *close_reason_name(int32_t v) {
+    switch ((cwnet_server_close_reason_t)v) {
+        case CWNET_SERVER_CLOSE_NO_SLOT:      return "nessuno slot libero";
+        case CWNET_SERVER_CLOSE_BAD_CONNECT:  return "CONNECT di lunghezza sbagliata";
+        case CWNET_SERVER_CLOSE_PARSE_ERROR:  return "errore di parse";
+        case CWNET_SERVER_CLOSE_BAD_STRING:   return "stringa 0x06 senza NUL";
+        case CWNET_SERVER_CLOSE_HANDSHAKE:    return "CONNECT non arrivato in tempo";
+        case CWNET_SERVER_CLOSE_PING_TIMEOUT: return "tre PING senza risposta";
+        case CWNET_SERVER_CLOSE_SEND_FAILED:  return "invio fallito";
+        case CWNET_SERVER_CLOSE_PEER:         return "chiuso dal peer";
+        default:                              return "?";
+    }
+}
+
+static const char *fault_name(int32_t v) {
+    switch ((cwnet_server_fault_t)v) {
+        case CWNET_SERVER_FAULT_UNDERRUN:      return "underrun: FIFO vuota, tasto su";
+        case CWNET_SERVER_FAULT_HOLDER_GONE:   return "titolare sparito a meta' over";
+        case CWNET_SERVER_FAULT_IDLE:          return "titolare muto oltre l'inattivita'";
+        case CWNET_SERVER_FAULT_OVER_TOO_LONG: return "over oltre il tetto";
+        default:                               return "?";
+    }
+}
+
+static const char *name_of(int client_idx) {
+    conn_t *c = conn_of(client_idx);
+    if (c == NULL || c->name[0] == '\0') {
+        return "(senza nome)";
+    }
+    return c->name;
+}
+
+/**
+ * @brief Print what the core did, and put its keying edges on the output
+ *
+ * The core reports; the daemon decides what that looks like (KTD10). Every
+ * line carries the client index, so two clients never blur together, and the
+ * instants are the scheduled ones, so an over can be reconstructed from the
+ * lines alone (U6 Verification).
+ */
+static void handle_events(const cwnet_server_result_t *res) {
+    for (size_t i = 0; i < res->count; i++) {
+        const cwnet_server_event_t *e = &res->ev[i];
+        switch (e->type) {
+            case CWNET_SERVER_EV_CLIENT_READY: {
+                conn_t *c = conn_of(e->client_idx);
+                if (c != NULL) {
+                    sanitize(c->name, sizeof(c->name),
+                             cwnet_server_client_name(&g_srv, e->client_idx));
+                    status_line("stato connesso client %d %s da %s",
+                                e->client_idx, c->name, c->peer);
+                }
+                break;
+            }
+            case CWNET_SERVER_EV_CLIENT_CLOSED: {
+                if (e->client_idx == 0) {
+                    /* Refused past the client limit; the accept site said so
+                     * already, with the address this one does not carry. */
+                    break;
+                }
+                conn_t *c = conn_of(e->client_idx);
+                status_line("stato disconnesso client %d %s da %s: %s",
+                            e->client_idx, name_of(e->client_idx),
+                            (c != NULL) ? c->peer : "?",
+                            close_reason_name(e->value));
+                conn_drop(e->client_idx);
+                break;
+            }
+            case CWNET_SERVER_EV_KEY_HOLDER:
+                if (e->client_idx == CWNET_SERVER_NOBODY) {
+                    status_line("stato chiave libera");
+                } else {
+                    status_line("stato chiave client %d %s",
+                                e->client_idx, name_of(e->client_idx));
+                }
+                break;
+            case CWNET_SERVER_EV_LATENCY:
+                status_line("stato latenza client %d %d ms peak %d ms",
+                            e->client_idx, e->value, e->peak_ms);
+                break;
+            case CWNET_SERVER_EV_LINK_UNFIT:
+                status_line("stato link non idoneo client %d %s: peak %d ms",
+                            e->client_idx, name_of(e->client_idx), e->value);
+                break;
+            case CWNET_SERVER_EV_OVER_BUFFER:
+                status_line("stato over client %d %s B %d ms",
+                            e->client_idx, name_of(e->client_idx), e->value);
+                break;
+            case CWNET_SERVER_EV_KEY_DOWN:
+                key_output_set_key(&g_out, true, e->at_ms);
+                break;
+            case CWNET_SERVER_EV_KEY_UP:
+                key_output_set_key(&g_out, false, e->at_ms);
+                break;
+            case CWNET_SERVER_EV_PTT_ON:
+                key_output_set_ptt(&g_out, true, e->at_ms);
+                break;
+            case CWNET_SERVER_EV_PTT_OFF:
+                key_output_set_ptt(&g_out, false, e->at_ms);
+                break;
+            case CWNET_SERVER_EV_FAULT:
+                /* A safety net that has already freed the key reports it
+                 * against CWNET_SERVER_NOBODY; the client is named on the
+                 * line above it, so say "nobody" rather than "client -1". */
+                if (e->client_idx == CWNET_SERVER_NOBODY) {
+                    status_line("stato fault: %s", fault_name(e->value));
+                } else {
+                    status_line("stato fault client %d %s: %s", e->client_idx,
+                                name_of(e->client_idx), fault_name(e->value));
+                }
+                break;
+            default:
+                break;
+        }
+    }
+    if (res->dropped > 0u) {
+        status_line("stato eventi persi %zu", res->dropped);
+    }
+}
+
+/*===========================================================================*/
+/* Socket work                                                               */
+/*===========================================================================*/
+
+static void do_accept(sock_handle_t listener, int64_t now_ms) {
+    for (;;) {
+        sock_handle_t h = SOCK_INVALID;
+        if (!sock_accept(listener, &h)) {
+            return; /* nothing pending, or an error we will see again */
+        }
+
+        cwnet_server_result_t res;
+        int idx = cwnet_server_on_connected(&g_srv, now_ms, &res);
+        if (idx == CWNET_SERVER_NO_SLOT) {
+            char peer[CWNETD_PEER_LEN];
+            (void)sock_peer_string(h, peer, sizeof(peer));
+            sock_close(&h);
+            status_line("stato rifiutato da %s: nessuno slot libero", peer);
+            continue; /* R1: accepted and closed, the accept never blocks */
+        }
+
+        conn_t *c = conn_of(idx);
+        if (c == NULL) {
+            sock_close(&h);
+            continue;
+        }
+        c->in_use = true;
+        c->sock = h;
+        c->out_len = 0;
+        c->name[0] = '\0';
+        (void)sock_peer_string(h, c->peer, sizeof(c->peer));
+        status_line("stato accettato client %d da %s", idx, c->peer);
+        handle_events(&res);
+    }
+}
+
+static void do_disconnect(int client_idx, int64_t now_ms) {
+    cwnet_server_result_t res;
+    cwnet_server_on_disconnected(&g_srv, client_idx, now_ms, &res);
+    handle_events(&res);
+    conn_drop(client_idx); /* no-op when the event above already did it */
+}
+
+static void do_recv(int client_idx, int64_t now_ms) {
+    conn_t *c = conn_of(client_idx);
+    if (c == NULL || !c->in_use) {
+        return;
+    }
+    uint8_t buf[CWNETD_RECV_CHUNK];
+
+    for (;;) {
+        int n = sock_recv(c->sock, buf, sizeof(buf));
+        if (n > 0) {
+            cwnet_server_result_t res;
+            cwnet_server_on_data(&g_srv, client_idx, buf, (size_t)n, now_ms, &res);
+            handle_events(&res);
+            if (!c->in_use) {
+                return; /* the core closed it on us */
+            }
+            if ((size_t)n < sizeof(buf)) {
+                return; /* drained */
+            }
+            continue;
+        }
+        if (n == 0) {
+            do_disconnect(client_idx, now_ms);
+            return;
+        }
+        if (sock_would_block(sock_last_error())) {
+            return;
+        }
+        do_disconnect(client_idx, now_ms);
+        return;
+    }
+}
+
+/*===========================================================================*/
+/* Signals                                                                   */
+/*===========================================================================*/
+
+static void on_signal(int sig) {
+    (void)sig;
+    g_stop = 1;
+}
+
+/*
+ * sigaction without SA_RESTART on purpose. signal() gives BSD semantics on
+ * macOS, which restarts poll() and would leave a Ctrl-C sitting unnoticed in
+ * a daemon that is idle — exactly the state it is in most of the time.
+ */
+static bool install_signals(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = on_signal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGINT, &sa, NULL) != 0 || sigaction(SIGTERM, &sa, NULL) != 0) {
+        return false;
+    }
+
+    /* A client that dies while we are writing must not kill the station. */
+    struct sigaction ign;
+    memset(&ign, 0, sizeof(ign));
+    ign.sa_handler = SIG_IGN;
+    sigemptyset(&ign.sa_mask);
+    return sigaction(SIGPIPE, &ign, NULL) == 0;
+}
+
+/*===========================================================================*/
+/* Command line (R13, KTD12)                                                 */
+/*===========================================================================*/
+
+typedef struct {
+    const char *listen_addr;
+    unsigned long port;
+    unsigned long max_clients;
+    unsigned long play_floor_ms;
+    unsigned long link_ceiling_ms;
+    unsigned long ptt_tail_ms;
+    unsigned long ptt_lead_ms;
+    unsigned long idle_ms;
+    unsigned long over_max_ms;
+    unsigned long handshake_ms;
+    const char *output;
+} args_t;
+
+static void usage(const char *argv0, const args_t *d) {
+    printf(
+        "cwnetd - daemon di stazione CWNet\n"
+        "\n"
+        "Uso: %s [opzioni]\n"
+        "\n"
+        "  --listen ADDR       indirizzo IPv4 di ascolto (default %s: tutte le\n"
+        "                      interfacce; il confine di fiducia e' la LAN o la VPN)\n"
+        "  --port N            porta TCP (default %lu)\n"
+        "  --max-clients N     client serviti insieme, max %d (default %lu)\n"
+        "  --play-floor MS     pavimento del buffer B (default %lu)\n"
+        "  --link-ceiling MS   peak-hold oltre cui il link non e' idoneo (default %lu)\n"
+        "  --ptt-tail MS       coda del PTT dopo l'ultimo key-up (default %lu)\n"
+        "  --ptt-lead MS       anticipo del PTT sul primo key-down, mai oltre B (default %lu)\n"
+        "  --idle MS           silenzio del titolare che rilascia la chiave (default %lu)\n"
+        "  --over-max MS       tetto di un over (default %lu)\n"
+        "  --handshake MS      tempo per completare il CONNECT (default %lu)\n"
+        "  --output BACKEND    uscita di tasto e PTT: %s (default %s)\n"
+        "  --help              questo testo\n"
+        "\n"
+        "Lo stato esce su stdout a righe. L'uscita virtuale scrive ogni fronte\n"
+        "come \"key 1 <ms>\" / \"ptt 0 <ms>\", con l'istante per cui il fronte era\n"
+        "programmato. SIGINT e SIGTERM chiudono i client e rilasciano l'uscita.\n",
+        argv0, d->listen_addr, d->port, CWNET_SERVER_MAX_CLIENTS, d->max_clients,
+        d->play_floor_ms, d->link_ceiling_ms, d->ptt_tail_ms, d->ptt_lead_ms,
+        d->idle_ms, d->over_max_ms, d->handshake_ms,
+        key_output_backends(), d->output);
+}
+
+static bool parse_ulong(const char *s, unsigned long max, unsigned long *out) {
+    char *end = NULL;
+    errno = 0;
+    unsigned long v = strtoul(s, &end, 10);
+    if (errno != 0 || end == s || *end != '\0' || v > max) {
+        return false;
+    }
+    *out = v;
+    return true;
+}
+
+enum {
+    OPT_LISTEN = 1000, OPT_PORT, OPT_MAX_CLIENTS, OPT_PLAY_FLOOR, OPT_LINK_CEILING,
+    OPT_PTT_TAIL, OPT_PTT_LEAD, OPT_IDLE, OPT_OVER_MAX, OPT_HANDSHAKE, OPT_OUTPUT,
+    OPT_HELP
+};
+
+static bool parse_args(int argc, char **argv, args_t *a, bool *want_help) {
+    static const struct option opts[] = {
+        { "listen",       required_argument, NULL, OPT_LISTEN },
+        { "port",         required_argument, NULL, OPT_PORT },
+        { "max-clients",  required_argument, NULL, OPT_MAX_CLIENTS },
+        { "play-floor",   required_argument, NULL, OPT_PLAY_FLOOR },
+        { "link-ceiling", required_argument, NULL, OPT_LINK_CEILING },
+        { "ptt-tail",     required_argument, NULL, OPT_PTT_TAIL },
+        { "ptt-lead",     required_argument, NULL, OPT_PTT_LEAD },
+        { "idle",         required_argument, NULL, OPT_IDLE },
+        { "over-max",     required_argument, NULL, OPT_OVER_MAX },
+        { "handshake",    required_argument, NULL, OPT_HANDSHAKE },
+        { "output",       required_argument, NULL, OPT_OUTPUT },
+        { "help",         no_argument,       NULL, OPT_HELP },
+        { NULL, 0, NULL, 0 },
+    };
+
+    *want_help = false;
+    for (;;) {
+        int long_idx = -1;
+        int c = getopt_long(argc, argv, "h", opts, &long_idx);
+        if (c == -1) {
+            break;
+        }
+        bool ok = true;
+        switch (c) {
+            case OPT_LISTEN:       a->listen_addr = optarg; break;
+            case OPT_PORT:         ok = parse_ulong(optarg, 65535u, &a->port); break;
+            case OPT_MAX_CLIENTS:
+                ok = parse_ulong(optarg, (unsigned long)CWNET_SERVER_MAX_CLIENTS,
+                                 &a->max_clients) && a->max_clients > 0u;
+                break;
+            case OPT_PLAY_FLOOR:   ok = parse_ulong(optarg, 60000u, &a->play_floor_ms); break;
+            case OPT_LINK_CEILING: ok = parse_ulong(optarg, 60000u, &a->link_ceiling_ms); break;
+            case OPT_PTT_TAIL:     ok = parse_ulong(optarg, 60000u, &a->ptt_tail_ms); break;
+            case OPT_PTT_LEAD:     ok = parse_ulong(optarg, 60000u, &a->ptt_lead_ms); break;
+            case OPT_IDLE:         ok = parse_ulong(optarg, 3600000u, &a->idle_ms) && a->idle_ms > 0u; break;
+            case OPT_OVER_MAX:     ok = parse_ulong(optarg, 3600000u, &a->over_max_ms) && a->over_max_ms > 0u; break;
+            case OPT_HANDSHAKE:    ok = parse_ulong(optarg, 3600000u, &a->handshake_ms) && a->handshake_ms > 0u; break;
+            case OPT_OUTPUT:       a->output = optarg; break;
+            case OPT_HELP:
+            case 'h':              *want_help = true; return true;
+            default:               return false;
+        }
+        if (!ok) {
+            fprintf(stderr, "cwnetd: valore non valido per --%s: %s\n",
+                    (long_idx >= 0) ? opts[long_idx].name : "?",
+                    (optarg != NULL) ? optarg : "");
+            return false;
+        }
+    }
+    if (optind < argc) {
+        fprintf(stderr, "cwnetd: argomento inatteso: %s\n", argv[optind]);
+        return false;
+    }
+    return true;
+}
+
+/*===========================================================================*/
+/* main                                                                      */
+/*===========================================================================*/
+
+static void shutdown_clients(void) {
+    for (int i = 0; i < CWNET_SERVER_MAX_CLIENTS; i++) {
+        int idx = CWNET_SERVER_FIRST_CLIENT + i;
+        conn_t *c = &g_conn[i];
+        if (!c->in_use) {
+            continue;
+        }
+        status_line("stato disconnesso client %d %s da %s: arresto",
+                    idx, name_of(idx), c->peer);
+        conn_drop(idx);
+    }
+}
+
+int main(int argc, char **argv) {
+    args_t args = {
+        .listen_addr     = "0.0.0.0",
+        .port            = CWNETD_DEFAULT_PORT,
+        .max_clients     = CWNET_SERVER_DEFAULT_MAX_CLIENTS,
+        .play_floor_ms   = CWNET_SERVER_DEFAULT_BUFFER_FLOOR_MS,
+        .link_ceiling_ms = CWNET_SERVER_DEFAULT_BUFFER_CEILING_MS,
+        .ptt_tail_ms     = CWNET_PLAY_DEFAULT_PTT_TAIL_MS,
+        .ptt_lead_ms     = 0u,
+        .idle_ms         = CWNET_SERVER_DEFAULT_IDLE_MS,
+        .over_max_ms     = CWNET_SERVER_DEFAULT_OVER_MAX_MS,
+        .handshake_ms    = CWNET_SERVER_DEFAULT_HANDSHAKE_MS,
+        .output          = "virtual",
+    };
+    const args_t defaults = args;
+
+    bool want_help = false;
+    if (!parse_args(argc, argv, &args, &want_help)) {
+        usage(argv[0], &defaults);
+        return 2;
+    }
+    if (want_help) {
+        usage(argv[0], &defaults);
+        return 0;
+    }
+
+    /* stdout must never be what stalls the timing (KTD7) */
+    int flags = fcntl(STDOUT_FILENO, F_GETFL, 0);
+    if (flags >= 0) {
+        (void)fcntl(STDOUT_FILENO, F_SETFL, flags | O_NONBLOCK);
+    }
+
+    if (!key_output_open(&g_out, args.output, output_line, NULL)) {
+        fprintf(stderr, "cwnetd: backend di uscita sconosciuto: %s (validi: %s)\n",
+                args.output, key_output_backends());
+        return 2;
+    }
+    if (!install_signals()) {
+        fprintf(stderr, "cwnetd: sigaction: %s\n", strerror(errno));
+        return 1;
+    }
+    if (!sock_init()) {
+        fprintf(stderr, "cwnetd: sock_init fallita\n");
+        return 1;
+    }
+
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.max_clients         = (uint16_t)args.max_clients;
+    cfg.buffer_floor_ms     = (uint32_t)args.play_floor_ms;
+    cfg.buffer_ceiling_ms   = (uint32_t)args.link_ceiling_ms;
+    cfg.idle_timeout_ms     = (uint32_t)args.idle_ms;
+    cfg.over_max_ms         = (uint32_t)args.over_max_ms;
+    cfg.handshake_timeout_ms = (uint32_t)args.handshake_ms;
+    cfg.play.ptt_tail_ms    = (uint32_t)args.ptt_tail_ms;
+    cfg.play.ptt_lead_ms    = (uint32_t)args.ptt_lead_ms;
+    cfg.send_cb             = send_cb;
+    cfg.user_data           = NULL;
+    if (!cwnet_server_init(&g_srv, &cfg)) {
+        fprintf(stderr, "cwnetd: cwnet_server_init fallita\n");
+        sock_cleanup();
+        return 1;
+    }
+
+    sock_handle_t listener = sock_listen(args.listen_addr, (uint16_t)args.port,
+                                          CWNETD_BACKLOG);
+    if (!sock_valid(listener)) {
+        fprintf(stderr, "cwnetd: ascolto su %s:%lu fallito: %s\n",
+                args.listen_addr, args.port, strerror(sock_last_error()));
+        sock_cleanup();
+        return 1;
+    }
+
+    uint16_t bound = (uint16_t)args.port;
+    (void)sock_local_port(listener, &bound);
+    status_line("stato ascolto %s:%u max-clients %lu B>=%lu ms tetto %lu ms "
+                "coda %lu ms lead %lu ms uscita %s",
+                args.listen_addr, (unsigned)bound, args.max_clients,
+                args.play_floor_ms, args.link_ceiling_ms, args.ptt_tail_ms,
+                args.ptt_lead_ms, g_out.name);
+
+    while (g_stop == 0) {
+        int64_t now_ms = (int64_t)clock_now_ms();
+
+        sock_pollfd_t fds[1 + CWNET_SERVER_MAX_CLIENTS];
+        int owner[1 + CWNET_SERVER_MAX_CLIENTS];
+        size_t nfds = 0;
+
+        fds[nfds].handle = listener;
+        fds[nfds].events = SOCK_POLLIN;
+        fds[nfds].revents = 0;
+        owner[nfds] = 0;
+        nfds++;
+
+        for (int i = 0; i < CWNET_SERVER_MAX_CLIENTS; i++) {
+            conn_t *c = &g_conn[i];
+            if (!c->in_use) {
+                continue;
+            }
+            fds[nfds].handle = c->sock;
+            fds[nfds].events = (short)(SOCK_POLLIN |
+                                       ((c->out_len > 0u) ? SOCK_POLLOUT : 0));
+            fds[nfds].revents = 0;
+            owner[nfds] = CWNET_SERVER_FIRST_CLIENT + i;
+            nfds++;
+        }
+
+        /* The timeout is the next deadline the core names, never a tick */
+        int timeout = -1;
+        int64_t deadline = 0;
+        if (cwnet_server_next_deadline(&g_srv, &deadline)) {
+            int64_t d = deadline - now_ms;
+            if (d < 0) {
+                d = 0;
+            }
+            if (d > (int64_t)INT_MAX) {
+                d = (int64_t)INT_MAX;
+            }
+            timeout = (int)d;
+        }
+
+        int ready = sock_poll(fds, nfds, timeout);
+        if (ready < 0 && !sock_would_block(sock_last_error()) &&
+            sock_last_error() != EINTR) {
+            status_line("stato poll fallita: %s", strerror(sock_last_error()));
+            break;
+        }
+
+        now_ms = (int64_t)clock_now_ms();
+
+        if (ready > 0) {
+            for (size_t k = 1; k < nfds; k++) {
+                if ((fds[k].revents & SOCK_POLLOUT) != 0) {
+                    conn_t *c = conn_of(owner[k]);
+                    if (c != NULL && c->in_use) {
+                        conn_flush(c);
+                    }
+                }
+            }
+            for (size_t k = 1; k < nfds; k++) {
+                if ((fds[k].revents & SOCK_POLLIN) != 0) {
+                    do_recv(owner[k], now_ms);
+                }
+            }
+            if ((fds[0].revents & SOCK_POLLIN) != 0) {
+                do_accept(listener, now_ms);
+            }
+        }
+
+        cwnet_server_result_t res;
+        cwnet_server_poll(&g_srv, now_ms, &res);
+        handle_events(&res);
+    }
+
+    int64_t now_ms = (int64_t)clock_now_ms();
+    status_line("stato arresto");
+    shutdown_clients();
+    key_output_close(&g_out, now_ms);
+    sock_close(&listener);
+    sock_cleanup();
+    if (g_lines_dropped > 0u) {
+        /* Best effort: stdout may still refuse it, and by now nothing else
+         * is waiting on this process. */
+        status_line("stato stdout %lu righe scartate in totale", g_lines_dropped);
+    }
+    return 0;
+}

--- a/host/cwnetd/main.c
+++ b/host/cwnetd/main.c
@@ -28,6 +28,16 @@
  *   - text that came from a client is escaped before it reaches stdout, so
  *     a callsign carrying ESC[2J cannot clear the operator's terminal.
  *
+ * Events are diagnostics, the state is the truth
+ * ----------------------------------------------
+ * A cwnet_server_result_t carries at most CWNET_SERVER_MAX_EVENTS and counts
+ * the rest in `dropped`; a single burst of keying schedules more than that.
+ * So the edges are never what the output is built from: after every batch of
+ * events the key and the PTT are aligned to the state the core declares
+ * (reconcile_output()). A lost key-up must not leave the transmitter keyed —
+ * corrupted timing is worse than silence, and a key stuck down is worse than
+ * both (ARCHITECTURE.md 8.1).
+ *
  * SIGINT and SIGTERM close the clients and put the output back to rest. The
  * key is never left down on the way out.
  */
@@ -67,6 +77,18 @@
 
 /** One read from a socket per pass round the FIFO */
 #define CWNETD_RECV_CHUNK 4096u
+
+/**
+ * Reads from one client in a single pass of the loop at most.
+ *
+ * Without a ceiling, a peer that keeps its socket full holds the only thread
+ * inside do_recv(): playback does not run, the safety nets do not fire, and
+ * the timeline stands still for as long as the peer cares to push. Bounded,
+ * the backlog is taken over several passes instead — the socket stays
+ * readable, so the next sock_poll() returns at once and nothing is lost.
+ * Same shape as CWNET_FEED_MAX_EDGES_PER_PASS on the box side.
+ */
+#define CWNETD_RECV_MAX_PASSES 8u
 
 /**
  * Unsent bytes one client may accumulate before we give up on it.
@@ -331,14 +353,47 @@ static const char *name_of(int client_idx) {
 }
 
 /**
+ * @brief Align the output to the state the core declares
+ *
+ * The edges are not the authority: a result holds at most
+ * CWNET_SERVER_MAX_EVENTS, and one burst of keying can schedule more, so a
+ * key-up can be counted in `dropped` instead of reported. Nothing else
+ * drives key_output, and the core never re-sends an edge it has already
+ * applied — the key would stay down for the rest of the session. Hence this,
+ * after every batch: two comparisons against the truth.
+ *
+ * key_output_set_*() drops a write that changes nothing, so on the normal
+ * path it prints nothing at all. The order is key_output_release()'s, and for
+ * the same reason: raise the PTT before the key goes down, and lower the key
+ * before the PTT goes away. Never a key down with no PTT behind it.
+ *
+ * @param now_ms The correction happens now; it is not a scheduled instant.
+ */
+static void reconcile_output(int64_t now_ms) {
+    bool key = cwnet_server_key_down(&g_srv);
+    bool ptt = cwnet_server_ptt_on(&g_srv);
+
+    if (ptt) {
+        key_output_set_ptt(&g_out, true, now_ms);
+        key_output_set_key(&g_out, key, now_ms);
+    } else {
+        key_output_set_key(&g_out, key, now_ms);
+        key_output_set_ptt(&g_out, false, now_ms);
+    }
+}
+
+/**
  * @brief Print what the core did, and put its keying edges on the output
  *
  * The core reports; the daemon decides what that looks like (KTD10). Every
  * line carries the client index, so two clients never blur together, and the
  * instants are the scheduled ones, so an over can be reconstructed from the
  * lines alone (U6 Verification).
+ *
+ * @param now_ms The instant of the call, for the reconciliation that closes
+ *               it — not for the events, which carry their own.
  */
-static void handle_events(const cwnet_server_result_t *res) {
+static void handle_events(const cwnet_server_result_t *res, int64_t now_ms) {
     for (size_t i = 0; i < res->count; i++) {
         const cwnet_server_event_t *e = &res->ev[i];
         switch (e->type) {
@@ -416,6 +471,7 @@ static void handle_events(const cwnet_server_result_t *res) {
     if (res->dropped > 0u) {
         status_line("stato eventi persi %zu", res->dropped);
     }
+    reconcile_output(now_ms);
 }
 
 /*===========================================================================*/
@@ -426,7 +482,15 @@ static void do_accept(sock_handle_t listener, int64_t now_ms) {
     for (;;) {
         sock_handle_t h = SOCK_INVALID;
         if (!sock_accept(listener, &h)) {
-            return; /* nothing pending, or an error we will see again */
+            /* "Nothing pending" and "the listener is in trouble" arrive the
+             * same way; every other error path here says its piece, and a
+             * station that has quietly stopped accepting is worth a line.
+             * One per pass at most: we return either way. */
+            int err = sock_last_error();
+            if (!sock_would_block(err) && err != EINTR) {
+                status_line("stato accept fallita: %s", strerror(err));
+            }
+            return;
         }
 
         cwnet_server_result_t res;
@@ -444,20 +508,30 @@ static void do_accept(sock_handle_t listener, int64_t now_ms) {
             sock_close(&h);
             continue;
         }
+        if (c->in_use) {
+            /* The core handed back a slot the daemon still believes is live:
+             * the CLIENT_CLOSED that freed it was one of the events a full
+             * result dropped. Overwriting c->sock here would leak the
+             * descriptor and leave the old peer connected to nothing. Say so
+             * — silence is the worse half of this — and close it properly. */
+            status_line("stato slot client %d ancora in uso da %s: chiudo la "
+                        "connessione precedente", idx, c->peer);
+            conn_drop(idx);
+        }
         c->in_use = true;
         c->sock = h;
         c->out_len = 0;
         c->name[0] = '\0';
         (void)sock_peer_string(h, c->peer, sizeof(c->peer));
         status_line("stato accettato client %d da %s", idx, c->peer);
-        handle_events(&res);
+        handle_events(&res, now_ms);
     }
 }
 
 static void do_disconnect(int client_idx, int64_t now_ms) {
     cwnet_server_result_t res;
     cwnet_server_on_disconnected(&g_srv, client_idx, now_ms, &res);
-    handle_events(&res);
+    handle_events(&res, now_ms);
     conn_drop(client_idx); /* no-op when the event above already did it */
 }
 
@@ -467,13 +541,24 @@ static void do_recv(int client_idx, int64_t now_ms) {
         return;
     }
     uint8_t buf[CWNETD_RECV_CHUNK];
+    int64_t t_ms = now_ms;
 
-    for (;;) {
+    /* Bounded: a client that never lets the socket run short does not get to
+     * own the thread. What it left behind keeps the socket readable, so the
+     * next sock_poll() returns immediately and the reading resumes there —
+     * with the playback and the safety nets having had their turn between. */
+    for (unsigned pass = 0; pass < CWNETD_RECV_MAX_PASSES; pass++) {
+        if (pass > 0u) {
+            /* Re-read the clock every round: the core schedules against the
+             * instant it is handed, and a burst must not freeze it. */
+            t_ms = (int64_t)clock_now_ms();
+        }
+
         int n = sock_recv(c->sock, buf, sizeof(buf));
         if (n > 0) {
             cwnet_server_result_t res;
-            cwnet_server_on_data(&g_srv, client_idx, buf, (size_t)n, now_ms, &res);
-            handle_events(&res);
+            cwnet_server_on_data(&g_srv, client_idx, buf, (size_t)n, t_ms, &res);
+            handle_events(&res, t_ms);
             if (!c->in_use) {
                 return; /* the core closed it on us */
             }
@@ -483,13 +568,13 @@ static void do_recv(int client_idx, int64_t now_ms) {
             continue;
         }
         if (n == 0) {
-            do_disconnect(client_idx, now_ms);
+            do_disconnect(client_idx, t_ms);
             return;
         }
         if (sock_would_block(sock_last_error())) {
             return;
         }
-        do_disconnect(client_idx, now_ms);
+        do_disconnect(client_idx, t_ms);
         return;
     }
 }
@@ -814,9 +899,13 @@ int main(int argc, char **argv) {
             }
         }
 
+        /* Read again: the socket work above is bounded but not free, and the
+         * engine must be ticked with the instant it is actually at. */
+        now_ms = (int64_t)clock_now_ms();
+
         cwnet_server_result_t res;
         cwnet_server_poll(&g_srv, now_ms, &res);
-        handle_events(&res);
+        handle_events(&res, now_ms);
     }
 
     int64_t now_ms = (int64_t)clock_now_ms();

--- a/host/platform/clock.c
+++ b/host/platform/clock.c
@@ -1,0 +1,25 @@
+/**
+ * @file clock.c
+ * @brief POSIX CLOCK_MONOTONIC backing for clock.h.
+ */
+#include "clock.h"
+
+#include <time.h>
+
+#define WIRE_MS_MASK 0x7FFFFFFFu /* 31 bits: the codec's wire width */
+
+uint64_t clock_now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    /* tv_sec is a signed time_t; CLOCK_MONOTONIC never returns a negative
+     * reading, so the cast below just states that as far as the compiler's
+     * -Wsign-conversion is concerned. */
+    uint64_t sec_ms = (uint64_t)ts.tv_sec * 1000u;
+    uint64_t nsec_ms = (uint64_t)(ts.tv_nsec) / 1000000u;
+    return sec_ms + nsec_ms;
+}
+
+uint32_t clock_wire_ms(uint64_t monotonic_ms) {
+    return (uint32_t)(monotonic_ms & WIRE_MS_MASK);
+}

--- a/host/platform/clock.h
+++ b/host/platform/clock.h
@@ -23,11 +23,15 @@ extern "C" {
 uint64_t clock_now_ms(void);
 
 /**
- * The low 31 bits of a monotonic-ms reading — the width the CWNet wire
- * timestamp codec actually carries (see keyer_cwnet's non-linear ms codec
- * upstream of this layer). Callers needing a wire-ready value call this
- * instead of masking clock_now_ms() themselves: the width is a wire
- * contract, not something to reconstruct at each call site.
+ * The low 31 bits of a monotonic-ms reading — the width a CWNet ping
+ * timestamp carries on the wire.
+ *
+ * Nothing in cwnetd calls this: the daemon hands the core 64-bit
+ * milliseconds and the core masks its own timestamps, because it cannot
+ * depend on this layer (it is host-only and also builds in test_host,
+ * without host/platform). It is here for the Windows host client of #68,
+ * which will have to produce wire timestamps itself and should not
+ * re-derive the width at each call site.
  */
 uint32_t clock_wire_ms(uint64_t monotonic_ms);
 

--- a/host/platform/clock.h
+++ b/host/platform/clock.h
@@ -1,0 +1,38 @@
+/**
+ * @file clock.h
+ * @brief Monotonic clock for host programs (cwnetd and friends).
+ *
+ * POSIX today (CLOCK_MONOTONIC). No esp_timer, no test_host stub: this is
+ * the host's own clock, independent of the firmware build.
+ */
+#ifndef HOST_PLATFORM_CLOCK_H
+#define HOST_PLATFORM_CLOCK_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Monotonic milliseconds since an unspecified epoch, as a 64-bit value so it
+ * never wraps within a daemon's lifetime. This is the value schedule/timeout
+ * arithmetic (KTD7: absolute deadlines, poll() timeout to the next one)
+ * should be done in.
+ */
+uint64_t clock_now_ms(void);
+
+/**
+ * The low 31 bits of a monotonic-ms reading — the width the CWNet wire
+ * timestamp codec actually carries (see keyer_cwnet's non-linear ms codec
+ * upstream of this layer). Callers needing a wire-ready value call this
+ * instead of masking clock_now_ms() themselves: the width is a wire
+ * contract, not something to reconstruct at each call site.
+ */
+uint32_t clock_wire_ms(uint64_t monotonic_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HOST_PLATFORM_CLOCK_H */

--- a/host/platform/sock.c
+++ b/host/platform/sock.c
@@ -1,0 +1,303 @@
+/**
+ * @file sock.c
+ * @brief POSIX backing for sock.h (see that file for the winsock seam).
+ */
+#include "sock.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+const sock_handle_t SOCK_INVALID = { .native_handle = -1 };
+
+bool sock_valid(sock_handle_t h) {
+    return h.native_handle != -1;
+}
+
+bool sock_init(void) {
+    /* POSIX: nothing to do. The winsock port calls WSAStartup() here. */
+    return true;
+}
+
+void sock_cleanup(void) {
+    /* POSIX: nothing to do. The winsock port calls WSACleanup() here. */
+}
+
+/*===========================================================================*/
+/* Internal helpers                                                          */
+/*===========================================================================*/
+
+static bool set_nonblocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        return false;
+    }
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+/* TCP_NODELAY on every socket per KTD7, plus non-blocking mode. On BSD/macOS
+ * also SO_NOSIGPIPE per-socket, since send() there has no MSG_NOSIGNAL flag
+ * and the daemon-wide SIGPIPE ignore (KTD7, done by cwnetd's main) is not
+ * this library's to assume for every caller (this loopback test included). */
+static bool set_common_opts(int fd) {
+    int one = 1;
+
+    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) != 0) {
+        return false;
+    }
+
+#ifdef SO_NOSIGPIPE
+    (void)setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+
+    return set_nonblocking(fd);
+}
+
+/*===========================================================================*/
+/* Listen / connect / accept                                                 */
+/*===========================================================================*/
+
+sock_handle_t sock_listen(const char *bind_addr, uint16_t port, int backlog) {
+    sock_handle_t h = SOCK_INVALID;
+
+    struct in_addr bind_ip;
+    if (bind_addr == NULL) {
+        bind_ip.s_addr = htonl(INADDR_ANY);
+    } else if (inet_pton(AF_INET, bind_addr, &bind_ip) != 1) {
+        errno = EINVAL;
+        return h;
+    }
+
+    int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (fd < 0) {
+        return h;
+    }
+
+    int one = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) {
+        close(fd);
+        return h;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr = bind_ip;
+    addr.sin_port = htons(port);
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        close(fd);
+        return h;
+    }
+
+    if (listen(fd, backlog) != 0) {
+        close(fd);
+        return h;
+    }
+
+    if (!set_common_opts(fd)) {
+        close(fd);
+        return h;
+    }
+
+    h.native_handle = fd;
+    return h;
+}
+
+bool sock_local_port(sock_handle_t h, uint16_t *out_port) {
+    if (out_port == NULL || !sock_valid(h)) {
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    socklen_t len = sizeof(addr);
+    memset(&addr, 0, sizeof(addr));
+
+    if (getsockname((int)h.native_handle, (struct sockaddr *)&addr, &len) != 0) {
+        return false;
+    }
+
+    *out_port = ntohs(addr.sin_port);
+    return true;
+}
+
+sock_handle_t sock_connect(const char *host, uint16_t port) {
+    sock_handle_t h = SOCK_INVALID;
+
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    char port_str[8];
+    (void)snprintf(port_str, sizeof(port_str), "%u", (unsigned)port);
+
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(host, port_str, &hints, &res) != 0 || res == NULL) {
+        return h;
+    }
+
+    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (fd < 0) {
+        freeaddrinfo(res);
+        return h;
+    }
+
+    if (!set_common_opts(fd)) {
+        close(fd);
+        freeaddrinfo(res);
+        return h;
+    }
+
+    int err = connect(fd, res->ai_addr, res->ai_addrlen);
+    freeaddrinfo(res);
+
+    if (err != 0 && errno != EINPROGRESS) {
+        close(fd);
+        return h;
+    }
+
+    h.native_handle = fd;
+    return h;
+}
+
+bool sock_accept(sock_handle_t listener, sock_handle_t *out) {
+    if (out == NULL || !sock_valid(listener)) {
+        return false;
+    }
+
+    int fd = accept((int)listener.native_handle, NULL, NULL);
+    if (fd < 0) {
+        /* EAGAIN/EWOULDBLOCK: nothing pending. A real error also lands
+         * here; sock_last_error()/sock_would_block() tell them apart. */
+        return false;
+    }
+
+    if (!set_common_opts(fd)) {
+        close(fd);
+        return false;
+    }
+
+    out->native_handle = fd;
+    return true;
+}
+
+/*===========================================================================*/
+/* I/O                                                                       */
+/*===========================================================================*/
+
+int sock_send(sock_handle_t h, const void *data, size_t len) {
+    if (!sock_valid(h)) {
+        errno = EBADF;
+        return -1;
+    }
+
+#ifdef MSG_NOSIGNAL
+    ssize_t n = send((int)h.native_handle, data, len, MSG_NOSIGNAL);
+#else
+    ssize_t n = send((int)h.native_handle, data, len, 0);
+#endif
+
+    if (n < 0) {
+        return -1;
+    }
+    /* send() never returns more than len; the cast just narrows the type. */
+    return (int)n;
+}
+
+int sock_recv(sock_handle_t h, void *buf, size_t len) {
+    if (!sock_valid(h)) {
+        errno = EBADF;
+        return -1;
+    }
+
+    ssize_t n = recv((int)h.native_handle, buf, len, 0);
+    if (n < 0) {
+        return -1;
+    }
+    return (int)n;
+}
+
+void sock_close(sock_handle_t *h) {
+    if (h == NULL || !sock_valid(*h)) {
+        return;
+    }
+    (void)close((int)h->native_handle);
+    *h = SOCK_INVALID;
+}
+
+/*===========================================================================*/
+/* poll                                                                      */
+/*===========================================================================*/
+
+static short to_native_events(short events) {
+    short native = 0;
+    if (events & SOCK_POLLIN) {
+        native = (short)(native | POLLIN);
+    }
+    if (events & SOCK_POLLOUT) {
+        native = (short)(native | POLLOUT);
+    }
+    return native;
+}
+
+static short from_native_revents(short revents) {
+    short out = 0;
+    /* POLLHUP/POLLERR fold into SOCK_POLLIN: a remote close or a socket
+     * error both mean "the next sock_recv()/sock_send() will tell you
+     * what happened", i.e. the handle is ready to be serviced. */
+    if (revents & (POLLIN | POLLHUP | POLLERR)) {
+        out = (short)(out | SOCK_POLLIN);
+    }
+    if (revents & POLLOUT) {
+        out = (short)(out | SOCK_POLLOUT);
+    }
+    return out;
+}
+
+int sock_poll(sock_pollfd_t *fds, size_t nfds, int timeout_ms) {
+    if (fds == NULL && nfds != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (nfds > SOCK_POLL_MAX_FDS) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    struct pollfd native[SOCK_POLL_MAX_FDS];
+    for (size_t i = 0; i < nfds; ++i) {
+        native[i].fd = (int)fds[i].handle.native_handle;
+        native[i].events = to_native_events(fds[i].events);
+        native[i].revents = 0;
+    }
+
+    int rc = poll(native, (nfds_t)nfds, timeout_ms);
+
+    for (size_t i = 0; i < nfds; ++i) {
+        fds[i].revents = from_native_revents(native[i].revents);
+    }
+
+    return rc;
+}
+
+/*===========================================================================*/
+/* Errors                                                                    */
+/*===========================================================================*/
+
+int sock_last_error(void) {
+    return errno;
+}
+
+bool sock_would_block(int err) {
+    return err == EAGAIN || err == EWOULDBLOCK || err == EINPROGRESS;
+}

--- a/host/platform/sock.c
+++ b/host/platform/sock.c
@@ -129,6 +129,28 @@ bool sock_local_port(sock_handle_t h, uint16_t *out_port) {
     return true;
 }
 
+bool sock_peer_string(sock_handle_t h, char *dst, size_t dst_size) {
+    if (dst == NULL || dst_size == 0u) {
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    socklen_t len = sizeof(addr);
+    char ip[INET_ADDRSTRLEN];
+
+    memset(&addr, 0, sizeof(addr));
+    if (!sock_valid(h) ||
+        getpeername((int)h.native_handle, (struct sockaddr *)&addr, &len) != 0 ||
+        addr.sin_family != AF_INET ||
+        inet_ntop(AF_INET, &addr.sin_addr, ip, sizeof(ip)) == NULL) {
+        (void)snprintf(dst, dst_size, "?");
+        return false;
+    }
+
+    (void)snprintf(dst, dst_size, "%s:%u", ip, (unsigned)ntohs(addr.sin_port));
+    return true;
+}
+
 sock_handle_t sock_connect(const char *host, uint16_t port) {
     sock_handle_t h = SOCK_INVALID;
 

--- a/host/platform/sock.h
+++ b/host/platform/sock.h
@@ -69,6 +69,17 @@ sock_handle_t sock_listen(const char *bind_addr, uint16_t port, int backlog);
 bool sock_local_port(sock_handle_t h, uint16_t *out_port);
 
 /**
+ * The peer of a connected handle, written as "a.b.c.d:port". Writes "?"
+ * and returns false when the peer cannot be had — an already-closed
+ * handle, or a family this layer does not speak. Never leaves dst unset.
+ *
+ * It lives here, and not in the caller, because reading the peer means
+ * touching the native handle: a caller that does that itself is a caller
+ * the winsock port has to rewrite.
+ */
+bool sock_peer_string(sock_handle_t h, char *dst, size_t dst_size);
+
+/**
  * Client-side connect, non-blocking: this returns before the handshake
  * completes (mirrors cwnet_socket.c's start_connect()/EINPROGRESS pattern).
  * Poll the handle for writability, then check sock_last_error() the way

--- a/host/platform/sock.h
+++ b/host/platform/sock.h
@@ -1,0 +1,150 @@
+/**
+ * @file sock.h
+ * @brief Non-blocking TCP sockets for host programs, with a winsock seam.
+ *
+ * Today this is POSIX (BSD sockets, poll()). It is written so a Windows
+ * port (the host client of issue #68) can implement the same functions
+ * against winsock without touching any caller:
+ *   - close()        -> closesocket()
+ *   - fcntl(O_NONBLOCK) -> ioctlsocket(FIONBIO)
+ *   - poll()         -> WSAPoll() is broken before Windows 10 2004, so that
+ *                       port likely reimplements sock_poll() on select();
+ *                       either way the signature below does not change.
+ *
+ * The handle is a small transparent struct, not a bare int, precisely so a
+ * winsock SOCKET (an unsigned handle, not a POSIX fd) can be stored in the
+ * same field later. INVALID_SOCKET on Windows is (SOCKET)(~0); stored in a
+ * signed intptr_t that is exactly -1, matching SOCK_INVALID below bit for
+ * bit — the sentinel survives the port unchanged.
+ */
+#ifndef HOST_PLATFORM_SOCK_H
+#define HOST_PLATFORM_SOCK_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Opaque-in-spirit handle. POSIX stores a plain fd; see the file banner. */
+typedef struct sock_handle {
+    intptr_t native_handle;
+} sock_handle_t;
+
+/** A closed/never-opened handle. Compare with sock_valid(), not by hand. */
+extern const sock_handle_t SOCK_INVALID;
+
+bool sock_valid(sock_handle_t h);
+
+/**
+ * Process-wide setup/teardown. No-ops on POSIX; the winsock port calls
+ * WSAStartup()/WSACleanup() here. Callers call sock_init() once before any
+ * other function in this file and sock_cleanup() once at exit, so the seam
+ * stays invisible to them either way.
+ */
+bool sock_init(void);
+void sock_cleanup(void);
+
+/**
+ * Listening socket bound to `bind_addr`:`port`, with the given backlog.
+ * `bind_addr` is a dotted-quad IPv4 address; NULL or "0.0.0.0" means every
+ * interface, which is the daemon's default (R13 makes it a flag: the trust
+ * boundary is the LAN or the VPN, so the operator can narrow it). Anything
+ * that is not a dotted quad is refused here rather than resolved — a
+ * listening address is configuration, not a name to look up.
+ *
+ * SO_REUSEADDR and TCP_NODELAY are set, and the socket is non-blocking.
+ * Pass port 0 to let the OS choose an ephemeral port; recover it with
+ * sock_local_port(). Returns SOCK_INVALID on failure.
+ */
+sock_handle_t sock_listen(const char *bind_addr, uint16_t port, int backlog);
+
+/**
+ * The port a sock_listen()'d (or connected) socket actually ended up bound
+ * to — needed after sock_listen(NULL, 0, ...) picked an ephemeral one. Returns
+ * false on failure, leaving *out_port untouched.
+ */
+bool sock_local_port(sock_handle_t h, uint16_t *out_port);
+
+/**
+ * Client-side connect, non-blocking: this returns before the handshake
+ * completes (mirrors cwnet_socket.c's start_connect()/EINPROGRESS pattern).
+ * Poll the handle for writability, then check sock_last_error() the way
+ * cwnet_socket.c's check_connect_complete() checks SO_ERROR. Returns
+ * SOCK_INVALID on a synchronous failure (bad host, socket() failed, ...).
+ */
+sock_handle_t sock_connect(const char *host, uint16_t port);
+
+/**
+ * Non-blocking accept. On success, *out receives a connected, non-blocking,
+ * TCP_NODELAY handle and this returns true. Returns false with *out left
+ * untouched when nothing is pending or on error — call sock_last_error()
+ * and sock_would_block() to tell the two apart, the same way cwnet_socket.c
+ * distinguishes EAGAIN from a real failure.
+ *
+ * No accept4(): it does not exist on macOS. This is accept() followed by
+ * setting O_NONBLOCK, same as cwnet_socket.c's set_nonblocking() step.
+ */
+bool sock_accept(sock_handle_t listener, sock_handle_t *out);
+
+/**
+ * Send with partial-write awareness: returns the number of bytes actually
+ * queued, which may be less than `len` on a full send buffer — the same
+ * contract cwnet_socket.c's socket_send_cb() gives its caller, which decides
+ * there that a short write ends the session. -1 on error (see
+ * sock_last_error()).
+ */
+int sock_send(sock_handle_t h, const void *data, size_t len);
+
+/**
+ * Returns bytes read, 0 on an orderly remote close, or -1 on error/would-
+ * block (see sock_last_error() / sock_would_block()).
+ */
+int sock_recv(sock_handle_t h, void *buf, size_t len);
+
+/** Closes the handle and sets *h to SOCK_INVALID. No-op on an already-closed
+ *  or NULL handle. */
+void sock_close(sock_handle_t *h);
+
+/** Readiness bits for sock_pollfd_t, decoupled from native POLLIN/POLLOUT
+ *  values so a winsock backend can translate freely without this header
+ *  changing. A remote close is reported as SOCK_POLLIN (readable — the
+ *  next sock_recv() returns 0), matching plain poll() semantics. */
+#define SOCK_POLLIN  0x0001
+#define SOCK_POLLOUT 0x0002
+
+typedef struct sock_pollfd {
+    sock_handle_t handle;
+    short events;   /**< SOCK_POLLIN / SOCK_POLLOUT, OR'd together */
+    short revents;  /**< filled in by sock_poll() */
+} sock_pollfd_t;
+
+/**
+ * poll() over a set of handles. timeout_ms < 0 blocks forever, 0 returns
+ * immediately. Returns the number of handles with revents set, 0 on
+ * timeout, -1 on error. `nfds` above SOCK_POLL_MAX_FDS fails with -1
+ * (EINVAL) rather than allocating — a daemon serving a handful of clients
+ * never approaches it.
+ */
+#define SOCK_POLL_MAX_FDS 64
+
+int sock_poll(sock_pollfd_t *fds, size_t nfds, int timeout_ms);
+
+/** errno-equivalent of the last failing call on this thread. Plain errno on
+ *  POSIX; the winsock port returns WSAGetLastError(). */
+int sock_last_error(void);
+
+/** True when `err` (as returned by sock_last_error()) means "would block,
+ *  try again" rather than a real failure — EAGAIN/EWOULDBLOCK/EINPROGRESS
+ *  on POSIX, their WSA* counterparts on the winsock port. Callers compare
+ *  through this instead of the raw errno constants so the port does not
+ *  have to touch call sites that check it. */
+bool sock_would_block(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HOST_PLATFORM_SOCK_H */

--- a/host/tests/loopback_test.c
+++ b/host/tests/loopback_test.c
@@ -1,0 +1,426 @@
+/**
+ * @file loopback_test.c
+ * @brief End-to-end exercise of host/platform's sock.h and clock.h over a
+ *        real local TCP connection. No mocks: two real sockets talk to each
+ *        other on 127.0.0.1, exactly as U5's Verification calls for.
+ */
+#include "../platform/sock.h"
+#include "../platform/clock.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <sys/socket.h>
+
+/*===========================================================================*/
+/* Fixture bytes                                                            */
+/*===========================================================================*/
+
+/*
+ * The same 94 bytes as test_host/cwnet_fixtures.h's ref_connect_echo (the
+ * 2026-09-05 capture's CONNECT echo for user "Moritz"). Copied in literally,
+ * not included: host/ must not depend on test_host, and this layer has no
+ * notion of the CWNet protocol anyway — the bytes are just a real, non-
+ * trivial payload to push through a real socket.
+ */
+static const uint8_t ref_connect_echo[] = {
+    0x41, 0x5C, 0x4D, 0x6F, 0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x6F,
+    0x72, 0x69, 0x74, 0x7A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+};
+
+/*===========================================================================*/
+/* Small helpers shared by the scenarios                                    */
+/*===========================================================================*/
+
+/* Listens on an ephemeral port, connects to it, accepts the connection, and
+ * confirms the client side is writable — a fully established local pair. */
+static bool establish_pair(sock_handle_t *listener, sock_handle_t *client,
+                            sock_handle_t *server) {
+    *listener = sock_listen("127.0.0.1", 0, 4);
+    if (!sock_valid(*listener)) {
+        fprintf(stderr, "establish_pair: sock_listen failed\n");
+        return false;
+    }
+
+    uint16_t port = 0;
+    if (!sock_local_port(*listener, &port)) {
+        fprintf(stderr, "establish_pair: sock_local_port failed\n");
+        return false;
+    }
+
+    *client = sock_connect("127.0.0.1", port);
+    if (!sock_valid(*client)) {
+        fprintf(stderr, "establish_pair: sock_connect failed\n");
+        return false;
+    }
+
+    *server = SOCK_INVALID;
+    bool client_writable = false;
+
+    for (int attempt = 0; attempt < 200 && (!sock_valid(*server) || !client_writable); ++attempt) {
+        sock_pollfd_t fds[2];
+        fds[0].handle = *listener;
+        fds[0].events = SOCK_POLLIN;
+        fds[0].revents = 0;
+        fds[1].handle = *client;
+        fds[1].events = SOCK_POLLOUT;
+        fds[1].revents = 0;
+
+        int n = sock_poll(fds, 2, 50);
+        if (n < 0) {
+            fprintf(stderr, "establish_pair: sock_poll error %d\n", sock_last_error());
+            return false;
+        }
+
+        if (!sock_valid(*server) && (fds[0].revents & SOCK_POLLIN)) {
+            sock_handle_t accepted;
+            if (sock_accept(*listener, &accepted)) {
+                *server = accepted;
+            }
+        }
+        if (fds[1].revents & SOCK_POLLOUT) {
+            client_writable = true;
+        }
+    }
+
+    return sock_valid(*server) && client_writable;
+}
+
+static void close_pair(sock_handle_t *listener, sock_handle_t *client, sock_handle_t *server) {
+    sock_close(client);
+    sock_close(server);
+    sock_close(listener);
+}
+
+/* Sends exactly len bytes, resuming on a would-block the way a real caller
+ * (cwnet_socket.c's pattern) is expected to. */
+static bool send_all(sock_handle_t h, const uint8_t *buf, size_t len) {
+    size_t sent = 0;
+    int attempts = 0;
+    while (sent < len && attempts < 2000) {
+        int n = sock_send(h, buf + sent, len - sent);
+        if (n < 0) {
+            if (sock_would_block(sock_last_error())) {
+                ++attempts;
+                continue;
+            }
+            fprintf(stderr, "send_all: error %d\n", sock_last_error());
+            return false;
+        }
+        sent += (size_t)n;
+        ++attempts;
+    }
+    return sent == len;
+}
+
+/* Receives exactly len bytes, polling for readability between calls. */
+static bool recv_exact(sock_handle_t h, uint8_t *buf, size_t len, int max_attempts) {
+    size_t got = 0;
+    for (int attempt = 0; attempt < max_attempts && got < len; ++attempt) {
+        sock_pollfd_t pfd;
+        pfd.handle = h;
+        pfd.events = SOCK_POLLIN;
+        pfd.revents = 0;
+
+        int n = sock_poll(&pfd, 1, 100);
+        if (n < 0) {
+            fprintf(stderr, "recv_exact: sock_poll error %d\n", sock_last_error());
+            return false;
+        }
+        if (n == 0 || !(pfd.revents & SOCK_POLLIN)) {
+            continue;
+        }
+
+        int r = sock_recv(h, buf + got, len - got);
+        if (r < 0) {
+            if (sock_would_block(sock_last_error())) {
+                continue;
+            }
+            fprintf(stderr, "recv_exact: recv error %d\n", sock_last_error());
+            return false;
+        }
+        if (r == 0) {
+            fprintf(stderr, "recv_exact: peer closed after %zu/%zu bytes\n", got, len);
+            return false;
+        }
+        got += (size_t)r;
+    }
+    return got == len;
+}
+
+/*===========================================================================*/
+/* Scenario 1: loopback echo of a real reference payload                    */
+/*===========================================================================*/
+
+static bool test_loopback_echo(void) {
+    sock_handle_t listener, client, server;
+    if (!establish_pair(&listener, &client, &server)) {
+        return false;
+    }
+
+    bool ok = send_all(client, ref_connect_echo, sizeof(ref_connect_echo));
+
+    uint8_t received[sizeof(ref_connect_echo)];
+    if (ok) {
+        ok = recv_exact(server, received, sizeof(received), 200);
+    }
+    if (ok) {
+        ok = memcmp(received, ref_connect_echo, sizeof(ref_connect_echo)) == 0;
+        if (!ok) {
+            fprintf(stderr, "loopback_echo: received bytes do not match ref_connect_echo\n");
+        }
+    }
+
+    close_pair(&listener, &client, &server);
+    return ok;
+}
+
+/*===========================================================================*/
+/* Scenario 2: partial send, caller resumes                                 */
+/*===========================================================================*/
+
+#define PARTIAL_PAYLOAD_LEN (300u * 1000u)
+
+static uint8_t s_partial_payload[PARTIAL_PAYLOAD_LEN];
+static uint8_t s_partial_received[PARTIAL_PAYLOAD_LEN];
+
+static bool test_partial_send(void) {
+    sock_handle_t listener, client, server;
+    if (!establish_pair(&listener, &client, &server)) {
+        return false;
+    }
+
+    /* Shrink the sender's kernel send buffer so a single sock_send() of the
+     * whole payload cannot possibly go out whole — this is what forces the
+     * short write cwnet_socket.c's socket_send_cb() is written to expect. */
+    int small_sndbuf = 2048;
+    (void)setsockopt((int)client.native_handle, SOL_SOCKET, SO_SNDBUF,
+                      &small_sndbuf, sizeof(small_sndbuf));
+
+    for (size_t i = 0; i < PARTIAL_PAYLOAD_LEN; ++i) {
+        s_partial_payload[i] = (uint8_t)(i % 251u);
+    }
+
+    size_t sent_total = 0;
+    size_t recv_total = 0;
+    bool saw_partial = false;
+    int attempts = 0;
+    bool io_error = false;
+
+    while ((sent_total < PARTIAL_PAYLOAD_LEN || recv_total < sent_total) &&
+           attempts < 200000 && !io_error) {
+        ++attempts;
+
+        if (sent_total < PARTIAL_PAYLOAD_LEN) {
+            int n = sock_send(client, s_partial_payload + sent_total,
+                               PARTIAL_PAYLOAD_LEN - sent_total);
+            if (n >= 0) {
+                if ((size_t)n < PARTIAL_PAYLOAD_LEN - sent_total) {
+                    saw_partial = true;
+                }
+                sent_total += (size_t)n;
+            } else if (!sock_would_block(sock_last_error())) {
+                fprintf(stderr, "partial_send: send error %d\n", sock_last_error());
+                io_error = true;
+            }
+        }
+
+        /* Drain whatever arrived so the sender keeps finding room, the same
+         * way an event loop would service both directions. */
+        if (recv_total < PARTIAL_PAYLOAD_LEN) {
+            int r = sock_recv(server, s_partial_received + recv_total,
+                               PARTIAL_PAYLOAD_LEN - recv_total);
+            if (r > 0) {
+                recv_total += (size_t)r;
+            } else if (r < 0 && !sock_would_block(sock_last_error())) {
+                fprintf(stderr, "partial_send: recv error %d\n", sock_last_error());
+                io_error = true;
+            }
+        }
+    }
+
+    bool ok = !io_error && saw_partial &&
+              sent_total == PARTIAL_PAYLOAD_LEN &&
+              recv_total == PARTIAL_PAYLOAD_LEN &&
+              memcmp(s_partial_payload, s_partial_received, PARTIAL_PAYLOAD_LEN) == 0;
+
+    if (!io_error && !saw_partial) {
+        fprintf(stderr, "partial_send: never observed a short write\n");
+    }
+
+    close_pair(&listener, &client, &server);
+    return ok;
+}
+
+/*===========================================================================*/
+/* Scenario 3: remote close unblocks poll and recv reports EOF              */
+/*===========================================================================*/
+
+static bool test_remote_close(void) {
+    sock_handle_t listener, client, server;
+    if (!establish_pair(&listener, &client, &server)) {
+        return false;
+    }
+
+    sock_close(&client); /* writer gone; server side should see the close */
+
+    bool saw_readable = false;
+    bool saw_eof = false;
+
+    for (int attempt = 0; attempt < 200 && !saw_eof; ++attempt) {
+        sock_pollfd_t pfd;
+        pfd.handle = server;
+        pfd.events = SOCK_POLLIN;
+        pfd.revents = 0;
+
+        int n = sock_poll(&pfd, 1, 50);
+        if (n < 0) {
+            fprintf(stderr, "remote_close: sock_poll error %d\n", sock_last_error());
+            break;
+        }
+        if (n == 0 || !(pfd.revents & SOCK_POLLIN)) {
+            continue;
+        }
+
+        saw_readable = true;
+        uint8_t byte;
+        int r = sock_recv(server, &byte, sizeof(byte));
+        if (r == 0) {
+            saw_eof = true;
+        } else if (r < 0 && !sock_would_block(sock_last_error())) {
+            fprintf(stderr, "remote_close: recv error %d\n", sock_last_error());
+            break;
+        }
+    }
+
+    if (!saw_readable) {
+        fprintf(stderr, "remote_close: poll never signalled readiness after the close\n");
+    } else if (!saw_eof) {
+        fprintf(stderr, "remote_close: recv never reported EOF (0) after the close\n");
+    }
+
+    sock_close(&server);
+    sock_close(&listener);
+    return saw_readable && saw_eof;
+}
+
+/*===========================================================================*/
+/* Scenario 4: the monotonic clock                                          */
+/*===========================================================================*/
+
+/* The plan's scenario asked for a 10 ms sleep to land in a 9..12 ms window.
+ * On a real machine that window pins the operating system's scheduler, not
+ * this clock: nanosleep(10ms) returns after 13 ms often enough on macOS to
+ * fail half the runs, and a test that fails at random is a test everyone
+ * learns to ignore — which the Definition of done forbids outright.
+ *
+ * So assert what clock_now_ms() actually owes its callers. It must never go
+ * backwards, and it must count milliseconds: after a 50 ms sleep the floor
+ * of 45 ms rules out a clock counting seconds (which would read 0) and the
+ * generous ceiling rules out one counting microseconds (which would read
+ * 50000). Everything between the two is scheduler jitter, and none of it is
+ * ours. */
+static bool test_clock_monotonic_and_in_ms(void) {
+    uint64_t previous = clock_now_ms();
+    for (int i = 0; i < 10000; ++i) {
+        uint64_t now = clock_now_ms();
+        if (now < previous) {
+            fprintf(stderr, "clock: went backwards, %" PRIu64 " after %" PRIu64 "\n",
+                    now, previous);
+            return false;
+        }
+        previous = now;
+    }
+
+    uint64_t t0 = clock_now_ms();
+
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 50 * 1000 * 1000; /* 50 ms */
+    nanosleep(&ts, NULL);
+
+    uint64_t delta = clock_now_ms() - t0;
+
+    bool ok = delta >= 45 && delta <= 500;
+    if (!ok) {
+        fprintf(stderr,
+                "clock: a 50 ms sleep should read 45..500 ms, got %" PRIu64 " ms\n",
+                delta);
+    }
+    return ok;
+}
+
+/* The bind address is configuration (R13), so sock_listen() takes a dotted
+ * quad and refuses anything else instead of resolving it. A hostname here
+ * would mean a DNS lookup deciding which interface a station daemon listens
+ * on, which is the operator's decision, not the resolver's. */
+static bool test_listen_refuses_a_hostname(void) {
+    sock_handle_t h = sock_listen("localhost", 0, 4);
+    if (sock_valid(h)) {
+        fprintf(stderr, "listen: a hostname should have been refused\n");
+        sock_close(&h);
+        return false;
+    }
+    return true;
+}
+
+/* Not one of the plan's listed scenarios, but the wire-width helper is new
+ * API surface with its own logic (masking to 31 bits) worth pinning
+ * directly rather than only through the clock scenario above. */
+static bool test_clock_wire_mask(void) {
+    uint64_t past_31_bits = (UINT64_C(1) << 33) | 5u; /* bit 33 set, low bits = 5 */
+    uint32_t wire = clock_wire_ms(past_31_bits);
+    bool ok = wire == 5u;
+    if (!ok) {
+        fprintf(stderr, "clock_wire_mask: expected 5, got %" PRIu32 "\n", wire);
+    }
+    return ok;
+}
+
+/*===========================================================================*/
+/* Runner                                                                   */
+/*===========================================================================*/
+
+typedef struct {
+    const char *name;
+    bool (*fn)(void);
+} test_case_t;
+
+int main(void) {
+    if (!sock_init()) {
+        fprintf(stderr, "sock_init failed\n");
+        return 1;
+    }
+
+    const test_case_t tests[] = {
+        {"loopback_echo", test_loopback_echo},
+        {"partial_send", test_partial_send},
+        {"remote_close", test_remote_close},
+        {"listen_refuses_a_hostname", test_listen_refuses_a_hostname},
+        {"clock_monotonic_and_in_ms", test_clock_monotonic_and_in_ms},
+        {"clock_wire_mask", test_clock_wire_mask},
+    };
+    size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+
+    size_t passed = 0;
+    for (size_t i = 0; i < n_tests; ++i) {
+        bool ok = tests[i].fn();
+        printf("[%s] %s\n", ok ? "PASS" : "FAIL", tests[i].name);
+        if (ok) {
+            ++passed;
+        }
+    }
+
+    sock_cleanup();
+
+    printf("%zu/%zu tests passed\n", passed, n_tests);
+    return passed == n_tests ? 0 : 1;
+}

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -1152,7 +1152,7 @@ families:
 
       server_port:
         type: u16
-        default: 7373
+        default: 7355
         range: [1, 65535]
         nvs_key: "cwnet_port"
         runtime_change: reboot
@@ -1165,8 +1165,8 @@ families:
             en: "CWNet Server Port"
             it: "Porta Server CWNet"
           description:
-            en: "CWNet server TCP port (default: 7373)"
-            it: "Porta TCP del server CWNet (default: 7373)"
+            en: "CWNet server TCP port (default: 7355)"
+            it: "Porta TCP del server CWNet (default: 7355)"
           widget: spinbox
           widget_config:
             step: 1

--- a/test_host/CMakeLists.txt
+++ b/test_host/CMakeLists.txt
@@ -94,6 +94,7 @@ set(CWNET_SOURCES
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_client.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_feed.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_play.c  # Host-only: the station daemon's playback engine
+    ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_server.c  # Host-only: the station daemon's server core
 )
 
 # Test sources
@@ -117,6 +118,7 @@ set(TEST_SOURCES
     test_cwnet_client.c
     test_cwnet_feed.c
     test_cwnet_play.c
+    test_cwnet_server.c
     stubs/esp_stubs.c
 )
 

--- a/test_host/CMakeLists.txt
+++ b/test_host/CMakeLists.txt
@@ -14,6 +14,10 @@ add_compile_options(
     -Wdouble-promotion
     -Wformat=2
     -Wnull-dereference
+    # keyer_cwnet's module brief promises these two; the suite compiles that
+    # component's sources, so the promise is kept here as well as in host/.
+    -Wshadow
+    -Wstrict-prototypes
     -g
 )
 

--- a/test_host/CMakeLists.txt
+++ b/test_host/CMakeLists.txt
@@ -93,6 +93,7 @@ set(CWNET_SOURCES
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_ping.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_client.c
     ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_feed.c
+    ${COMPONENT_DIR}/keyer_cwnet/src/cwnet_play.c  # Host-only: the station daemon's playback engine
 )
 
 # Test sources
@@ -115,6 +116,7 @@ set(TEST_SOURCES
     test_cwnet_ping.c
     test_cwnet_client.c
     test_cwnet_feed.c
+    test_cwnet_play.c
     stubs/esp_stubs.c
 )
 

--- a/test_host/test_cwnet_client.c
+++ b/test_host/test_cwnet_client.c
@@ -1149,6 +1149,30 @@ static void feed_rtt(int32_t rtt_ms) {
     cwnet_client_on_data(&client, frame, sizeof(frame));
 }
 
+/* A PING RESPONSE_2 with explicit t0/t2, for cases feed_rtt() cannot express:
+ * a "negative RTT" produced by the 31-bit clock wrapping between the two,
+ * rather than by a straightforward round trip. */
+static void feed_response2_explicit(int32_t t0_ms, int32_t t2_ms) {
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE] = {
+        0x43, 0x10,
+        0x02, 0x01, 0x00, 0x00,   /* RESPONSE_2, id 1 */
+        0x00, 0x00, 0x00, 0x00,   /* t0, filled below */
+        0x00, 0x00, 0x00, 0x00,   /* t1, unused for latency */
+        0x00, 0x00, 0x00, 0x00,   /* t2, filled below */
+    };
+    uint32_t t0 = (uint32_t)t0_ms;
+    frame[6] = (uint8_t)(t0 & 0xFFu);
+    frame[7] = (uint8_t)((t0 >> 8) & 0xFFu);
+    frame[8] = (uint8_t)((t0 >> 16) & 0xFFu);
+    frame[9] = (uint8_t)((t0 >> 24) & 0xFFu);
+    uint32_t t2 = (uint32_t)t2_ms;
+    frame[14] = (uint8_t)(t2 & 0xFFu);
+    frame[15] = (uint8_t)((t2 >> 8) & 0xFFu);
+    frame[16] = (uint8_t)((t2 >> 16) & 0xFFu);
+    frame[17] = (uint8_t)((t2 >> 24) & 0xFFu);
+    cwnet_client_on_data(&client, frame, sizeof(frame));
+}
+
 void test_client_latency_peak_holds_and_decays_like_the_reference(void) {
     ready_client_accumulating();
     TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_peak_ms(&client));
@@ -1181,6 +1205,42 @@ void test_client_latency_peak_holds_and_decays_like_the_reference(void) {
         feed_rtt(loopback[i]);
         TEST_ASSERT_EQUAL(7, cwnet_client_get_latency_peak_ms(&client));
     }
+}
+
+/*
+ * KTD2 (the station daemon plan) changed the peak-hold gate to reject RTTs
+ * outside 0..2000 ms, not only negative ones, and promised the change "pins
+ * with a client test" -- cwnet_ping_peak_hold_update() is pinned at the codec
+ * level (test_ping_peak_hold_gate_rejects_over_2000ms and
+ * test_ping_peak_hold_gate_rejects_negative_rtt_from_wrap in
+ * test_cwnet_ping.c), but nothing exercised the same gate through the box
+ * that actually receives RESPONSE_2 off the wire: cwnet_client_on_data().
+ * This is that missing counterpart.
+ */
+void test_client_ping_peak_hold_gate_rejects_out_of_range_rtt(void) {
+    ready_client_accumulating();
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_ms(&client));
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_peak_ms(&client));
+
+    /* Comfortably over the 2000 ms gate: rejected before it touches either
+     * the instant latency or the peak-hold. */
+    feed_rtt(2500);
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_ms(&client));
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_peak_ms(&client));
+
+    /* A negative RTT from the 31-bit clock wrapping between t0 and t2 (same
+     * shape as test_ping_peak_hold_gate_rejects_negative_rtt_from_wrap),
+     * fed through the client so the wire-to-state path is what gets pinned,
+     * not just the codec function in isolation. */
+    feed_response2_explicit(2147483600, 100);
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_ms(&client));
+    TEST_ASSERT_EQUAL(-1, cwnet_client_get_latency_peak_ms(&client));
+
+    /* The gate does not wedge the client: a realistic RTT afterwards still
+     * updates both values normally. */
+    feed_rtt(42);
+    TEST_ASSERT_EQUAL(42, cwnet_client_get_latency_ms(&client));
+    TEST_ASSERT_EQUAL(42, cwnet_client_get_latency_peak_ms(&client));
 }
 
 /*===========================================================================*/

--- a/test_host/test_cwnet_frame_parser.c
+++ b/test_host/test_cwnet_frame_parser.c
@@ -14,6 +14,8 @@
 
 #include "unity.h"
 #include "cwnet_frame.h"
+#include "cwnet_client.h"
+#include "cwnet_fixtures.h"
 #include <string.h>
 
 /*===========================================================================*/
@@ -446,4 +448,195 @@ void test_stream_parse_long_block_partial_length(void) {
     cwnet_parse_result_t r3 = cwnet_frame_parse(&parser, payload, 320);
     TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r3.status);
     TEST_ASSERT_EQUAL(320, r3.payload_len);
+}
+
+/*===========================================================================*/
+/* R14: a fragmented frame declaring more than the internal buffer          */
+/*===========================================================================*/
+
+void test_parse_fragmented_oversized_long_frame_is_skipped_not_error(void) {
+    /* AE7: a long-block frame declares 300 bytes (over CWNET_FRAME_PARSER_BUF_SIZE
+     * = 256), delivered in two fragments, immediately followed by a PING. The
+     * first fragment is 3-byte header + 100 payload bytes; the second is the
+     * remaining 200 payload bytes with the PING's 18 bytes appended -- the
+     * shape a socket read actually hands the parser mid-stream. */
+    uint8_t header[3] = {0x91, 0x2C, 0x01};  /* long block, len=300 (0x012C LE) */
+
+    uint8_t frag1[3 + 100];
+    memcpy(frag1, header, sizeof(header));
+    memset(frag1 + 3, 0x11, 100);
+
+    uint8_t frag2[200 + 18];
+    memset(frag2, 0x22, 200);
+    frag2[200] = 0x43;  /* PING */
+    frag2[201] = 0x10;  /* len = 16 */
+    memset(&frag2[202], 0xEE, 16);
+
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+
+    cwnet_parse_result_t r1 = cwnet_frame_parse(&parser, frag1, sizeof(frag1));
+    TEST_ASSERT_EQUAL(CWNET_PARSE_NEED_MORE, r1.status);
+    TEST_ASSERT_EQUAL(sizeof(frag1), r1.bytes_consumed);
+
+    cwnet_parse_result_t r2 = cwnet_frame_parse(&parser, frag2, sizeof(frag2));
+    TEST_ASSERT_EQUAL(CWNET_PARSE_SKIPPED, r2.status);
+    TEST_ASSERT_NULL(r2.payload);
+    TEST_ASSERT_EQUAL(0, r2.payload_len);
+    /* Consumed exactly the 200 bytes that complete the declared 300-byte
+     * payload -- not the PING that follows in the same fragment. */
+    TEST_ASSERT_EQUAL(200, r2.bytes_consumed);
+
+    /* Framing survived: the PING right after it parses intact. */
+    cwnet_frame_parser_reset(&parser);
+    cwnet_parse_result_t r3 = cwnet_frame_parse(&parser, frag2 + r2.bytes_consumed,
+                                                 sizeof(frag2) - r2.bytes_consumed);
+    TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r3.status);
+    TEST_ASSERT_EQUAL_HEX8(0x03, r3.command);
+    TEST_ASSERT_EQUAL(16, r3.payload_len);
+    TEST_ASSERT_EQUAL(18, r3.bytes_consumed);
+}
+
+void test_parse_fragmented_256_exact_still_buffers_and_copies(void) {
+    /* 256 == CWNET_FRAME_PARSER_BUF_SIZE exactly: still fits, still valid. */
+    uint8_t header[3] = {0x91, 0x00, 0x01};  /* long block, len=256 (0x0100 LE) */
+    uint8_t payload[256];
+    for (size_t i = 0; i < sizeof(payload); i++) {
+        payload[i] = (uint8_t)i;
+    }
+
+    uint8_t frag1[3 + 100];
+    memcpy(frag1, header, sizeof(header));
+    memcpy(frag1 + 3, payload, 100);
+    uint8_t frag2[156];
+    memcpy(frag2, payload + 100, sizeof(frag2));
+
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+
+    cwnet_parse_result_t r1 = cwnet_frame_parse(&parser, frag1, sizeof(frag1));
+    TEST_ASSERT_EQUAL(CWNET_PARSE_NEED_MORE, r1.status);
+
+    cwnet_parse_result_t r2 = cwnet_frame_parse(&parser, frag2, sizeof(frag2));
+    TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r2.status);
+    TEST_ASSERT_EQUAL(256, r2.payload_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(payload, r2.payload, sizeof(payload));
+}
+
+static uint8_t s_long_single_read_frame[3 + 65535];
+
+void test_parse_long_frame_65535_single_read_no_copy(void) {
+    /* Delivered whole in one read: valid regardless of size, pointer straight
+     * into the caller's buffer, no copy into the internal buffer at all. */
+    s_long_single_read_frame[0] = 0x91;
+    s_long_single_read_frame[1] = 0xFF;
+    s_long_single_read_frame[2] = 0xFF;  /* 0xFFFF = 65535 LE */
+    memset(s_long_single_read_frame + 3, 0x99, 65535);
+
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+
+    cwnet_parse_result_t r = cwnet_frame_parse(&parser, s_long_single_read_frame,
+                                                sizeof(s_long_single_read_frame));
+    TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r.status);
+    TEST_ASSERT_EQUAL(65535, r.payload_len);
+    TEST_ASSERT_EQUAL_PTR(&s_long_single_read_frame[3], r.payload);
+}
+
+/*===========================================================================*/
+/* Frame builder                                                             */
+/*===========================================================================*/
+
+void test_frame_build_empty_payload_writes_only_command_byte(void) {
+    uint8_t buf[4];
+    size_t out_len = 0;
+
+    bool ok = cwnet_frame_build(0x02 /* DISCONNECT */, NULL, 0, buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(1, out_len);
+    TEST_ASSERT_EQUAL_HEX8(0x02, buf[0]);
+}
+
+void test_frame_build_short_payload_92_bytes(void) {
+    /* Matches send_connect()'s CONNECT frame: cmd=0x41, len=0x5C (92) */
+    uint8_t payload[92];
+    memset(payload, 0, sizeof(payload));
+    uint8_t buf[2 + 92];
+    size_t out_len = 0;
+
+    bool ok = cwnet_frame_build((uint8_t)CWNET_CMD_CONNECT, payload, sizeof(payload),
+                                 buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(94, out_len);
+    TEST_ASSERT_EQUAL_HEX8(0x41, buf[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x5C, buf[1]);
+}
+
+void test_frame_build_long_payload_300_bytes_little_endian_length(void) {
+    uint8_t payload[300];
+    memset(payload, 0x77, sizeof(payload));
+    uint8_t buf[3 + 300];
+    size_t out_len = 0;
+
+    bool ok = cwnet_frame_build(0x11 /* long-block command */, payload, sizeof(payload),
+                                 buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(303, out_len);
+    TEST_ASSERT_EQUAL_HEX8(0x91, buf[0]);  /* cat=10 (long) | cmd=0x11 */
+    TEST_ASSERT_EQUAL_HEX8(0x2C, buf[1]);  /* 300 & 0xFF */
+    TEST_ASSERT_EQUAL_HEX8(0x01, buf[2]);  /* 300 >> 8 */
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(payload, &buf[3], sizeof(payload));
+}
+
+void test_frame_build_buffer_too_small_rejects_without_writing(void) {
+    uint8_t payload[10];
+    memset(payload, 0xAB, sizeof(payload));
+    uint8_t buf[5];
+    memset(buf, 0x00, sizeof(buf));
+    uint8_t sentinel[5];
+    memcpy(sentinel, buf, sizeof(buf));
+    size_t out_len = 0xDEAD;
+
+    bool ok = cwnet_frame_build(0x01, payload, sizeof(payload), buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_FALSE(ok);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(sentinel, buf, sizeof(buf));
+}
+
+/*
+ * DoD: "test_cwnet_frame_parser.c pinna i costruttori sulle intestazioni
+ * delle fixture." The builder must reproduce the reference's TX_INFO bytes
+ * (R3) exactly, byte for byte.
+ */
+void test_frame_build_matches_ref_tx_info_moritz(void) {
+    uint8_t payload[8];
+    payload[0] = 0x01;  /* remote client index 1 */
+    memcpy(&payload[1], "Moritz", 7);  /* 6 chars + NUL */
+
+    uint8_t buf[sizeof(ref_tx_info_moritz)];
+    size_t out_len = 0;
+    bool ok = cwnet_frame_build((uint8_t)CWNET_CMD_TX_INFO, payload, sizeof(payload),
+                                 buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(sizeof(ref_tx_info_moritz), out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_moritz, buf, sizeof(ref_tx_info_moritz));
+}
+
+void test_frame_build_matches_ref_tx_info_nobody(void) {
+    uint8_t payload[14];
+    payload[0] = 0xFF;  /* the key is free */
+    memcpy(&payload[1], "-- nobody --", 13);  /* 12 chars + NUL */
+
+    uint8_t buf[sizeof(ref_tx_info_nobody)];
+    size_t out_len = 0;
+    bool ok = cwnet_frame_build((uint8_t)CWNET_CMD_TX_INFO, payload, sizeof(payload),
+                                 buf, sizeof(buf), &out_len);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(sizeof(ref_tx_info_nobody), out_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, buf, sizeof(ref_tx_info_nobody));
 }

--- a/test_host/test_cwnet_ping.c
+++ b/test_host/test_cwnet_ping.c
@@ -388,3 +388,182 @@ void test_ping_latency_measurement(void) {
     int32_t rtt = cwnet_ping_calc_latency(&response2);
     TEST_ASSERT_EQUAL_INT32(85, rtt);  /* 5085 - 5000 = 85ms */
 }
+
+/*===========================================================================*/
+/* PING REQUEST Building Tests (U2: the daemon as initiator)                 */
+/*===========================================================================*/
+
+void test_ping_build_request_layout(void) {
+    /* CwNet.c:2255-2259 / cwnet_echo.py ping_loop(): id and t0 in an
+     * all-zero 16-byte frame otherwise. AE4: 16 bytes expected exactly. */
+    uint8_t buffer[16];
+    memset(buffer, 0xAA, sizeof(buffer));  /* poison, so untouched bytes show */
+
+    bool ok = cwnet_ping_build_request(1, 12345, buffer, sizeof(buffer));
+    TEST_ASSERT_TRUE(ok);
+
+    static const uint8_t expected[16] = {
+        0x00,                   /* type = REQUEST */
+        0x01,                   /* id = 1 */
+        0x00, 0x00,             /* reserved */
+        0x39, 0x30, 0x00, 0x00, /* t0 = 12345 (LE) */
+        0x00, 0x00, 0x00, 0x00, /* t1 slot = 0 */
+        0x00, 0x00, 0x00, 0x00  /* t2 slot = 0 */
+    };
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, buffer, sizeof(expected));
+
+    /* And it round-trips through the parser */
+    cwnet_ping_t parsed;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&parsed, buffer, sizeof(buffer)));
+    TEST_ASSERT_EQUAL(CWNET_PING_REQUEST, parsed.type);
+    TEST_ASSERT_EQUAL(1, parsed.id);
+    TEST_ASSERT_EQUAL_INT32(12345, parsed.t0_ms);
+    TEST_ASSERT_EQUAL_INT32(0, parsed.t1_ms);
+    TEST_ASSERT_EQUAL_INT32(0, parsed.t2_ms);
+}
+
+void test_ping_build_request_buffer_too_small(void) {
+    uint8_t buffer[15];
+    TEST_ASSERT_FALSE(cwnet_ping_build_request(1, 1000, buffer, sizeof(buffer)));
+}
+
+void test_ping_build_request_null_buffer(void) {
+    TEST_ASSERT_FALSE(cwnet_ping_build_request(1, 1000, NULL, 16));
+}
+
+/*===========================================================================*/
+/* PING RESPONSE_2 Building Tests (U2: the initiator closes the loop)        */
+/*===========================================================================*/
+
+void test_ping_build_response2_from_response1(void) {
+    /* Covers AE4: RESPONSE_2 built from a RESPONSE_1 keeps t0 and t1
+     * intact and writes t2. */
+    cwnet_ping_t response_1 = {
+        .type = CWNET_PING_RESPONSE_1,
+        .id = 7,
+        .t0_ms = 1000,
+        .t1_ms = 1050,
+        .t2_ms = 0
+    };
+
+    uint8_t buffer[16];
+    bool ok = cwnet_ping_build_response2(&response_1, buffer, sizeof(buffer), 1100);
+    TEST_ASSERT_TRUE(ok);
+
+    TEST_ASSERT_EQUAL_HEX8(0x02, buffer[0]);  /* type = RESPONSE_2 */
+    TEST_ASSERT_EQUAL_HEX8(0x07, buffer[1]);  /* id preserved */
+
+    cwnet_ping_t parsed;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&parsed, buffer, sizeof(buffer)));
+    TEST_ASSERT_EQUAL(CWNET_PING_RESPONSE_2, parsed.type);
+    TEST_ASSERT_EQUAL(7, parsed.id);
+    TEST_ASSERT_EQUAL_INT32(1000, parsed.t0_ms);  /* intact */
+    TEST_ASSERT_EQUAL_INT32(1050, parsed.t1_ms);  /* intact */
+    TEST_ASSERT_EQUAL_INT32(1100, parsed.t2_ms);  /* written */
+
+    /* And the latency it now carries is the expected RTT */
+    TEST_ASSERT_EQUAL_INT32(100, cwnet_ping_calc_latency(&parsed));
+}
+
+void test_ping_build_response2_wrong_type(void) {
+    /* Can only build a RESPONSE_2 from a RESPONSE_1 */
+    cwnet_ping_t request = {.type = CWNET_PING_REQUEST, .id = 1, .t0_ms = 1000};
+    uint8_t buffer[16];
+    TEST_ASSERT_FALSE(cwnet_ping_build_response2(&request, buffer, sizeof(buffer), 1100));
+}
+
+void test_ping_build_response2_buffer_too_small(void) {
+    cwnet_ping_t response_1 = {.type = CWNET_PING_RESPONSE_1, .id = 1};
+    uint8_t buffer[15];
+    TEST_ASSERT_FALSE(cwnet_ping_build_response2(&response_1, buffer, sizeof(buffer), 1100));
+}
+
+void test_ping_build_response2_null(void) {
+    uint8_t buffer[16];
+    cwnet_ping_t response_1 = {.type = CWNET_PING_RESPONSE_1};
+
+    TEST_ASSERT_FALSE(cwnet_ping_build_response2(NULL, buffer, 16, 1100));
+    TEST_ASSERT_FALSE(cwnet_ping_build_response2(&response_1, NULL, 16, 1100));
+}
+
+/*===========================================================================*/
+/* Peak-Hold Tests (U2: shared by client and server-to-be)                   */
+/*===========================================================================*/
+
+void test_ping_peak_hold_jumps_to_new_peak(void) {
+    /* An unheld peak (-1 sentinel) takes the first sample outright, and a
+     * higher sample afterwards jumps immediately, matching
+     * CwNet.c:1442-1444. */
+    int32_t peak = -1;
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 100));
+    TEST_ASSERT_EQUAL_INT32(100, peak);
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 200));
+    TEST_ASSERT_EQUAL_INT32(200, peak);
+}
+
+void test_ping_peak_hold_decays_by_tenth_of_gap(void) {
+    /* Plan's scenario: 100 then 200 rises to 200; 100 then drops to 190;
+     * 185 then stays at 190 (gap 5 ms, integer division rounds to 0). */
+    int32_t peak = -1;
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 100));
+    TEST_ASSERT_EQUAL_INT32(100, peak);
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 200));
+    TEST_ASSERT_EQUAL_INT32(200, peak);
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 100));
+    TEST_ASSERT_EQUAL_INT32(190, peak);  /* 200 - (200-100)/10 = 190 */
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 185));
+    TEST_ASSERT_EQUAL_INT32(190, peak);  /* gap 5, 5/10 = 0: unchanged */
+}
+
+void test_ping_peak_hold_null(void) {
+    TEST_ASSERT_FALSE(cwnet_ping_peak_hold_update(NULL, 100));
+}
+
+void test_ping_peak_hold_gate_rejects_over_2000ms(void) {
+    /* R4 / CwNet.c:1437: an RTT of 2001 ms is discarded, peak untouched. */
+    int32_t peak = 500;
+    TEST_ASSERT_FALSE(cwnet_ping_peak_hold_update(&peak, 2001));
+    TEST_ASSERT_EQUAL_INT32(500, peak);
+}
+
+void test_ping_peak_hold_gate_boundary(void) {
+    /* CwNet.c:1437 gates on i32 < 2000000 us, strictly: 2000 ms itself is
+     * outside the window, 1999 ms is inside. */
+    int32_t peak = -1;
+    TEST_ASSERT_FALSE(cwnet_ping_peak_hold_update(&peak, 2000));
+    TEST_ASSERT_EQUAL_INT32(-1, peak);  /* still unheld */
+
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 1999));
+    TEST_ASSERT_EQUAL_INT32(1999, peak);
+}
+
+void test_ping_peak_hold_gate_rejects_negative_rtt_from_wrap(void) {
+    /* R4: a negative RTT from the 31-bit wrap between t0 and t2 (same
+     * scenario as test_ping_calc_latency_wrap) is discarded, peak
+     * untouched -- neither latency nor peak-hold see it. */
+    cwnet_ping_t response = {
+        .type = CWNET_PING_RESPONSE_2,
+        .t0_ms = 2147483600,  /* Near INT32_MAX */
+        .t1_ms = 0,
+        .t2_ms = 100          /* Wrapped around */
+    };
+    int32_t latency = cwnet_ping_calc_latency(&response);
+    TEST_ASSERT_TRUE(latency < 0);
+
+    int32_t peak = 42;
+    TEST_ASSERT_FALSE(cwnet_ping_peak_hold_update(&peak, latency));
+    TEST_ASSERT_EQUAL_INT32(42, peak);
+}
+
+void test_ping_peak_hold_accepts_zero(void) {
+    /* Lower bound is inclusive: CwNet.c:1437 accepts i32 >= 0. */
+    int32_t peak = -1;
+    TEST_ASSERT_TRUE(cwnet_ping_peak_hold_update(&peak, 0));
+    TEST_ASSERT_EQUAL_INT32(0, peak);
+}

--- a/test_host/test_cwnet_play.c
+++ b/test_host/test_cwnet_play.c
@@ -1,0 +1,670 @@
+/**
+ * @file test_cwnet_play.c
+ * @brief The playback engine against the reference capture and the codec
+ *
+ * Every expected instant below is derived BY HAND from the 7-bit waits the
+ * bytes carry (cwnet_timestamp.h, CwStreamEnc.c), never read back from the
+ * engine. The derivation is written out next to each scenario so it can be
+ * checked without redoing it.
+ *
+ * The clock base T0 sits above 2^31 ms on purpose: a 32-bit instant would
+ * wrap there and every assertion would move.
+ */
+
+#include "unity.h"
+#include "cwnet_play.h"
+#include "cwnet_frame.h"
+#include "cwnet_timestamp.h"
+#include "cwnet_fixtures.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Beyond 2^31 - 1 = 2147483647: instants and deadlines are 64-bit */
+#define T0 ((int64_t)4000000000)
+
+#define B_MS 50u
+#define TAIL_MS 100u
+
+/*===========================================================================*/
+/* Harness: a simulated clock, and the events the engine hands back          */
+/*===========================================================================*/
+
+typedef struct {
+    cwnet_play_event_t ev[64];
+    size_t n;
+} evlog_t;
+
+typedef struct {
+    cwnet_play_event_type_t type;
+    int64_t at;
+} exp_ev_t;
+
+static void log_append(evlog_t *log, const cwnet_play_result_t *r) {
+    for (size_t i = 0; i < r->count; i++) {
+        TEST_ASSERT_LESS_THAN_size_t(64u, log->n);
+        log->ev[log->n++] = r->ev[i];
+    }
+}
+
+/**
+ * @brief Run the engine on an ideal scheduler: tick exactly at each deadline
+ */
+static void run_until(cwnet_play_t *play, evlog_t *log, int64_t until_ms) {
+    for (int guard = 0; guard < 500; guard++) {
+        int64_t next = 0;
+        if (!cwnet_play_next_deadline(play, &next) || next > until_ms) {
+            return;
+        }
+        cwnet_play_result_t r;
+        cwnet_play_tick(play, next, &r);
+        log_append(log, &r);
+    }
+    TEST_FAIL_MESSAGE("run_until did not settle");
+}
+
+static const char *ev_name(cwnet_play_event_type_t t) {
+    switch (t) {
+        case CWNET_PLAY_EV_KEY_DOWN:      return "KEY_DOWN";
+        case CWNET_PLAY_EV_KEY_UP:        return "KEY_UP";
+        case CWNET_PLAY_EV_PTT_ON:        return "PTT_ON";
+        case CWNET_PLAY_EV_PTT_OFF:       return "PTT_OFF";
+        case CWNET_PLAY_EV_END_OF_OVER:   return "END_OF_OVER";
+        case CWNET_PLAY_EV_UNDERRUN:      return "UNDERRUN";
+        case CWNET_PLAY_EV_OVER_FINISHED: return "OVER_FINISHED";
+        default:                          return "?";
+    }
+}
+
+static void assert_log(const evlog_t *log, const exp_ev_t *exp, size_t n) {
+    char msg[128];
+    for (size_t i = 0; i < n && i < log->n; i++) {
+        snprintf(msg, sizeof msg, "event %zu: got %s at T0%+lld, want %s at T0%+lld",
+                 i, ev_name(log->ev[i].type), (long long)(log->ev[i].at_ms - T0),
+                 ev_name(exp[i].type), (long long)(exp[i].at - T0));
+        TEST_ASSERT_EQUAL_INT_MESSAGE((int)exp[i].type, (int)log->ev[i].type, msg);
+        TEST_ASSERT_EQUAL_INT64_MESSAGE(exp[i].at, log->ev[i].at_ms, msg);
+    }
+    snprintf(msg, sizeof msg, "event count: got %zu, want %zu", log->n, n);
+    TEST_ASSERT_EQUAL_size_t_MESSAGE(n, log->n, msg);
+}
+
+static size_t count_of(const evlog_t *log, cwnet_play_event_type_t t) {
+    size_t n = 0;
+    for (size_t i = 0; i < log->n; i++) {
+        if (log->ev[i].type == t) {
+            n++;
+        }
+    }
+    return n;
+}
+
+static void push_bytes(cwnet_play_t *play, const uint8_t *bytes, size_t len, int64_t at_ms) {
+    for (size_t i = 0; i < len; i++) {
+        TEST_ASSERT_TRUE(cwnet_play_push(play, bytes[i], at_ms));
+    }
+}
+
+/**
+ * @brief Push the payload of every MORSE frame of a capture slice
+ *
+ * This is the path the daemon walks: capture bytes -> frame parser ->
+ * keying bytes -> engine.
+ */
+static void push_morse_payload(cwnet_play_t *play, const uint8_t *frames, size_t len,
+                               int64_t at_ms) {
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+    size_t off = 0;
+    while (off < len) {
+        cwnet_parse_result_t r = cwnet_frame_parse(&parser, frames + off, len - off);
+        TEST_ASSERT_EQUAL(CWNET_PARSE_OK, r.status);
+        TEST_ASSERT_EQUAL(CWNET_CMD_MORSE, r.command);
+        push_bytes(play, r.payload, r.payload_len, at_ms);
+        off += r.bytes_consumed;
+    }
+}
+
+/**
+ * @brief Push the MORSE bytes of ref_first_over, through the fixture helper
+ *
+ * ref_morse_frames() keeps the MORSE frames of the capture slice and drops
+ * the two rigctld set_ptt frames the reference interleaves: those never
+ * reach this module (R10).
+ */
+static void push_first_over_morse(cwnet_play_t *play, int64_t at_ms) {
+    uint8_t morse[sizeof ref_first_over];
+    size_t len = 0;
+    TEST_ASSERT_TRUE(ref_morse_frames(ref_first_over, sizeof ref_first_over, morse, &len));
+    push_morse_payload(play, morse, len, at_ms);
+}
+
+static void play_setup(cwnet_play_t *play, uint32_t lead_ms, uint32_t buffer_ms) {
+    cwnet_play_cfg_t cfg = { .ptt_lead_ms = lead_ms, .ptt_tail_ms = TAIL_MS };
+    cwnet_play_init(play, &cfg);
+    cwnet_play_start_over(play, buffer_ms);
+}
+
+/*===========================================================================*/
+/* AE2: the first over of the capture                                        */
+/*===========================================================================*/
+
+/*
+ * ref_first_over, session 12 of the 2026-09-05 capture: the letter A at
+ * 25 WPM (dot 48 ms). Its five MORSE bytes and their hand decode:
+ *
+ *   0x80  bit7=1 key down, 0x00 -> linear range        ->    0 ms
+ *   0x24  bit7=0 key up,   0x24 -> 32 + 4*(0x24-0x20)  ->   48 ms
+ *   0xA4  bit7=1 key down, 0x24 -> same                ->   48 ms
+ *   0x3C  bit7=0 key up,   0x3C -> 32 + 4*(0x3C-0x20)  ->  144 ms
+ *   0x60  bit7=0 key up,   0x60 -> 157 + 16*(0x60-0x40) -> 669 ms
+ *
+ * With B = 50 the timeline is, from the instant the first byte arrived:
+ *
+ *   first byte: T0 + wait(0) + B          = T0 +  50  key down
+ *   += 48                                 = T0 +  98  key up
+ *   += 48                                 = T0 + 146  key down
+ *   += 144                                = T0 + 290  key up
+ *   0x60 is the second key-up in a row    = T0 + 290  end of over
+ *   last key-up + tail(100)               = T0 + 390  PTT off, over finished
+ *
+ * B delays the first edge and nothing else: 98 - 50 = 48 is the dot itself.
+ */
+void test_play_first_over_of_the_capture_plays_at_the_encoded_instants(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    push_first_over_morse(&play, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,        T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 98 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 146 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 290 },
+        { CWNET_PLAY_EV_END_OF_OVER,   T0 + 290 },
+        { CWNET_PLAY_EV_PTT_OFF,       T0 + 390 },
+        { CWNET_PLAY_EV_OVER_FINISHED, T0 + 390 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+
+    TEST_ASSERT_FALSE(cwnet_play_key_down(&play));
+    TEST_ASSERT_FALSE(cwnet_play_ptt_on(&play));
+    TEST_ASSERT_FALSE(cwnet_play_over_open(&play));
+}
+
+/*
+ * Same bytes, one late tick: a caller that wakes 1000 ms after the over
+ * started still reports every edge at the instant it belonged to. The
+ * deadline advances by the decoded wait, never by the measured time.
+ */
+void test_play_a_late_tick_does_not_move_the_edges(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    push_first_over_morse(&play, T0);
+
+    evlog_t log = { .n = 0 };
+    cwnet_play_result_t r;
+    cwnet_play_tick(&play, T0 + 1000, &r);
+    log_append(&log, &r);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,        T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 98 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 146 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 290 },
+        { CWNET_PLAY_EV_END_OF_OVER,   T0 + 290 },
+        { CWNET_PLAY_EV_PTT_OFF,       T0 + 390 },
+        { CWNET_PLAY_EV_OVER_FINISHED, T0 + 390 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*
+ * A byte that arrives late, but before the deadline that will consume it,
+ * does not drag the timeline with it: 0xA4 arrives at T0+90 and its edge
+ * still lands 48 ms after the key-up it follows, at T0+146, not at T0+138.
+ */
+void test_play_a_late_byte_does_not_move_the_deadline_it_follows(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t first[] = { 0x80, 0x24 };
+    push_bytes(&play, first, sizeof first, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 50);      /* key down at T0+50 */
+
+    const uint8_t late[] = { 0xA4, 0x24 };
+    push_bytes(&play, late, sizeof late, T0 + 90);
+
+    run_until(&play, &log, T0 + 400);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 98 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 146 },   /* not T0+138: 98 + 48, not 90 + 48 */
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 194 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 294 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*===========================================================================*/
+/* Two keying events per frame, the shape a server sees at speed             */
+/*===========================================================================*/
+
+/*
+ * ref_two_event_frames, session 12 bytes 6982..6989: two frames of two
+ * events each from the fast part of the session (dot about 20 ms).
+ *
+ *   0x96  key down, 0x16 = 22 -> linear ->  22 ms
+ *   0x12  key up,   0x12 = 18 -> linear ->  18 ms
+ *
+ * With B = 0, from the instant they arrived:
+ *   first byte: T0 + wait(22) + B(0) = T0 + 22   key down
+ *   += 18                            = T0 + 40   key up
+ *   += 22                            = T0 + 62   key down
+ *   += 18                            = T0 + 80   key up
+ * and the PTT drops a tail after the last key-up, T0 + 180.
+ */
+void test_play_two_event_frames_play_at_their_encoded_distances(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, 0u);
+
+    push_morse_payload(&play, ref_two_event_frames, sizeof ref_two_event_frames, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 500);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 22 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 22 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 40 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 62 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 80 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 180 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*===========================================================================*/
+/* A wait split over several bytes                                           */
+/*===========================================================================*/
+
+/*
+ * Case C of tools/cwnet/keyer_sim.c, the reference KeyerThread encoding a
+ * 2000 ms gap at dot 240 ms: 80 14 FF EA 21. The gap is longer than one
+ * byte can carry, so the encoder emits it as 1165 + the rest, both bytes
+ * carrying the state the gap ends in (CwStreamEnc.c:135-146).
+ *
+ *   0x80  key down, 0x00                                ->    0 ms
+ *   0x14  key up,   0x14 = 20 -> linear                 ->   20 ms
+ *   0xFF  key down, 0x7F -> 157 + 16*(0x7F-0x40) = 1165 -> 1165 ms, split
+ *   0xEA  key down, 0x6A -> 157 + 16*(0x6A-0x40)        ->  829 ms
+ *   0x21  key up,   0x21 -> 32 + 4*(0x21-0x20)          ->   36 ms
+ *
+ * The split carries ONE edge, after the sum: 1165 + 829 = 1994.
+ *   first byte: T0 + 0 + B(50)  = T0 +   50  key down
+ *   += 20                       = T0 +   70  key up
+ *   += 1165 (no edge, split)    = T0 + 1235
+ *   += 829                      = T0 + 2064  key down   (= 70 + 1994)
+ *   += 36                       = T0 + 2100  key up
+ *
+ * The PTT drops a tail after each key-up and rises again with the key:
+ * T0+170, then T0+2064, then T0+2200.
+ */
+void test_play_a_split_wait_makes_one_edge_after_the_sum(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t case_c[] = { 0x80, 0x14, 0xFF, 0xEA, 0x21 };
+    push_bytes(&play, case_c, sizeof case_c, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 3000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 70 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 170 },
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 2064 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 2064 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 2100 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 2200 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+
+    /* Two key-downs, not three: the 1165 ms byte is not an edge of its own */
+    TEST_ASSERT_EQUAL_size_t(2u, count_of(&log, CWNET_PLAY_EV_KEY_DOWN));
+    /* Two key-downs in a row are never an end of over */
+    TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_END_OF_OVER));
+}
+
+/*===========================================================================*/
+/* AE6: the FIFO runs dry under a key-down                                   */
+/*===========================================================================*/
+
+/*
+ * One key-down byte and nothing else. At T0 + B the key goes down, the
+ * FIFO is empty, and the length of that element is unknown: the key goes
+ * up at once and the underrun is reported. The PTT drops a tail later,
+ * T0 + 50 + 100 = T0 + 150. The over is not finished: no marker was
+ * played, and the bytes that follow restart it.
+ */
+void test_play_underrun_lifts_the_key_at_once_and_reports_it(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t only_down[] = { 0x80 };
+    push_bytes(&play, only_down, sizeof only_down, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 500);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 50 },
+        { CWNET_PLAY_EV_UNDERRUN, T0 + 50 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 150 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+
+    TEST_ASSERT_FALSE(cwnet_play_key_down(&play));
+    TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_OVER_FINISHED));
+}
+
+/*
+ * After the underrun the bytes that follow restart as a new over with the
+ * SAME B, without the caller arming anything: a byte received at T0+500
+ * keys down at T0+550, and its dot still lasts its encoded 48 ms.
+ */
+void test_play_after_an_underrun_the_next_byte_restarts_with_the_same_buffer(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t only_down[] = { 0x80 };
+    push_bytes(&play, only_down, sizeof only_down, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 400);
+    log.n = 0;   /* the underrun itself is pinned by the test above */
+
+    const uint8_t again[] = { 0x80, 0x24 };
+    push_bytes(&play, again, sizeof again, T0 + 500);
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 550 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 550 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 598 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 698 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*===========================================================================*/
+/* End of over                                                               */
+/*===========================================================================*/
+
+/*
+ * Two consecutive key-up bytes end the over, and the second one is not
+ * waited out: 0x80, 0x24, 0x24 gives key down at T0+50, key up at T0+98,
+ * and the end of over at T0+98 even though the last byte carries 48 ms.
+ * The key is released when the PTT has dropped, T0+198.
+ */
+void test_play_end_of_over_does_not_wait_out_the_marker(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t bytes[] = { 0x80, 0x24, 0x24 };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,        T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 98 },
+        { CWNET_PLAY_EV_END_OF_OVER,   T0 + 98 },
+        { CWNET_PLAY_EV_PTT_OFF,       T0 + 198 },
+        { CWNET_PLAY_EV_OVER_FINISHED, T0 + 198 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*
+ * Key-ups separated by a key-down are ordinary keying, not an end of over:
+ * 0x80 0x24 0xA4 0x24 plays four edges and leaves the over open.
+ */
+void test_play_key_ups_split_by_a_key_down_are_not_an_end_of_over(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t bytes[] = { 0x80, 0x24, 0xA4, 0x24 };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 98 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 146 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 194 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 294 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+    TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_END_OF_OVER));
+    TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_OVER_FINISHED));
+}
+
+/*===========================================================================*/
+/* PTT lead                                                                  */
+/*===========================================================================*/
+
+/*
+ * A 20 ms lead with B = 50: the first key-down is known 50 ms ahead, so
+ * the PTT can rise at T0 + 50 - 20 = T0 + 30 and the key still goes down
+ * at T0 + 50.
+ */
+void test_play_ptt_lead_raises_the_ptt_before_the_first_key_down(void) {
+    cwnet_play_t play;
+    play_setup(&play, 20u, B_MS);
+
+    const uint8_t bytes[] = { 0x80, 0x24 };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+
+    int64_t next = 0;
+    TEST_ASSERT_TRUE(cwnet_play_next_deadline(&play, &next));
+    TEST_ASSERT_EQUAL_INT64(T0 + 30, next);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 30 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 98 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 198 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*
+ * A lead longer than B would put the PTT before the byte arrived: it is
+ * clamped to B, so with lead 80 and B 50 the PTT rises at T0 exactly.
+ */
+void test_play_ptt_lead_is_clamped_to_the_buffer(void) {
+    cwnet_play_t play;
+    play_setup(&play, 80u, B_MS);
+
+    const uint8_t bytes[] = { 0x80, 0x24 };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 0 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 98 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 198 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*===========================================================================*/
+/* Back pressure and the safety nets                                         */
+/*===========================================================================*/
+
+/*
+ * The FIFO holds CWNET_PLAY_FIFO_SIZE bytes, the reference's size. What
+ * does not fit is dropped and counted, and nothing spurious comes out.
+ */
+void test_play_a_full_fifo_drops_the_byte_and_counts_it(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    /* The byte being played is held outside the FIFO, so the queue takes
+     * CWNET_PLAY_FIFO_SIZE more once the over is anchored. */
+    for (size_t i = 0; i <= CWNET_PLAY_FIFO_SIZE; i++) {
+        uint8_t b = (i == 0) ? 0x80u : ((i & 1u) ? 0x24u : 0xA4u);
+        TEST_ASSERT_TRUE(cwnet_play_push(&play, b, T0));
+    }
+    TEST_ASSERT_FALSE(cwnet_play_push(&play, 0x24u, T0));
+    TEST_ASSERT_FALSE(cwnet_play_push(&play, 0xA4u, T0));
+    TEST_ASSERT_EQUAL_UINT32(2u, cwnet_play_dropped(&play));
+
+    /* Nothing is due before the first deadline at T0 + B */
+    cwnet_play_result_t r;
+    cwnet_play_tick(&play, T0 + 49, &r);
+    TEST_ASSERT_EQUAL_size_t(0u, r.count);
+}
+
+/*
+ * force_release with the key down: up at once, and the PTT down a tail
+ * later. This is the shape U3 needs when the holder's TCP dies mid-over.
+ */
+void test_play_force_release_lifts_the_key_and_drops_the_ptt_at_the_tail(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t bytes[] = { 0x80, 0x3C };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 60);
+    TEST_ASSERT_TRUE(cwnet_play_key_down(&play));
+
+    cwnet_play_result_t r;
+    cwnet_play_force_release(&play, T0 + 100, &r);
+    log_append(&log, &r);
+
+    run_until(&play, &log, T0 + 1000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,        T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN,      T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,        T0 + 100 },
+        { CWNET_PLAY_EV_PTT_OFF,       T0 + 200 },
+        { CWNET_PLAY_EV_OVER_FINISHED, T0 + 200 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+    TEST_ASSERT_FALSE(cwnet_play_over_open(&play));
+}
+
+/*
+ * force_release on an engine that is not playing: nothing on the key,
+ * nothing on the PTT, the over is finished there and then.
+ */
+void test_play_force_release_when_idle_finishes_the_over_at_once(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    cwnet_play_result_t r;
+    cwnet_play_force_release(&play, T0 + 7, &r);
+
+    TEST_ASSERT_EQUAL_size_t(1u, r.count);
+    TEST_ASSERT_EQUAL_INT(CWNET_PLAY_EV_OVER_FINISHED, (int)r.ev[0].type);
+    TEST_ASSERT_EQUAL_INT64(T0 + 7, r.ev[0].at_ms);
+
+    int64_t next = 0;
+    TEST_ASSERT_FALSE(cwnet_play_next_deadline(&play, &next));
+}
+
+/*
+ * start_over fixes B for the over and throws away what was queued: the
+ * bytes of an interrupted over never leak into the next one.
+ */
+void test_play_start_over_fixes_the_buffer_and_clears_the_queue(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t stale[] = { 0x80, 0x24, 0xA4 };
+    push_bytes(&play, stale, sizeof stale, T0);
+
+    cwnet_play_start_over(&play, 200u);
+    int64_t next = 0;
+    TEST_ASSERT_FALSE(cwnet_play_next_deadline(&play, &next));
+
+    const uint8_t fresh[] = { 0x80, 0x24 };
+    push_bytes(&play, fresh, sizeof fresh, T0 + 1000);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 3000);
+
+    /* B = 200 now: T0+1000 + 0 + 200, then the dot's own 48 ms */
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 1200 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 1200 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 1248 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 1348 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+}
+
+/*
+ * Every entry point survives a NULL engine and reports nothing.
+ */
+void test_play_survives_null_and_reports_nothing(void) {
+    cwnet_play_result_t r;
+    int64_t next = 0;
+
+    cwnet_play_init(NULL, NULL);
+    cwnet_play_start_over(NULL, 50u);
+    TEST_ASSERT_FALSE(cwnet_play_push(NULL, 0x80u, T0));
+    TEST_ASSERT_FALSE(cwnet_play_next_deadline(NULL, &next));
+    cwnet_play_tick(NULL, T0, &r);
+    cwnet_play_force_release(NULL, T0, &r);
+    TEST_ASSERT_FALSE(cwnet_play_key_down(NULL));
+    TEST_ASSERT_FALSE(cwnet_play_ptt_on(NULL));
+    TEST_ASSERT_FALSE(cwnet_play_over_open(NULL));
+    TEST_ASSERT_EQUAL_UINT32(0u, cwnet_play_dropped(NULL));
+
+    cwnet_play_t play;
+    cwnet_play_init(&play, NULL);   /* NULL cfg -> defaults */
+    TEST_ASSERT_FALSE(cwnet_play_next_deadline(&play, NULL));
+    cwnet_play_tick(&play, T0, NULL);
+
+    /* The default tail is the box's 100 ms */
+    cwnet_play_start_over(&play, B_MS);
+    const uint8_t bytes[] = { 0x80, 0x24 };
+    push_bytes(&play, bytes, sizeof bytes, T0);
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 1000);
+    TEST_ASSERT_EQUAL_size_t(4u, log.n);
+    TEST_ASSERT_EQUAL_INT(CWNET_PLAY_EV_PTT_OFF, (int)log.ev[3].type);
+    TEST_ASSERT_EQUAL_INT64(T0 + 198, log.ev[3].at_ms);
+}

--- a/test_host/test_cwnet_play.c
+++ b/test_host/test_cwnet_play.c
@@ -349,6 +349,56 @@ void test_play_a_split_wait_makes_one_edge_after_the_sum(void) {
     TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_END_OF_OVER));
 }
 
+/*
+ * The other half of the split: an ELEMENT longer than one byte can carry.
+ * Holding the key down to tune is ordinary practice, and at 1994 ms the
+ * key-up edge that closes it does not fit one byte either. send_morse()
+ * splits it exactly as CwStream_EncodeKeyUpDownEvent does — a full chunk
+ * of 1165 ms, then the remainder — and both chunks carry the state the
+ * wait ends in, up (cwnet_client.c:157-186).
+ *
+ *   0x80  key down, 0x00                                 ->    0 ms
+ *   0x7F  key up,   0x7F -> 157 + 16*(0x7F-0x40) = 1165  -> 1165 ms, split
+ *   0x6A  key up,   0x6A -> 157 + 16*(0x6A-0x40)         ->  829 ms
+ *
+ * Two key-up bytes in a row, and they are NOT the end-of-over marker: the
+ * first spends its time in the state the key is already in, so the single
+ * edge lands after the sum, 1165 + 829 = 1994.
+ *
+ *   first byte: T0 + 0 + B(50)   = T0 +   50  key down
+ *   += 1165 (no edge, split)     = T0 + 1215
+ *   += 829                       = T0 + 2044  key up   (= 50 + 1994)
+ *   last key-up + tail(100)      = T0 + 2144  PTT off
+ *
+ * Taken for an end of over at T0+1215 instead, the over goes to CLOSING
+ * with the key still down, the PTT still up and nothing scheduled: the
+ * carrier stays on air until something outside this module notices.
+ */
+void test_play_a_key_down_longer_than_one_byte_is_not_an_end_of_over(void) {
+    cwnet_play_t play;
+    play_setup(&play, 0u, B_MS);
+
+    const uint8_t long_down[] = { 0x80, 0x7F, 0x6A };
+    push_bytes(&play, long_down, sizeof long_down, T0);
+
+    evlog_t log = { .n = 0 };
+    run_until(&play, &log, T0 + 3000);
+
+    const exp_ev_t want[] = {
+        { CWNET_PLAY_EV_PTT_ON,   T0 + 50 },
+        { CWNET_PLAY_EV_KEY_DOWN, T0 + 50 },
+        { CWNET_PLAY_EV_KEY_UP,   T0 + 2044 },
+        { CWNET_PLAY_EV_PTT_OFF,  T0 + 2144 },
+    };
+    assert_log(&log, want, sizeof want / sizeof want[0]);
+
+    /* One edge for one element, and no end of over anywhere near it */
+    TEST_ASSERT_EQUAL_size_t(1u, count_of(&log, CWNET_PLAY_EV_KEY_UP));
+    TEST_ASSERT_EQUAL_size_t(0u, count_of(&log, CWNET_PLAY_EV_END_OF_OVER));
+    TEST_ASSERT_FALSE(cwnet_play_key_down(&play));
+    TEST_ASSERT_FALSE(cwnet_play_ptt_on(&play));
+}
+
 /*===========================================================================*/
 /* AE6: the FIFO runs dry under a key-down                                   */
 /*===========================================================================*/
@@ -667,4 +717,65 @@ void test_play_survives_null_and_reports_nothing(void) {
     TEST_ASSERT_EQUAL_size_t(4u, log.n);
     TEST_ASSERT_EQUAL_INT(CWNET_PLAY_EV_PTT_OFF, (int)log.ev[3].type);
     TEST_ASSERT_EQUAL_INT64(T0 + 198, log.ev[3].at_ms);
+}
+
+/*===========================================================================*/
+/* The invariant: the engine never comes to rest with the key down           */
+/*===========================================================================*/
+
+/**
+ * @brief Tick once, then check the one state that must never exist
+ *
+ * A key that is down with nothing scheduled is a carrier nobody will ever
+ * lower: no byte sequence may leave the engine there (ARCHITECTURE.md 8.1,
+ * corrupted timing is worse than silence, and a stuck carrier is worse
+ * than both).
+ */
+static void tick_and_check_invariant(cwnet_play_t *play, int64_t now_ms) {
+    cwnet_play_result_t r;
+    cwnet_play_tick(play, now_ms, &r);
+
+    int64_t next = 0;
+    bool scheduled = cwnet_play_next_deadline(play, &next);
+    if (cwnet_play_key_down(play) && !scheduled) {
+        char msg[128];
+        snprintf(msg, sizeof msg, "key down at T0%+lld with nothing scheduled",
+                 (long long)(now_ms - T0));
+        TEST_FAIL_MESSAGE(msg);
+    }
+}
+
+/*
+ * The sequences this file pins, plus the reference's own slow end of over
+ * (keyer_sim.c case F, 80 31 7F 44), each ticked at every millisecond of
+ * its span. The engine is allowed to key down, to underrun, to close and
+ * to stall for want of bytes; it is never allowed to stop with the key
+ * down and no deadline in the diary.
+ */
+void test_play_never_comes_to_rest_with_the_key_down(void) {
+    static const uint8_t long_down[]   = { 0x80, 0x7F, 0x6A };              /* 1994 ms down */
+    static const uint8_t split_gap[]   = { 0x80, 0x14, 0xFF, 0xEA, 0x21 };  /* 1994 ms up */
+    static const uint8_t end_of_over[] = { 0x80, 0x24, 0x24 };
+    static const uint8_t starved[]     = { 0x80 };
+    static const uint8_t slow_eoo[]    = { 0x80, 0x31, 0x7F, 0x44 };
+
+    const struct {
+        const uint8_t *bytes;
+        size_t len;
+    } cases[] = {
+        { long_down,   sizeof long_down },
+        { split_gap,   sizeof split_gap },
+        { end_of_over, sizeof end_of_over },
+        { starved,     sizeof starved },
+        { slow_eoo,    sizeof slow_eoo },
+    };
+
+    for (size_t c = 0; c < sizeof cases / sizeof cases[0]; c++) {
+        cwnet_play_t play;
+        play_setup(&play, 0u, B_MS);
+        push_bytes(&play, cases[c].bytes, cases[c].len, T0);
+        for (int64_t t = T0; t <= T0 + 2400; t++) {
+            tick_and_check_invariant(&play, t);
+        }
+    }
 }

--- a/test_host/test_cwnet_server.c
+++ b/test_host/test_cwnet_server.c
@@ -815,6 +815,33 @@ void test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak(void) {
 /* R6: the safety nets                                                       */
 /*===========================================================================*/
 
+/*
+ * A holder that vanishes inside the buffer B, before a single edge has been
+ * played, leaves no PTT raised — so the playback engine finishes the over
+ * inside the very call that forces the release, and the key is free before
+ * the fault is emitted. The fault must still name the client that had the
+ * key: that line is how the operator learns who dropped, and "nobody
+ * dropped" tells him nothing.
+ */
+void test_server_a_holder_lost_inside_the_buffer_is_still_named_in_the_fault(void) {
+    server_setup();
+    int holder = ready_client("Moritz", "Moritz", 1000);
+
+    /* The key is taken at 2000; with B at the floor nothing plays until 2050 */
+    cwnet_server_on_data(&srv, holder, morse_key_down_held, sizeof(morse_key_down_held),
+                         2000, &res);
+    TEST_ASSERT_EQUAL_INT(holder, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_FALSE(cwnet_server_ptt_on(&srv));
+
+    cwnet_server_on_disconnected(&srv, holder, 2020, &res);
+
+    const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
+    TEST_ASSERT_NOT_NULL(fault);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_HOLDER_GONE, fault->value);
+    TEST_ASSERT_EQUAL_INT(holder, fault->client_idx);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+}
+
 void test_server_the_holder_disconnecting_frees_the_key_for_the_others(void) {
     server_setup();
     int first = ready_client("Moritz", "Moritz", 1000);
@@ -834,6 +861,9 @@ void test_server_the_holder_disconnecting_frees_the_key_for_the_others(void) {
     const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
     TEST_ASSERT_NOT_NULL(fault);
     TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_HOLDER_GONE, fault->value);
+    /* The fault names the client that lost the key, not the emptiness left
+     * behind: the daemon prints this line and the operator has to know who. */
+    TEST_ASSERT_EQUAL_INT(first, fault->client_idx);
     TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_KEY_UP));
     TEST_ASSERT_EQUAL_INT64(2200, event_first(CWNET_SERVER_EV_KEY_UP)->at_ms);
 

--- a/test_host/test_cwnet_server.c
+++ b/test_host/test_cwnet_server.c
@@ -1,0 +1,962 @@
+/**
+ * @file test_cwnet_server.c
+ * @brief The station server's core, against the 2026-09-05 capture
+ *
+ * The server is a pure state machine: no socket, no clock, no log. Here it
+ * is fed the bytes a real client sends and its answers are compared with
+ * the bytes the reference server put on the wire (cwnet_fixtures.h) or
+ * with the layout its source documents. Nothing is compared with what the
+ * implementation happens to produce.
+ */
+
+#include "unity.h"
+
+#include "cwnet_fixtures.h"
+#include "cwnet_frame.h"
+#include "cwnet_ping.h"
+#include "cwnet_play.h"
+#include "cwnet_server.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/*===========================================================================*/
+/* Fake wire: one buffer per client index                                    */
+/*===========================================================================*/
+
+#define FAKE_CLIENTS (CWNET_SERVER_MAX_CLIENTS + 1)
+#define FAKE_TX_SIZE 4096
+
+static cwnet_server_t srv;
+static cwnet_server_result_t res;
+
+static uint8_t fake_tx[FAKE_CLIENTS][FAKE_TX_SIZE];
+static size_t fake_tx_len[FAKE_CLIENTS];
+static bool fake_send_fails;
+
+static int fake_send(int client_idx, const uint8_t *data, size_t len, void *user_data) {
+    (void)user_data;
+    if (fake_send_fails) {
+        return -1;
+    }
+    TEST_ASSERT_TRUE(client_idx >= CWNET_SERVER_FIRST_CLIENT && client_idx < FAKE_CLIENTS);
+    size_t s = (size_t)client_idx;
+    TEST_ASSERT_TRUE(fake_tx_len[s] + len <= FAKE_TX_SIZE);
+    memcpy(fake_tx[s] + fake_tx_len[s], data, len);
+    fake_tx_len[s] += len;
+    return (int)len;
+}
+
+static void wire_clear(void) {
+    memset(fake_tx, 0, sizeof(fake_tx));
+    memset(fake_tx_len, 0, sizeof(fake_tx_len));
+}
+
+static const uint8_t *wire(int client_idx) {
+    return fake_tx[(size_t)client_idx];
+}
+
+static size_t wire_len(int client_idx) {
+    return fake_tx_len[(size_t)client_idx];
+}
+
+/**
+ * @brief The nth frame with this command on a client's wire, header included
+ *
+ * Walks the bytes the server sent with the real parser, so a test compares
+ * whole frames with a fixture, not payloads it reassembled itself.
+ *
+ * @param nth 0 for the first, 1 for the second, SIZE_MAX for the last
+ */
+static bool wire_frame(int client_idx, uint8_t cmd, size_t nth,
+                       uint8_t *out, size_t out_size, size_t *out_len) {
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+    const uint8_t *buf = wire(client_idx);
+    size_t len = wire_len(client_idx);
+    size_t off = 0;
+    size_t seen = 0;
+    bool found = false;
+    while (off < len) {
+        cwnet_parse_result_t r = cwnet_frame_parse(&parser, buf + off, len - off);
+        if (r.status != CWNET_PARSE_OK) {
+            break;
+        }
+        if (r.command == cmd) {
+            if (seen == nth || nth == SIZE_MAX) {
+                TEST_ASSERT_TRUE(r.bytes_consumed <= out_size);
+                memcpy(out, buf + off, r.bytes_consumed);
+                *out_len = r.bytes_consumed;
+                found = true;
+                if (nth != SIZE_MAX) {
+                    return true;
+                }
+            }
+            seen++;
+        }
+        off += r.bytes_consumed;
+        cwnet_frame_parser_reset(&parser);
+    }
+    return found;
+}
+
+/** How many frames with this command the server sent to a client */
+static size_t wire_frame_count(int client_idx, uint8_t cmd) {
+    cwnet_frame_parser_t parser;
+    cwnet_frame_parser_init(&parser);
+    const uint8_t *buf = wire(client_idx);
+    size_t len = wire_len(client_idx);
+    size_t off = 0;
+    size_t seen = 0;
+    while (off < len) {
+        cwnet_parse_result_t r = cwnet_frame_parse(&parser, buf + off, len - off);
+        if (r.status != CWNET_PARSE_OK) {
+            break;
+        }
+        if (r.command == cmd) {
+            seen++;
+        }
+        off += r.bytes_consumed;
+        cwnet_frame_parser_reset(&parser);
+    }
+    return seen;
+}
+
+/*===========================================================================*/
+/* Reading the result                                                        */
+/*===========================================================================*/
+
+static size_t event_count(cwnet_server_event_type_t type) {
+    size_t n = 0;
+    for (size_t i = 0; i < res.count; i++) {
+        if (res.ev[i].type == type) {
+            n++;
+        }
+    }
+    return n;
+}
+
+static const cwnet_server_event_t *event_nth(cwnet_server_event_type_t type, size_t nth) {
+    size_t seen = 0;
+    for (size_t i = 0; i < res.count; i++) {
+        if (res.ev[i].type == type) {
+            if (seen == nth) {
+                return &res.ev[i];
+            }
+            seen++;
+        }
+    }
+    return NULL;
+}
+
+static const cwnet_server_event_t *event_first(cwnet_server_event_type_t type) {
+    return event_nth(type, 0);
+}
+
+/*===========================================================================*/
+/* Building what a client sends                                              */
+/*===========================================================================*/
+
+/**
+ * @brief The bytes a client's CONNECT is, from its two fields
+ *
+ * The capture holds no client-to-server CONNECT to copy (the plan says the
+ * record is rebuilt from its layout): 44 bytes of user name, 44 of
+ * callsign, 4 of permissions, zero from the client. What comes back is
+ * what gets compared with the capture.
+ */
+static size_t build_connect(uint8_t *out, size_t out_size,
+                            const char *username, const char *callsign,
+                            size_t payload_len) {
+    uint8_t payload[CWNET_CONNECT_PAYLOAD_LEN];
+    memset(payload, 0, sizeof(payload));
+    memcpy(payload, username, strlen(username));
+    memcpy(payload + CWNET_CONNECT_USERNAME_LEN, callsign, strlen(callsign));
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(cwnet_frame_build((uint8_t)CWNET_CMD_CONNECT, payload, payload_len,
+                                       out, out_size, &frame_len));
+    return frame_len;
+}
+
+/** One frame around a payload, as a client would put it on the wire */
+static size_t build_frame(uint8_t *out, size_t out_size, uint8_t cmd,
+                          const void *payload, size_t payload_len) {
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(cwnet_frame_build(cmd, (const uint8_t *)payload, payload_len,
+                                       out, out_size, &frame_len));
+    return frame_len;
+}
+
+/**
+ * @brief A key-down that stays down: one MORSE frame of two capture bytes
+ *
+ * 0x80 is the key-down with wait 0 that opens ref_first_over, 0x60 the
+ * key-up after 669 ms that closes it. Between them the played key stays
+ * down, which is what a safety-net test needs: a lone key-down byte is an
+ * underrun by design (R8), and the engine lifts it at once.
+ */
+static const uint8_t morse_key_down_held[] = { 0x50, 0x02, 0x80, 0x60 };
+
+/*===========================================================================*/
+/* Setup helpers                                                             */
+/*===========================================================================*/
+
+static void server_setup_cfg(const cwnet_server_cfg_t *cfg) {
+    wire_clear();
+    fake_send_fails = false;
+    TEST_ASSERT_TRUE(cwnet_server_init(&srv, cfg));
+}
+
+static void server_setup(void) {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.send_cb = fake_send;
+    cfg.user_data = NULL;
+    server_setup_cfg(&cfg);
+}
+
+/** A connected client that has completed its CONNECT; the wire is cleared */
+static int ready_client(const char *username, const char *callsign, int64_t now_ms) {
+    int idx = cwnet_server_on_connected(&srv, now_ms, &res);
+    TEST_ASSERT_TRUE(idx >= CWNET_SERVER_FIRST_CLIENT);
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), username, callsign,
+                               CWNET_CONNECT_PAYLOAD_LEN);
+    cwnet_server_on_data(&srv, idx, connect, len, now_ms, &res);
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+    wire_clear();
+    return idx;
+}
+
+/**
+ * @brief One complete PING exchange, so a client ends with a known peak-hold
+ *
+ * The server is the initiator (R4): poll makes the REQUEST, the test
+ * answers it as the client would with cwnet_ping_build_response(), and the
+ * answer arrives rtt_ms later.
+ */
+static void ping_exchange(int idx, int64_t request_at_ms, int32_t rtt_ms) {
+    cwnet_server_poll(&srv, request_at_ms, &res);
+
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_PING, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    cwnet_ping_t request;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&request, frame + 2, frame_len - 2));
+    TEST_ASSERT_EQUAL_INT(CWNET_PING_REQUEST, request.type);
+
+    uint8_t payload[CWNET_PING_PAYLOAD_SIZE];
+    TEST_ASSERT_TRUE(cwnet_ping_build_response(&request, payload, sizeof(payload),
+                                               request.t0_ms + rtt_ms / 2));
+    uint8_t reply[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t reply_len = build_frame(reply, sizeof(reply), (uint8_t)CWNET_CMD_PING,
+                                   payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, reply, reply_len, request_at_ms + rtt_ms, &res);
+}
+
+/*===========================================================================*/
+/* R2: the log-in, byte for byte against the capture                         */
+/*===========================================================================*/
+
+void test_server_connect_echo_matches_the_capture(void) {
+    server_setup();
+
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_FIRST_CLIENT, idx);
+
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), "Moritz", "Moritz",
+                               CWNET_CONNECT_PAYLOAD_LEN);
+    cwnet_server_on_data(&srv, idx, connect, len, 1000, &res);
+
+    /* The echo, with the permissions filled in: session 10 of the capture */
+    TEST_ASSERT_TRUE(wire_len(idx) >= sizeof(ref_connect_echo));
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_connect_echo, wire(idx), sizeof(ref_connect_echo));
+
+    /* Then the welcome, then the state of the key */
+    uint8_t frame[128];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_SERVER_CMD_PRINT, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_UINT8(0u, frame[frame_len - 1]);   /* the NUL goes on the wire */
+    TEST_ASSERT_NOT_NULL(strstr((const char *)frame + 2, "Welcome Moritz"));
+
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_nobody), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, frame, sizeof(ref_tx_info_nobody));
+
+    TEST_ASSERT_EQUAL_size_t(1u, event_count(CWNET_SERVER_EV_CLIENT_READY));
+    TEST_ASSERT_EQUAL_INT(idx, event_first(CWNET_SERVER_EV_CLIENT_READY)->client_idx);
+}
+
+void test_server_connect_of_the_wrong_length_closes_the_client(void) {
+    server_setup();
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), "Moritz", "Moritz",
+                               CWNET_CONNECT_PAYLOAD_LEN - 1);
+    cwnet_server_on_data(&srv, idx, connect, len, 1000, &res);
+
+    TEST_ASSERT_EQUAL_size_t(0u, wire_len(idx));
+    TEST_ASSERT_FALSE(cwnet_server_client_ready(&srv, idx));
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_BAD_CONNECT, ev->value);
+}
+
+void test_server_connect_arriving_one_byte_at_a_time_still_logs_in(void) {
+    server_setup();
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), "Moritz", "Moritz",
+                               CWNET_CONNECT_PAYLOAD_LEN);
+    for (size_t i = 0; i < len; i++) {
+        cwnet_server_on_data(&srv, idx, connect + i, 1u, 1000, &res);
+    }
+
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+    TEST_ASSERT_TRUE(wire_len(idx) >= sizeof(ref_connect_echo));
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_connect_echo, wire(idx), sizeof(ref_connect_echo));
+}
+
+void test_server_an_empty_callsign_is_announced_as_nocall(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "", 1000);
+
+    TEST_ASSERT_EQUAL_STRING("NoCall #1", cwnet_server_client_name(&srv, idx));
+
+    /* And that is what goes out when it takes the key */
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, idx, morse, sizeof(morse), 2000, &res);
+
+    uint8_t frame[64];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_UINT8(0x45u, frame[0]);
+    TEST_ASSERT_EQUAL_UINT8(1u, frame[2]);   /* the client index, from 1 */
+    TEST_ASSERT_EQUAL_STRING("NoCall #1", (const char *)frame + 3);
+}
+
+void test_server_connect_fields_without_a_nul_are_read_no_further(void) {
+    server_setup();
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+
+    /* Both 44-byte fields filled to the brim: no terminator anywhere */
+    uint8_t payload[CWNET_CONNECT_PAYLOAD_LEN];
+    memset(payload, 'X', CWNET_CONNECT_USERNAME_LEN);
+    memset(payload + CWNET_CONNECT_USERNAME_LEN, 'Y', CWNET_CONNECT_CALLSIGN_LEN);
+    memset(payload + CWNET_CONNECT_PERMISSIONS_OFFSET, 0, 4);
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_frame(connect, sizeof(connect), (uint8_t)CWNET_CMD_CONNECT,
+                             payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, connect, len, 1000, &res);
+
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+    const char *name = cwnet_server_client_name(&srv, idx);
+    TEST_ASSERT_EQUAL_size_t((size_t)CWNET_CONNECT_CALLSIGN_LEN, strlen(name));
+    for (size_t i = 0; i < strlen(name); i++) {
+        TEST_ASSERT_EQUAL_CHAR('Y', name[i]);
+    }
+
+    /* The announcement carries it terminated, and nothing beyond it */
+    uint8_t frame[128];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_UINT8(0u, frame[frame_len - 1]);
+}
+
+/*===========================================================================*/
+/* R1: the client table                                                      */
+/*===========================================================================*/
+
+void test_server_a_connection_past_the_limit_is_accepted_and_closed(void) {
+    server_setup();
+
+    int idx[CWNET_SERVER_DEFAULT_MAX_CLIENTS];
+    for (unsigned i = 0; i < CWNET_SERVER_DEFAULT_MAX_CLIENTS; i++) {
+        idx[i] = ready_client("Moritz", "Moritz", 1000);
+        TEST_ASSERT_EQUAL_INT((int)i + CWNET_SERVER_FIRST_CLIENT, idx[i]);
+    }
+
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NO_SLOT, cwnet_server_on_connected(&srv, 1000, &res));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_NO_SLOT, ev->value);
+
+    /* The four that were already in are untouched */
+    TEST_ASSERT_EQUAL_size_t((size_t)CWNET_SERVER_DEFAULT_MAX_CLIENTS,
+                             cwnet_server_client_count(&srv));
+    for (unsigned i = 0; i < CWNET_SERVER_DEFAULT_MAX_CLIENTS; i++) {
+        TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx[i]));
+    }
+}
+
+/*===========================================================================*/
+/* R16: the timeouts                                                         */
+/*===========================================================================*/
+
+void test_server_a_client_that_never_logs_in_is_closed(void) {
+    server_setup();
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), "Moritz", "Moritz",
+                               CWNET_CONNECT_PAYLOAD_LEN);
+    cwnet_server_on_data(&srv, idx, connect, 1u, 1000, &res);   /* one byte, then silence */
+    (void)len;
+
+    cwnet_server_poll(&srv, 1000 + CWNET_SERVER_DEFAULT_HANDSHAKE_MS - 1, &res);
+    TEST_ASSERT_EQUAL_size_t(1u, cwnet_server_client_count(&srv));
+
+    cwnet_server_poll(&srv, 1000 + CWNET_SERVER_DEFAULT_HANDSHAKE_MS, &res);
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_HANDSHAKE, ev->value);
+}
+
+void test_server_three_unanswered_pings_close_the_client(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    for (unsigned n = 1; n <= CWNET_SERVER_PING_MISSES; n++) {
+        cwnet_server_poll(&srv, 1000 + (int64_t)n * CWNET_SERVER_DEFAULT_PING_INTERVAL_MS, &res);
+        TEST_ASSERT_EQUAL_size_t(1u, cwnet_server_client_count(&srv));
+    }
+    TEST_ASSERT_EQUAL_size_t((size_t)CWNET_SERVER_PING_MISSES,
+                             wire_frame_count(idx, (uint8_t)CWNET_CMD_PING));
+
+    cwnet_server_poll(&srv,
+                      1000 + (int64_t)(CWNET_SERVER_PING_MISSES + 1u) *
+                                 CWNET_SERVER_DEFAULT_PING_INTERVAL_MS,
+                      &res);
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_PING_TIMEOUT, ev->value);
+}
+
+/*===========================================================================*/
+/* R4: the PING, as the initiator                                            */
+/*===========================================================================*/
+
+void test_server_ping_request_and_response2_carry_the_reference_layout(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    /* At t + 2 s the REQUEST goes out: [0, idx, 0, 0, t0, 0, 0] */
+    cwnet_server_poll(&srv, 3000, &res);
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_PING, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(2u + CWNET_PING_PAYLOAD_SIZE, frame_len);
+    TEST_ASSERT_EQUAL_UINT8(0x40u | CWNET_CMD_PING, frame[0]);
+    TEST_ASSERT_EQUAL_UINT8(CWNET_PING_PAYLOAD_SIZE, frame[1]);
+    TEST_ASSERT_EQUAL_UINT8(0u, frame[2]);              /* type REQUEST */
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)idx, frame[3]);    /* id = the client index */
+    TEST_ASSERT_EQUAL_UINT8(0u, frame[4]);
+    TEST_ASSERT_EQUAL_UINT8(0u, frame[5]);
+    cwnet_ping_t request;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&request, frame + 2, frame_len - 2));
+    TEST_ASSERT_EQUAL_INT32(3000, request.t0_ms);
+    TEST_ASSERT_EQUAL_INT32(0, request.t1_ms);
+    TEST_ASSERT_EQUAL_INT32(0, request.t2_ms);
+
+    /* The client answers; the RESPONSE_2 closes the loop and t2 - t0 is the latency */
+    uint8_t payload[CWNET_PING_PAYLOAD_SIZE];
+    TEST_ASSERT_TRUE(cwnet_ping_build_response(&request, payload, sizeof(payload), 3040));
+    uint8_t reply[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t reply_len = build_frame(reply, sizeof(reply), (uint8_t)CWNET_CMD_PING,
+                                   payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, reply, reply_len, 3080, &res);
+
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_PING, 1,
+                                frame, sizeof(frame), &frame_len));
+    cwnet_ping_t response2;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&response2, frame + 2, frame_len - 2));
+    TEST_ASSERT_EQUAL_INT(CWNET_PING_RESPONSE_2, response2.type);
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)idx, response2.id);
+    TEST_ASSERT_EQUAL_INT32(3000, response2.t0_ms);
+    TEST_ASSERT_EQUAL_INT32(3040, response2.t1_ms);
+    TEST_ASSERT_EQUAL_INT32(3080, response2.t2_ms);
+
+    TEST_ASSERT_EQUAL_INT32(80, cwnet_server_client_latency_ms(&srv, idx));
+    TEST_ASSERT_EQUAL_INT32(80, cwnet_server_client_peak_ms(&srv, idx));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_LATENCY);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT32(80, ev->value);
+    TEST_ASSERT_EQUAL_INT32(80, ev->peak_ms);
+}
+
+void test_server_a_response_that_matches_no_pending_request_is_ignored(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+    ping_exchange(idx, 3000, 80);
+    TEST_ASSERT_EQUAL_INT32(80, cwnet_server_client_peak_ms(&srv, idx));
+
+    cwnet_server_poll(&srv, 5000, &res);   /* a second request is pending now */
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_PING, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    cwnet_ping_t request;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&request, frame + 2, frame_len - 2));
+
+    /* Another client's id: the peak-hold belongs to the connection */
+    cwnet_ping_t forged = request;
+    forged.id = (uint8_t)(request.id + 1u);
+    uint8_t payload[CWNET_PING_PAYLOAD_SIZE];
+    uint8_t reply[2 + CWNET_PING_PAYLOAD_SIZE];
+    TEST_ASSERT_TRUE(cwnet_ping_build_response(&forged, payload, sizeof(payload), 5300));
+    size_t reply_len = build_frame(reply, sizeof(reply), (uint8_t)CWNET_CMD_PING,
+                                   payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, reply, reply_len, 5600, &res);
+    TEST_ASSERT_EQUAL_INT32(80, cwnet_server_client_peak_ms(&srv, idx));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_LATENCY));
+
+    /* A different t0: same answer */
+    forged = request;
+    forged.t0_ms = request.t0_ms + 1;
+    TEST_ASSERT_TRUE(cwnet_ping_build_response(&forged, payload, sizeof(payload), 5300));
+    reply_len = build_frame(reply, sizeof(reply), (uint8_t)CWNET_CMD_PING,
+                            payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, reply, reply_len, 5600, &res);
+    TEST_ASSERT_EQUAL_INT32(80, cwnet_server_client_peak_ms(&srv, idx));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_LATENCY));
+
+    /* A PING payload shorter than the reference's 16 bytes is not a framing
+     * error: it is dropped, and the client stays */
+    uint8_t stub[8] = { 1, 0, 0, 0, 0, 0, 0, 0 };
+    reply_len = build_frame(reply, sizeof(reply), (uint8_t)CWNET_CMD_PING, stub, sizeof(stub));
+    cwnet_server_on_data(&srv, idx, reply, reply_len, 5700, &res);
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+}
+
+void test_server_answers_a_ping_request_from_the_client(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    uint8_t payload[CWNET_PING_PAYLOAD_SIZE];
+    TEST_ASSERT_TRUE(cwnet_ping_build_request(9u, 12345, payload, sizeof(payload)));
+    uint8_t frame[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t frame_len = build_frame(frame, sizeof(frame), (uint8_t)CWNET_CMD_PING,
+                                   payload, sizeof(payload));
+    cwnet_server_on_data(&srv, idx, frame, frame_len, 2000, &res);
+
+    uint8_t sent[2 + CWNET_PING_PAYLOAD_SIZE];
+    size_t sent_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_PING, 0, sent, sizeof(sent), &sent_len));
+    cwnet_ping_t response1;
+    TEST_ASSERT_TRUE(cwnet_ping_parse(&response1, sent + 2, sent_len - 2));
+    TEST_ASSERT_EQUAL_INT(CWNET_PING_RESPONSE_1, response1.type);
+    TEST_ASSERT_EQUAL_UINT8(9u, response1.id);
+    TEST_ASSERT_EQUAL_INT32(12345, response1.t0_ms);
+    TEST_ASSERT_EQUAL_INT32(2000, response1.t1_ms);
+}
+
+/*===========================================================================*/
+/* R5: the rig-control strings                                               */
+/*===========================================================================*/
+
+/** Feed one 0x06 string and read back the "RPRT n" the server answered */
+static int32_t rig_string_result(int idx, const char *text, size_t len, int64_t now_ms) {
+    uint8_t frame[2 + 96];
+    size_t frame_len = build_frame(frame, sizeof(frame), (uint8_t)CWNET_CMD_RIG_STRING,
+                                   text, len);
+    size_t before = wire_frame_count(idx, (uint8_t)CWNET_CMD_RIG_STRING);
+    cwnet_server_on_data(&srv, idx, frame, frame_len, now_ms, &res);
+    TEST_ASSERT_EQUAL_size_t(before + 1u, wire_frame_count(idx, (uint8_t)CWNET_CMD_RIG_STRING));
+
+    uint8_t answer[2 + 32];
+    size_t answer_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_RIG_STRING, SIZE_MAX,
+                                answer, sizeof(answer), &answer_len));
+    TEST_ASSERT_EQUAL_UINT8(0u, answer[answer_len - 1]);
+    const char *body = (const char *)answer + 2;
+    TEST_ASSERT_EQUAL_size_t(0u, (size_t)strncmp(body, "RPRT ", 5));
+    return (int32_t)atoi(body + 5);
+}
+
+void test_server_set_ptt_is_acknowledged_and_never_applied(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_OK,
+                            rig_string_result(idx, "set_ptt 1\n", 11u, 2000));
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_OK,
+                            rig_string_result(idx, "set_ptt 0\n", 11u, 2000));
+
+    /* R10: the string moves nothing. The PTT follows the keying played. */
+    TEST_ASSERT_FALSE(cwnet_server_ptt_on(&srv));
+    TEST_ASSERT_FALSE(cwnet_server_key_down(&srv));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_PTT_ON));
+}
+
+void test_server_any_other_rig_string_gets_a_negative_code(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    /* Not a command we have: HAMLIB_RESULT_NOT_AVAILABLE, the code CwNet.c
+     * itself sends when the software, not the rig, declines (CwNet.c:4114) */
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_NO_FUNC,
+                            rig_string_result(idx, "get_freq\n", 10u, 2000));
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_NO_FUNC,
+                            rig_string_result(idx, "set_pttx 1\n", 12u, 2000));
+
+    /* An argument that is not 0 or 1: HAMLIB_RESULT_ARG_OUT_OF_DOM, the code
+     * CwNet_Rigctld_OnSetPTT() returns for one it cannot parse (CwNet.c:4102) */
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_BAD_ARG,
+                            rig_string_result(idx, "set_ptt 7\n", 11u, 2000));
+    TEST_ASSERT_EQUAL_INT32(CWNET_SERVER_RPRT_BAD_ARG,
+                            rig_string_result(idx, "set_ptt\n", 9u, 2000));
+
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+}
+
+void test_server_a_rig_string_without_a_nul_closes_the_client(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    uint8_t text[64];
+    memset(text, 'A', sizeof(text));       /* 64 bytes, no terminator anywhere */
+    uint8_t frame[2 + sizeof(text)];
+    size_t frame_len = build_frame(frame, sizeof(frame), (uint8_t)CWNET_CMD_RIG_STRING,
+                                   text, sizeof(text));
+    cwnet_server_on_data(&srv, idx, frame, frame_len, 2000, &res);
+
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_BAD_STRING, ev->value);
+}
+
+/*===========================================================================*/
+/* R15: what is ignored and what is fatal                                    */
+/*===========================================================================*/
+
+void test_server_ignores_ci_v_and_spectrum_and_closes_on_a_parse_error(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    uint8_t junk[4] = { 0xFE, 0xFE, 0x00, 0xFD };
+    uint8_t frame[2 + sizeof(junk)];
+    size_t frame_len = build_frame(frame, sizeof(frame), (uint8_t)CWNET_CMD_CI_V,
+                                   junk, sizeof(junk));
+    cwnet_server_on_data(&srv, idx, frame, frame_len, 2000, &res);
+    frame_len = build_frame(frame, sizeof(frame), (uint8_t)CWNET_CMD_SPECTRUM,
+                            junk, sizeof(junk));
+    cwnet_server_on_data(&srv, idx, frame, frame_len, 2000, &res);
+
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, idx));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_len(idx));
+
+    /* Category 11 is reserved: a byte in it is the one framing error there is */
+    uint8_t reserved[1] = { 0xC5 };
+    cwnet_server_on_data(&srv, idx, reserved, sizeof(reserved), 2000, &res);
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_PARSE_ERROR, ev->value);
+}
+
+/*===========================================================================*/
+/* R6, R7, R9: one whole over, against the capture                           */
+/*===========================================================================*/
+
+void test_server_plays_the_first_over_of_the_capture_and_announces_both_ends(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    /* No PING has been answered: B falls to the floor, 50 ms (R7) */
+    cwnet_server_on_data(&srv, idx, ref_first_over, sizeof(ref_first_over), 2000, &res);
+
+    /* AE1/R3: the announcement is the capture's, byte for byte */
+    uint8_t frame[64];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_moritz), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_moritz, frame, sizeof(ref_tx_info_moritz));
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_UINT32(CWNET_SERVER_DEFAULT_BUFFER_FLOOR_MS,
+                             cwnet_server_buffer_ms(&srv));
+
+    /* The two "set_ptt" strings of the capture were both answered */
+    TEST_ASSERT_EQUAL_size_t(2u, wire_frame_count(idx, (uint8_t)CWNET_CMD_RIG_STRING));
+
+    /* One late poll: the edges land where they were scheduled, not where the
+     * poll happened. 'A' at 25 WPM: down at +B, up +48, down +48, up +144. */
+    cwnet_server_poll(&srv, 4000, &res);
+
+    TEST_ASSERT_EQUAL_size_t(2u, event_count(CWNET_SERVER_EV_KEY_DOWN));
+    TEST_ASSERT_EQUAL_size_t(2u, event_count(CWNET_SERVER_EV_KEY_UP));
+    TEST_ASSERT_EQUAL_INT64(2050, event_nth(CWNET_SERVER_EV_KEY_DOWN, 0)->at_ms);
+    TEST_ASSERT_EQUAL_INT64(2098, event_nth(CWNET_SERVER_EV_KEY_UP, 0)->at_ms);
+    TEST_ASSERT_EQUAL_INT64(2146, event_nth(CWNET_SERVER_EV_KEY_DOWN, 1)->at_ms);
+    TEST_ASSERT_EQUAL_INT64(2290, event_nth(CWNET_SERVER_EV_KEY_UP, 1)->at_ms);
+
+    /* The PTT rises with the first key-down and drops a tail after the last
+     * key-up (R9), and the key comes back when it does (R6) */
+    TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_PTT_ON));
+    TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_PTT_OFF));
+    TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_KEY_HOLDER));
+    TEST_ASSERT_EQUAL_INT64(2050, event_first(CWNET_SERVER_EV_PTT_ON)->at_ms);
+    TEST_ASSERT_EQUAL_INT64(2290 + CWNET_PLAY_DEFAULT_PTT_TAIL_MS,
+                            event_first(CWNET_SERVER_EV_PTT_OFF)->at_ms);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY,
+                          event_first(CWNET_SERVER_EV_KEY_HOLDER)->client_idx);
+
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_nobody), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, frame, sizeof(ref_tx_info_nobody));
+}
+
+void test_server_morse_from_a_client_without_the_key_is_dropped_in_silence(void) {
+    server_setup();
+    int first = ready_client("Moritz", "Moritz", 1000);
+    int second = ready_client("Karl", "Karl", 1000);
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, first, morse, sizeof(morse), 2000, &res);
+    TEST_ASSERT_EQUAL_INT(first, cwnet_server_key_holder(&srv));
+    wire_clear();
+
+    cwnet_server_on_data(&srv, second, morse, sizeof(morse), 2010, &res);
+
+    TEST_ASSERT_EQUAL_INT(first, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_frame_count(first, (uint8_t)CWNET_CMD_TX_INFO));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_frame_count(second, (uint8_t)CWNET_CMD_TX_INFO));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_KEY_HOLDER));
+    TEST_ASSERT_EQUAL_UINT32(1u, cwnet_server_morse_ignored(&srv));
+}
+
+void test_server_announces_the_holder_to_every_client(void) {
+    server_setup();
+    int first = ready_client("Moritz", "Moritz", 1000);
+    int second = ready_client("Karl", "Karl", 1000);
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, first, morse, sizeof(morse), 2000, &res);
+
+    uint8_t frame[64];
+    size_t frame_len = 0;
+    for (int idx = first; idx <= second; idx++) {
+        TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_CMD_TX_INFO, 0,
+                                    frame, sizeof(frame), &frame_len));
+        TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_moritz), frame_len);
+        TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_moritz, frame, sizeof(ref_tx_info_moritz));
+    }
+}
+
+/*===========================================================================*/
+/* R7: the eligibility ceiling                                               */
+/*===========================================================================*/
+
+void test_server_a_link_over_the_ceiling_does_not_get_the_key(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    ping_exchange(idx, 3000, 1200);   /* over the 1000 ms ceiling */
+    TEST_ASSERT_EQUAL_INT32(1200, cwnet_server_client_peak_ms(&srv, idx));
+    wire_clear();
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, idx, morse, sizeof(morse), 5000, &res);
+    cwnet_server_poll(&srv, 7000, &res);
+
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_frame_count(idx, (uint8_t)CWNET_CMD_TX_INFO));
+    TEST_ASSERT_FALSE(cwnet_server_key_down(&srv));
+    TEST_ASSERT_FALSE(cwnet_server_ptt_on(&srv));
+
+    /* It is told so, with the measured value (R7, R12) */
+    uint8_t frame[128];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_SERVER_CMD_PRINT, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_NOT_NULL(strstr((const char *)frame + 2, "not fit"));
+    TEST_ASSERT_NOT_NULL(strstr((const char *)frame + 2, "1200"));
+}
+
+void test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    ping_exchange(idx, 3000, 900);
+    TEST_ASSERT_EQUAL_INT32(900, cwnet_server_client_peak_ms(&srv, idx));
+    wire_clear();
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, idx, morse, sizeof(morse), 5000, &res);
+
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_UINT32(900u, cwnet_server_buffer_ms(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_OVER_BUFFER);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT32(900, ev->value);
+
+    /* And the first edge lands B after the byte arrived */
+    cwnet_server_poll(&srv, 6000, &res);
+    TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_KEY_DOWN));
+    TEST_ASSERT_EQUAL_INT64(5900, event_first(CWNET_SERVER_EV_KEY_DOWN)->at_ms);
+}
+
+/*===========================================================================*/
+/* R6: the safety nets                                                       */
+/*===========================================================================*/
+
+void test_server_the_holder_disconnecting_frees_the_key_for_the_others(void) {
+    server_setup();
+    int first = ready_client("Moritz", "Moritz", 1000);
+    int second = ready_client("Karl", "Karl", 1000);
+
+    cwnet_server_on_data(&srv, first, morse_key_down_held, sizeof(morse_key_down_held),
+                         2000, &res);
+    cwnet_server_poll(&srv, 2100, &res);
+    TEST_ASSERT_TRUE(cwnet_server_key_down(&srv));
+    TEST_ASSERT_TRUE(cwnet_server_ptt_on(&srv));
+    wire_clear();
+
+    cwnet_server_on_disconnected(&srv, first, 2200, &res);
+
+    TEST_ASSERT_FALSE(cwnet_server_key_down(&srv));
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
+    TEST_ASSERT_NOT_NULL(fault);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_HOLDER_GONE, fault->value);
+    TEST_ASSERT_NOT_NULL(event_first(CWNET_SERVER_EV_KEY_UP));
+    TEST_ASSERT_EQUAL_INT64(2200, event_first(CWNET_SERVER_EV_KEY_UP)->at_ms);
+
+    /* The others hear that the key is free; the one that left hears nothing */
+    uint8_t frame[64];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(second, (uint8_t)CWNET_CMD_TX_INFO, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_nobody), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, frame, sizeof(ref_tx_info_nobody));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_len(first));
+
+    /* The PTT drops at the tail, no later */
+    cwnet_server_poll(&srv, 2200 + CWNET_PLAY_DEFAULT_PTT_TAIL_MS, &res);
+    TEST_ASSERT_FALSE(cwnet_server_ptt_on(&srv));
+}
+
+void test_server_silence_from_the_holder_releases_the_key_with_a_fault(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    cwnet_server_on_data(&srv, idx, morse_key_down_held, sizeof(morse_key_down_held),
+                         2000, &res);
+    cwnet_server_poll(&srv, 2100, &res);
+    TEST_ASSERT_TRUE(cwnet_server_key_down(&srv));
+
+    cwnet_server_poll(&srv, 2000 + CWNET_SERVER_DEFAULT_IDLE_MS - 1, &res);
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+
+    cwnet_server_poll(&srv, 2000 + CWNET_SERVER_DEFAULT_IDLE_MS, &res);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_FALSE(cwnet_server_key_down(&srv));
+    const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
+    TEST_ASSERT_NOT_NULL(fault);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_IDLE, fault->value);
+}
+
+void test_server_an_over_past_its_ceiling_is_cut_off(void) {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.send_cb = fake_send;
+    cfg.idle_timeout_ms = 600000u;   /* out of the way: the ceiling is on trial */
+    cfg.over_max_ms = 3000u;
+    server_setup_cfg(&cfg);
+
+    int idx = ready_client("Moritz", "Moritz", 1000);
+    cwnet_server_on_data(&srv, idx, morse_key_down_held, sizeof(morse_key_down_held),
+                         2000, &res);
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+
+    cwnet_server_poll(&srv, 4999, &res);
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+
+    cwnet_server_poll(&srv, 5000, &res);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
+    TEST_ASSERT_NOT_NULL(fault);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_OVER_TOO_LONG, fault->value);
+}
+
+/*===========================================================================*/
+/* Robustness                                                                */
+/*===========================================================================*/
+
+static uint8_t huge_morse[3 + 65535];
+
+void test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    huge_morse[0] = 0x80u | CWNET_CMD_MORSE;   /* long block */
+    huge_morse[1] = 0xFFu;
+    huge_morse[2] = 0xFFu;
+    memset(huge_morse + 3, 0x80u, 65535);
+    cwnet_server_on_data(&srv, idx, huge_morse, sizeof(huge_morse), 2000, &res);
+
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+    /* The engine holds the FIFO plus the byte whose deadline is running */
+    TEST_ASSERT_EQUAL_UINT32(65535u - (CWNET_PLAY_FIFO_SIZE + 1u),
+                             cwnet_server_play_dropped(&srv));
+}
+
+void test_server_survives_null_and_unknown_indices(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    TEST_ASSERT_FALSE(cwnet_server_init(NULL, NULL));
+    cwnet_server_cfg_defaults(NULL);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NO_SLOT, cwnet_server_on_connected(NULL, 0, &res));
+    cwnet_server_on_data(NULL, 1, NULL, 0, 0, &res);
+    cwnet_server_on_disconnected(NULL, 1, 0, &res);
+    cwnet_server_poll(NULL, 0, &res);
+
+    int64_t at = 0;
+    TEST_ASSERT_FALSE(cwnet_server_next_deadline(NULL, &at));
+    TEST_ASSERT_FALSE(cwnet_server_next_deadline(&srv, NULL));
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(1000 + CWNET_SERVER_DEFAULT_PING_INTERVAL_MS, at);
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, 99, morse, sizeof(morse), 2000, &res);
+    cwnet_server_on_disconnected(&srv, 99, 2000, &res);
+    cwnet_server_on_data(&srv, idx, NULL, 0, 2000, &res);
+
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_STRING("", cwnet_server_client_name(&srv, 99));
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_latency_ms(&srv, 99));
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_peak_ms(&srv, 99));
+    TEST_ASSERT_EQUAL_size_t(1u, cwnet_server_client_count(&srv));
+}
+
+void test_server_a_failed_send_closes_that_client(void) {
+    server_setup();
+    int idx = cwnet_server_on_connected(&srv, 1000, &res);
+
+    fake_send_fails = true;
+    uint8_t connect[2 + CWNET_CONNECT_PAYLOAD_LEN];
+    size_t len = build_connect(connect, sizeof(connect), "Moritz", "Moritz",
+                               CWNET_CONNECT_PAYLOAD_LEN);
+    cwnet_server_on_data(&srv, idx, connect, len, 1000, &res);
+
+    TEST_ASSERT_EQUAL_size_t(0u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(ev);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_SEND_FAILED, ev->value);
+}

--- a/test_host/test_cwnet_server.c
+++ b/test_host/test_cwnet_server.c
@@ -34,9 +34,12 @@ static uint8_t fake_tx[FAKE_CLIENTS][FAKE_TX_SIZE];
 static size_t fake_tx_len[FAKE_CLIENTS];
 static bool fake_send_fails;
 
+/** Sends to this one client fail; 0 means nobody. Everything else goes out. */
+static int fake_send_fail_idx;
+
 static int fake_send(int client_idx, const uint8_t *data, size_t len, void *user_data) {
     (void)user_data;
-    if (fake_send_fails) {
+    if (fake_send_fails || client_idx == fake_send_fail_idx) {
         return -1;
     }
     TEST_ASSERT_TRUE(client_idx >= CWNET_SERVER_FIRST_CLIENT && client_idx < FAKE_CLIENTS);
@@ -204,6 +207,7 @@ static const uint8_t morse_key_down_held[] = { 0x50, 0x02, 0x80, 0x60 };
 static void server_setup_cfg(const cwnet_server_cfg_t *cfg) {
     wire_clear();
     fake_send_fails = false;
+    fake_send_fail_idx = 0;
     TEST_ASSERT_TRUE(cwnet_server_init(&srv, cfg));
 }
 
@@ -989,4 +993,242 @@ void test_server_a_failed_send_closes_that_client(void) {
     const cwnet_server_event_t *ev = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
     TEST_ASSERT_NOT_NULL(ev);
     TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_SEND_FAILED, ev->value);
+}
+
+/*===========================================================================*/
+/* R3: the announcement, when one of its sends dies halfway through          */
+/*===========================================================================*/
+
+/*
+ * The TX_INFO is one payload sent to everybody, and a send inside that loop
+ * can close the client it is writing to. When that client is the one that
+ * has just taken the key, closing it releases the key and announces the
+ * release from inside the loop; whatever the outer loop has not reached yet
+ * would then be told about a holder that no longer exists. The last word a
+ * client hears on the key has to be the state as it is.
+ */
+void test_server_a_send_dying_mid_announcement_leaves_no_stale_tx_info(void) {
+    server_setup();
+    int first = ready_client("Moritz", "Moritz", 1000);
+    int second = ready_client("Karl", "Karl", 1000);
+    int third = ready_client("Anna", "Anna", 1000);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_FIRST_CLIENT + 1, second);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_FIRST_CLIENT + 2, third);
+    wire_clear();
+
+    /* The middle client takes the key and its own copy of the announcement
+     * cannot go out: it is closed, and the key is free again at once */
+    fake_send_fail_idx = second;
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, second, morse, sizeof(morse), 2000, &res);
+
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_size_t(2u, cwnet_server_client_count(&srv));
+    const cwnet_server_event_t *closed = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(closed);
+    TEST_ASSERT_EQUAL_INT(second, closed->client_idx);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_SEND_FAILED, closed->value);
+
+    /* Neither survivor is left believing client 2 is on the key. The one
+     * the loop had not reached yet is the one that used to get it wrong. */
+    uint8_t frame[64];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(first, (uint8_t)CWNET_CMD_TX_INFO, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_nobody), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, frame, sizeof(ref_tx_info_nobody));
+
+    TEST_ASSERT_TRUE(wire_frame(third, (uint8_t)CWNET_CMD_TX_INFO, SIZE_MAX,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_EQUAL_size_t(sizeof(ref_tx_info_nobody), frame_len);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ref_tx_info_nobody, frame, sizeof(ref_tx_info_nobody));
+}
+
+/*===========================================================================*/
+/* R7: a link that answers, but never inside the window                      */
+/*===========================================================================*/
+
+/*
+ * The peak-hold only moves when a sample lands inside the gate's 0..2000 ms
+ * window. A link whose every answer is slower than that never records one,
+ * so its peak stays at the -1 that also means "never pinged". The two are
+ * not the same client: one has produced no evidence yet, the other has
+ * produced nothing but evidence that it is too slow to be heard.
+ */
+void test_server_a_link_that_never_answers_inside_the_window_is_not_fit(void) {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.send_cb = fake_send;
+    /* Wide enough that the slow answer still matches the pending request */
+    cfg.ping_interval_ms = 10000u;
+    server_setup_cfg(&cfg);
+
+    int idx = ready_client("Moritz", "Moritz", 1000);
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_peak_ms(&srv, idx));
+
+    /* Three answers, none of them inside the window: no peak is ever held */
+    ping_exchange(idx, 11000, 2500);
+    ping_exchange(idx, 21000, 3000);
+    ping_exchange(idx, 31000, 4000);
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_peak_ms(&srv, idx));
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_latency_ms(&srv, idx));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_LATENCY));
+    wire_clear();
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, idx, morse, sizeof(morse), 40000, &res);
+
+    /* It does not take the key, nothing of its is played, and it is told */
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_size_t(0u, wire_frame_count(idx, (uint8_t)CWNET_CMD_TX_INFO));
+    TEST_ASSERT_EQUAL_UINT32(1u, cwnet_server_morse_ignored(&srv));
+    TEST_ASSERT_EQUAL_size_t(1u, event_count(CWNET_SERVER_EV_LINK_UNFIT));
+
+    uint8_t frame[128];
+    size_t frame_len = 0;
+    TEST_ASSERT_TRUE(wire_frame(idx, (uint8_t)CWNET_SERVER_CMD_PRINT, 0,
+                                frame, sizeof(frame), &frame_len));
+    TEST_ASSERT_NOT_NULL(strstr((const char *)frame + 2, "not fit"));
+
+    cwnet_server_poll(&srv, 41000, &res);
+    TEST_ASSERT_FALSE(cwnet_server_key_down(&srv));
+    TEST_ASSERT_FALSE(cwnet_server_ptt_on(&srv));
+}
+
+void test_server_a_link_that_has_never_been_pinged_still_gets_the_key(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    /* No PING has been answered at all: no measurement is not a bad one, or
+     * every client would be refused for its first two seconds */
+    TEST_ASSERT_EQUAL_INT32(-1, cwnet_server_client_peak_ms(&srv, idx));
+
+    uint8_t morse[] = { 0x50, 0x01, 0x80 };
+    cwnet_server_on_data(&srv, idx, morse, sizeof(morse), 2000, &res);
+
+    TEST_ASSERT_EQUAL_INT(idx, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_UINT32(CWNET_SERVER_DEFAULT_BUFFER_FLOOR_MS,
+                             cwnet_server_buffer_ms(&srv));
+    TEST_ASSERT_EQUAL_size_t(0u, event_count(CWNET_SERVER_EV_LINK_UNFIT));
+}
+
+/*
+ * A refused client keeps sending: it does not know it is refused until the
+ * PRINT reaches it, and it may not stop even then. One event per rejected
+ * byte fills the result's array and starts costing the daemon the events it
+ * needs, so the refusal is reported exactly as often as it is printed: once,
+ * until a sample brings the peak back under the ceiling.
+ */
+void test_server_an_unfit_link_is_reported_once_not_once_per_frame(void) {
+    server_setup();
+    int idx = ready_client("Moritz", "Moritz", 1000);
+
+    ping_exchange(idx, 3000, 1200);   /* over the 1000 ms ceiling */
+    TEST_ASSERT_EQUAL_INT32(1200, cwnet_server_client_peak_ms(&srv, idx));
+    wire_clear();
+
+    /* Forty MORSE frames in one read: forty asks for a key it cannot have */
+    uint8_t stream[40u * 3u];
+    for (size_t i = 0; i < 40u; i++) {
+        static const uint8_t key_down = 0x80u;
+        uint8_t one[3];
+        TEST_ASSERT_EQUAL_size_t(sizeof(one),
+                                 build_frame(one, sizeof(one), (uint8_t)CWNET_CMD_MORSE,
+                                             &key_down, 1u));
+        memcpy(stream + i * 3u, one, sizeof(one));
+    }
+    cwnet_server_on_data(&srv, idx, stream, sizeof(stream), 5000, &res);
+
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_EQUAL_UINT32(40u, cwnet_server_morse_ignored(&srv));
+    TEST_ASSERT_EQUAL_size_t(1u, event_count(CWNET_SERVER_EV_LINK_UNFIT));
+    TEST_ASSERT_EQUAL_size_t(1u, wire_frame_count(idx, (uint8_t)CWNET_SERVER_CMD_PRINT));
+    /* And the result still has room for the events that matter */
+    TEST_ASSERT_EQUAL_size_t(0u, res.dropped);
+}
+
+/*===========================================================================*/
+/* The next deadline, with several of them in competition                    */
+/*===========================================================================*/
+
+/*
+ * cwnet_server_next_deadline() is the daemon's loop timeout: everything the
+ * server does on time does it because this number was the true minimum.
+ */
+void test_server_next_deadline_is_the_nearest_of_the_over_and_the_pings(void) {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.send_cb = fake_send;
+    cfg.ping_interval_ms = 10000u;
+    cfg.idle_timeout_ms = 4000u;
+    server_setup_cfg(&cfg);
+
+    int first = ready_client("Moritz", "Moritz", 1000);   /* PING due at 11000 */
+    int second = ready_client("Karl", "Karl", 5000);      /* PING due at 15000 */
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_FIRST_CLIENT + 1, second);
+
+    int64_t at = 0;
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(11000, at);   /* the nearer of the two PINGs */
+
+    /* The key is taken at 6000. With no measurement B is the floor, so the
+     * first edge is due at 6050: nearer than either PING and nearer than the
+     * idle net at 10000 and the over ceiling at 126000. */
+    cwnet_server_on_data(&srv, first, morse_key_down_held, sizeof(morse_key_down_held),
+                         6000, &res);
+    TEST_ASSERT_EQUAL_INT(first, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(6050, at);
+
+    /* Played out — the two bytes hold the key down and then lift it, and
+     * with an empty FIFO under them that is an underrun (R8), not the end of
+     * an over: the holder keeps the key and the idle net is now the nearest
+     * thing the server has to do. */
+    cwnet_server_poll(&srv, 7000, &res);
+    TEST_ASSERT_EQUAL_INT(first, cwnet_server_key_holder(&srv));
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(10000, at);   /* 6000 + the idle timeout */
+
+    /* And that instant is the real one */
+    cwnet_server_poll(&srv, 10000, &res);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_NOBODY, cwnet_server_key_holder(&srv));
+    const cwnet_server_event_t *fault = event_first(CWNET_SERVER_EV_FAULT);
+    TEST_ASSERT_NOT_NULL(fault);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_FAULT_IDLE, fault->value);
+
+    /* With the over gone the nearer PING comes back to the front */
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(11000, at);
+}
+
+void test_server_next_deadline_takes_an_expiring_handshake_before_the_rest(void) {
+    cwnet_server_cfg_t cfg;
+    cwnet_server_cfg_defaults(&cfg);
+    cfg.send_cb = fake_send;
+    cfg.handshake_timeout_ms = 200u;
+    server_setup_cfg(&cfg);
+
+    int ready = ready_client("Moritz", "Moritz", 1000);   /* PING due at 3000 */
+    int64_t at = 0;
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(1000 + CWNET_SERVER_DEFAULT_PING_INTERVAL_MS, at);
+
+    /* A second connection that has not logged in: its handshake runs out at
+     * 2700, before anything else the server owes anybody */
+    int silent = cwnet_server_on_connected(&srv, 2500, &res);
+    TEST_ASSERT_EQUAL_INT(CWNET_SERVER_FIRST_CLIENT + 1, silent);
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(2700, at);
+
+    cwnet_server_poll(&srv, at, &res);
+    TEST_ASSERT_EQUAL_size_t(1u, cwnet_server_client_count(&srv));
+    TEST_ASSERT_TRUE(cwnet_server_client_ready(&srv, ready));
+    const cwnet_server_event_t *closed = event_first(CWNET_SERVER_EV_CLIENT_CLOSED);
+    TEST_ASSERT_NOT_NULL(closed);
+    TEST_ASSERT_EQUAL_INT(silent, closed->client_idx);
+    TEST_ASSERT_EQUAL_INT((int32_t)CWNET_SERVER_CLOSE_HANDSHAKE, closed->value);
+
+    /* With it gone the PING is the front of the queue again */
+    TEST_ASSERT_TRUE(cwnet_server_next_deadline(&srv, &at));
+    TEST_ASSERT_EQUAL_INT64(1000 + CWNET_SERVER_DEFAULT_PING_INTERVAL_MS, at);
 }

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -326,6 +326,34 @@ void test_play_force_release_when_idle_finishes_the_over_at_once(void);
 void test_play_start_over_fixes_the_buffer_and_clears_the_queue(void);
 void test_play_survives_null_and_reports_nothing(void);
 
+/* CWNet server core (station side: CONNECT, key, PING, rig strings) */
+void test_server_connect_echo_matches_the_capture(void);
+void test_server_connect_of_the_wrong_length_closes_the_client(void);
+void test_server_connect_arriving_one_byte_at_a_time_still_logs_in(void);
+void test_server_an_empty_callsign_is_announced_as_nocall(void);
+void test_server_connect_fields_without_a_nul_are_read_no_further(void);
+void test_server_a_connection_past_the_limit_is_accepted_and_closed(void);
+void test_server_a_client_that_never_logs_in_is_closed(void);
+void test_server_three_unanswered_pings_close_the_client(void);
+void test_server_ping_request_and_response2_carry_the_reference_layout(void);
+void test_server_a_response_that_matches_no_pending_request_is_ignored(void);
+void test_server_answers_a_ping_request_from_the_client(void);
+void test_server_set_ptt_is_acknowledged_and_never_applied(void);
+void test_server_any_other_rig_string_gets_a_negative_code(void);
+void test_server_a_rig_string_without_a_nul_closes_the_client(void);
+void test_server_ignores_ci_v_and_spectrum_and_closes_on_a_parse_error(void);
+void test_server_plays_the_first_over_of_the_capture_and_announces_both_ends(void);
+void test_server_morse_from_a_client_without_the_key_is_dropped_in_silence(void);
+void test_server_announces_the_holder_to_every_client(void);
+void test_server_a_link_over_the_ceiling_does_not_get_the_key(void);
+void test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak(void);
+void test_server_the_holder_disconnecting_frees_the_key_for_the_others(void);
+void test_server_silence_from_the_holder_releases_the_key_with_a_fault(void);
+void test_server_an_over_past_its_ceiling_is_cut_off(void);
+void test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest(void);
+void test_server_a_failed_send_closes_that_client(void);
+void test_server_survives_null_and_unknown_indices(void);
+
 void setUp(void) {
     /* Called before each test */
 }
@@ -710,6 +738,35 @@ int main(void) {
     RUN_TEST(test_play_force_release_when_idle_finishes_the_over_at_once);
     RUN_TEST(test_play_start_over_fixes_the_buffer_and_clears_the_queue);
     RUN_TEST(test_play_survives_null_and_reports_nothing);
+
+    /* CWNet server core: the station takes a client in and arbitrates the key */
+    printf("\n=== CWNet Server Tests ===\n");
+    RUN_TEST(test_server_connect_echo_matches_the_capture);
+    RUN_TEST(test_server_connect_of_the_wrong_length_closes_the_client);
+    RUN_TEST(test_server_connect_arriving_one_byte_at_a_time_still_logs_in);
+    RUN_TEST(test_server_an_empty_callsign_is_announced_as_nocall);
+    RUN_TEST(test_server_connect_fields_without_a_nul_are_read_no_further);
+    RUN_TEST(test_server_a_connection_past_the_limit_is_accepted_and_closed);
+    RUN_TEST(test_server_a_client_that_never_logs_in_is_closed);
+    RUN_TEST(test_server_three_unanswered_pings_close_the_client);
+    RUN_TEST(test_server_ping_request_and_response2_carry_the_reference_layout);
+    RUN_TEST(test_server_a_response_that_matches_no_pending_request_is_ignored);
+    RUN_TEST(test_server_answers_a_ping_request_from_the_client);
+    RUN_TEST(test_server_set_ptt_is_acknowledged_and_never_applied);
+    RUN_TEST(test_server_any_other_rig_string_gets_a_negative_code);
+    RUN_TEST(test_server_a_rig_string_without_a_nul_closes_the_client);
+    RUN_TEST(test_server_ignores_ci_v_and_spectrum_and_closes_on_a_parse_error);
+    RUN_TEST(test_server_plays_the_first_over_of_the_capture_and_announces_both_ends);
+    RUN_TEST(test_server_morse_from_a_client_without_the_key_is_dropped_in_silence);
+    RUN_TEST(test_server_announces_the_holder_to_every_client);
+    RUN_TEST(test_server_a_link_over_the_ceiling_does_not_get_the_key);
+    RUN_TEST(test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak);
+    RUN_TEST(test_server_the_holder_disconnecting_frees_the_key_for_the_others);
+    RUN_TEST(test_server_silence_from_the_holder_releases_the_key_with_a_fault);
+    RUN_TEST(test_server_an_over_past_its_ceiling_is_cut_off);
+    RUN_TEST(test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest);
+    RUN_TEST(test_server_a_failed_send_closes_that_client);
+    RUN_TEST(test_server_survives_null_and_unknown_indices);
 
     return UNITY_END();
 }

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -183,6 +183,15 @@ void test_parser_reset_clears_state(void);
 void test_parser_init_state(void);
 void test_parser_null_safety(void);
 void test_stream_parse_long_block_partial_length(void);
+void test_parse_fragmented_oversized_long_frame_is_skipped_not_error(void);
+void test_parse_fragmented_256_exact_still_buffers_and_copies(void);
+void test_parse_long_frame_65535_single_read_no_copy(void);
+void test_frame_build_empty_payload_writes_only_command_byte(void);
+void test_frame_build_short_payload_92_bytes(void);
+void test_frame_build_long_payload_300_bytes_little_endian_length(void);
+void test_frame_build_buffer_too_small_rejects_without_writing(void);
+void test_frame_build_matches_ref_tx_info_moritz(void);
+void test_frame_build_matches_ref_tx_info_nobody(void);
 
 /* CWNet PING/Timer tests */
 void test_timer_sync_init(void);
@@ -496,6 +505,16 @@ int main(void) {
     RUN_TEST(test_stream_parse_two_disconnects);
     RUN_TEST(test_stream_parse_disconnect_then_ping);
     RUN_TEST(test_stream_parse_long_block_partial_length);
+    RUN_TEST(test_parse_fragmented_oversized_long_frame_is_skipped_not_error);
+    RUN_TEST(test_parse_fragmented_256_exact_still_buffers_and_copies);
+    RUN_TEST(test_parse_long_frame_65535_single_read_no_copy);
+    /* Frame builders */
+    RUN_TEST(test_frame_build_empty_payload_writes_only_command_byte);
+    RUN_TEST(test_frame_build_short_payload_92_bytes);
+    RUN_TEST(test_frame_build_long_payload_300_bytes_little_endian_length);
+    RUN_TEST(test_frame_build_buffer_too_small_rejects_without_writing);
+    RUN_TEST(test_frame_build_matches_ref_tx_info_moritz);
+    RUN_TEST(test_frame_build_matches_ref_tx_info_nobody);
     /* Error handling */
     RUN_TEST(test_parse_reserved_category);
     RUN_TEST(test_parse_incomplete_returns_need_more);

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -348,6 +348,7 @@ void test_server_announces_the_holder_to_every_client(void);
 void test_server_a_link_over_the_ceiling_does_not_get_the_key(void);
 void test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak(void);
 void test_server_the_holder_disconnecting_frees_the_key_for_the_others(void);
+void test_server_a_holder_lost_inside_the_buffer_is_still_named_in_the_fault(void);
 void test_server_silence_from_the_holder_releases_the_key_with_a_fault(void);
 void test_server_an_over_past_its_ceiling_is_cut_off(void);
 void test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest(void);
@@ -762,6 +763,7 @@ int main(void) {
     RUN_TEST(test_server_a_link_over_the_ceiling_does_not_get_the_key);
     RUN_TEST(test_server_a_link_under_the_ceiling_sets_the_buffer_to_its_peak);
     RUN_TEST(test_server_the_holder_disconnecting_frees_the_key_for_the_others);
+    RUN_TEST(test_server_a_holder_lost_inside_the_buffer_is_still_named_in_the_fault);
     RUN_TEST(test_server_silence_from_the_holder_releases_the_key_with_a_fault);
     RUN_TEST(test_server_an_over_past_its_ceiling_is_cut_off);
     RUN_TEST(test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest);

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -264,6 +264,7 @@ void test_client_rx_event_carries_reception_time(void);
 void test_client_rx_fifo_full_drops_and_counts(void);
 void test_client_rx_ignores_ci_v_and_spectrum(void);
 void test_client_latency_peak_holds_and_decays_like_the_reference(void);
+void test_client_ping_peak_hold_gate_rejects_out_of_range_rtt(void);
 void test_client_round_trip_returns_the_edges_sent(void);
 void test_client_tx_first_over_with_ptt_matches_reference_capture_whole(void);
 void test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail(void);
@@ -314,6 +315,7 @@ void test_play_a_late_tick_does_not_move_the_edges(void);
 void test_play_a_late_byte_does_not_move_the_deadline_it_follows(void);
 void test_play_two_event_frames_play_at_their_encoded_distances(void);
 void test_play_a_split_wait_makes_one_edge_after_the_sum(void);
+void test_play_a_key_down_longer_than_one_byte_is_not_an_end_of_over(void);
 void test_play_underrun_lifts_the_key_at_once_and_reports_it(void);
 void test_play_after_an_underrun_the_next_byte_restarts_with_the_same_buffer(void);
 void test_play_end_of_over_does_not_wait_out_the_marker(void);
@@ -325,6 +327,7 @@ void test_play_force_release_lifts_the_key_and_drops_the_ptt_at_the_tail(void);
 void test_play_force_release_when_idle_finishes_the_over_at_once(void);
 void test_play_start_over_fixes_the_buffer_and_clears_the_queue(void);
 void test_play_survives_null_and_reports_nothing(void);
+void test_play_never_comes_to_rest_with_the_key_down(void);
 
 /* CWNet server core (station side: CONNECT, key, PING, rig strings) */
 void test_server_connect_echo_matches_the_capture(void);
@@ -354,6 +357,12 @@ void test_server_an_over_past_its_ceiling_is_cut_off(void);
 void test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest(void);
 void test_server_a_failed_send_closes_that_client(void);
 void test_server_survives_null_and_unknown_indices(void);
+void test_server_a_send_dying_mid_announcement_leaves_no_stale_tx_info(void);
+void test_server_a_link_that_never_answers_inside_the_window_is_not_fit(void);
+void test_server_a_link_that_has_never_been_pinged_still_gets_the_key(void);
+void test_server_an_unfit_link_is_reported_once_not_once_per_frame(void);
+void test_server_next_deadline_is_the_nearest_of_the_over_and_the_pings(void);
+void test_server_next_deadline_takes_an_expiring_handshake_before_the_rest(void);
 
 void setUp(void) {
     /* Called before each test */
@@ -673,6 +682,7 @@ int main(void) {
     RUN_TEST(test_client_rx_fifo_full_drops_and_counts);
     RUN_TEST(test_client_rx_ignores_ci_v_and_spectrum);
     RUN_TEST(test_client_latency_peak_holds_and_decays_like_the_reference);
+    RUN_TEST(test_client_ping_peak_hold_gate_rejects_out_of_range_rtt);
     RUN_TEST(test_client_round_trip_returns_the_edges_sent);
     RUN_TEST(test_client_tx_first_over_with_ptt_matches_reference_capture_whole);
     RUN_TEST(test_client_tx_ptt_holds_across_gaps_shorter_than_the_tail);
@@ -728,6 +738,7 @@ int main(void) {
     RUN_TEST(test_play_a_late_byte_does_not_move_the_deadline_it_follows);
     RUN_TEST(test_play_two_event_frames_play_at_their_encoded_distances);
     RUN_TEST(test_play_a_split_wait_makes_one_edge_after_the_sum);
+    RUN_TEST(test_play_a_key_down_longer_than_one_byte_is_not_an_end_of_over);
     RUN_TEST(test_play_underrun_lifts_the_key_at_once_and_reports_it);
     RUN_TEST(test_play_after_an_underrun_the_next_byte_restarts_with_the_same_buffer);
     RUN_TEST(test_play_end_of_over_does_not_wait_out_the_marker);
@@ -739,6 +750,7 @@ int main(void) {
     RUN_TEST(test_play_force_release_when_idle_finishes_the_over_at_once);
     RUN_TEST(test_play_start_over_fixes_the_buffer_and_clears_the_queue);
     RUN_TEST(test_play_survives_null_and_reports_nothing);
+    RUN_TEST(test_play_never_comes_to_rest_with_the_key_down);
 
     /* CWNet server core: the station takes a client in and arbitrates the key */
     printf("\n=== CWNet Server Tests ===\n");
@@ -769,6 +781,12 @@ int main(void) {
     RUN_TEST(test_server_a_huge_morse_frame_fills_the_engine_and_counts_the_rest);
     RUN_TEST(test_server_a_failed_send_closes_that_client);
     RUN_TEST(test_server_survives_null_and_unknown_indices);
+    RUN_TEST(test_server_a_send_dying_mid_announcement_leaves_no_stale_tx_info);
+    RUN_TEST(test_server_a_link_that_never_answers_inside_the_window_is_not_fit);
+    RUN_TEST(test_server_a_link_that_has_never_been_pinged_still_gets_the_key);
+    RUN_TEST(test_server_an_unfit_link_is_reported_once_not_once_per_frame);
+    RUN_TEST(test_server_next_deadline_is_the_nearest_of_the_over_and_the_pings);
+    RUN_TEST(test_server_next_deadline_takes_an_expiring_handshake_before_the_rest);
 
     return UNITY_END();
 }

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -217,6 +217,20 @@ void test_ping_calc_latency_wrong_type(void);
 void test_ping_calc_latency_null(void);
 void test_ping_full_sequence(void);
 void test_ping_latency_measurement(void);
+void test_ping_build_request_layout(void);
+void test_ping_build_request_buffer_too_small(void);
+void test_ping_build_request_null_buffer(void);
+void test_ping_build_response2_from_response1(void);
+void test_ping_build_response2_wrong_type(void);
+void test_ping_build_response2_buffer_too_small(void);
+void test_ping_build_response2_null(void);
+void test_ping_peak_hold_jumps_to_new_peak(void);
+void test_ping_peak_hold_decays_by_tenth_of_gap(void);
+void test_ping_peak_hold_null(void);
+void test_ping_peak_hold_gate_rejects_over_2000ms(void);
+void test_ping_peak_hold_gate_boundary(void);
+void test_ping_peak_hold_gate_rejects_negative_rtt_from_wrap(void);
+void test_ping_peak_hold_accepts_zero(void);
 
 /* CWNet Client tests */
 void test_client_init_basic(void);
@@ -574,6 +588,22 @@ int main(void) {
     /* Integration */
     RUN_TEST(test_ping_full_sequence);
     RUN_TEST(test_ping_latency_measurement);
+    /* Initiator side: the daemon builds these (U2) */
+    RUN_TEST(test_ping_build_request_layout);
+    RUN_TEST(test_ping_build_request_buffer_too_small);
+    RUN_TEST(test_ping_build_request_null_buffer);
+    RUN_TEST(test_ping_build_response2_from_response1);
+    RUN_TEST(test_ping_build_response2_wrong_type);
+    RUN_TEST(test_ping_build_response2_buffer_too_small);
+    RUN_TEST(test_ping_build_response2_null);
+    /* Peak-hold, shared by client and server, behind the 0..2000 ms gate */
+    RUN_TEST(test_ping_peak_hold_jumps_to_new_peak);
+    RUN_TEST(test_ping_peak_hold_decays_by_tenth_of_gap);
+    RUN_TEST(test_ping_peak_hold_null);
+    RUN_TEST(test_ping_peak_hold_gate_rejects_over_2000ms);
+    RUN_TEST(test_ping_peak_hold_gate_boundary);
+    RUN_TEST(test_ping_peak_hold_gate_rejects_negative_rtt_from_wrap);
+    RUN_TEST(test_ping_peak_hold_accepts_zero);
 
     /* CWNet Client tests */
     printf("\n=== CWNet Client Tests ===\n");

--- a/test_host/test_main.c
+++ b/test_host/test_main.c
@@ -294,6 +294,24 @@ void test_feed_send_failure_closes_the_over_and_retries(void);
 void test_feed_disconnect_mid_over_then_reconnect(void);
 void test_feed_long_key_down_is_sent_in_full(void);
 
+/* CWNet playback engine (station side: bytes -> key edges and PTT) */
+void test_play_first_over_of_the_capture_plays_at_the_encoded_instants(void);
+void test_play_a_late_tick_does_not_move_the_edges(void);
+void test_play_a_late_byte_does_not_move_the_deadline_it_follows(void);
+void test_play_two_event_frames_play_at_their_encoded_distances(void);
+void test_play_a_split_wait_makes_one_edge_after_the_sum(void);
+void test_play_underrun_lifts_the_key_at_once_and_reports_it(void);
+void test_play_after_an_underrun_the_next_byte_restarts_with_the_same_buffer(void);
+void test_play_end_of_over_does_not_wait_out_the_marker(void);
+void test_play_key_ups_split_by_a_key_down_are_not_an_end_of_over(void);
+void test_play_ptt_lead_raises_the_ptt_before_the_first_key_down(void);
+void test_play_ptt_lead_is_clamped_to_the_buffer(void);
+void test_play_a_full_fifo_drops_the_byte_and_counts_it(void);
+void test_play_force_release_lifts_the_key_and_drops_the_ptt_at_the_tail(void);
+void test_play_force_release_when_idle_finishes_the_over_at_once(void);
+void test_play_start_over_fixes_the_buffer_and_clears_the_queue(void);
+void test_play_survives_null_and_reports_nothing(void);
+
 void setUp(void) {
     /* Called before each test */
 }
@@ -643,6 +661,25 @@ int main(void) {
     RUN_TEST(test_feed_send_failure_closes_the_over_and_retries);
     RUN_TEST(test_feed_disconnect_mid_over_then_reconnect);
     RUN_TEST(test_feed_long_key_down_is_sent_in_full);
+
+    /* CWNet playback: the station plays the key holder's bytes and the PTT */
+    printf("\n=== CWNet Playback Tests ===\n");
+    RUN_TEST(test_play_first_over_of_the_capture_plays_at_the_encoded_instants);
+    RUN_TEST(test_play_a_late_tick_does_not_move_the_edges);
+    RUN_TEST(test_play_a_late_byte_does_not_move_the_deadline_it_follows);
+    RUN_TEST(test_play_two_event_frames_play_at_their_encoded_distances);
+    RUN_TEST(test_play_a_split_wait_makes_one_edge_after_the_sum);
+    RUN_TEST(test_play_underrun_lifts_the_key_at_once_and_reports_it);
+    RUN_TEST(test_play_after_an_underrun_the_next_byte_restarts_with_the_same_buffer);
+    RUN_TEST(test_play_end_of_over_does_not_wait_out_the_marker);
+    RUN_TEST(test_play_key_ups_split_by_a_key_down_are_not_an_end_of_over);
+    RUN_TEST(test_play_ptt_lead_raises_the_ptt_before_the_first_key_down);
+    RUN_TEST(test_play_ptt_lead_is_clamped_to_the_buffer);
+    RUN_TEST(test_play_a_full_fifo_drops_the_byte_and_counts_it);
+    RUN_TEST(test_play_force_release_lifts_the_key_and_drops_the_ptt_at_the_tail);
+    RUN_TEST(test_play_force_release_when_idle_finishes_the_over_at_once);
+    RUN_TEST(test_play_start_over_fixes_the_buffer_and_clears_the_queue);
+    RUN_TEST(test_play_survives_null_and_reports_nothing);
 
     return UNITY_END();
 }

--- a/tools/cwnet/README.md
+++ b/tools/cwnet/README.md
@@ -11,8 +11,10 @@ compilano con clang/gcc. In particolare `pcap_to_stream.py` sostituisce
 
 | File | Cosa fa |
 |---|---|
-| `cwnet_echo.py` | Server CWNet minimo per il loop di determinismo (R7, #14): eco del CONNECT con i permessi, PING come richiedente ogni 2 s, `RPRT 0` alle stringhe 0x06, `TX_INFO` con la chiave presa al primo byte MORSE e rilasciata dopo 1 s, ed eco byte per byte di ogni frame MORSE al mittente. Il server DL4YHF non rimanda mai MORSE (H6). Registra i due versi come il tap. |
+| `cwnet_echo.py` | Server CWNet minimo per il loop di determinismo (R7, #14): eco del CONNECT con i permessi, PING come richiedente ogni 2 s, `RPRT 0` alle stringhe 0x06, `TX_INFO` con la chiave presa al primo byte MORSE e rilasciata dopo 1 s, ed eco byte per byte di ogni frame MORSE al mittente. Il `TX_INFO` annuncia il **nominativo** del CONNECT (`NoCall #n` se vuoto), non lo username: sono due campi distinti del CONNECT (92 byte: 44 username, 44 nominativo, 4 permessi) e solo il secondo e' quello che un vero server CWNet mostra agli altri client. Il server DL4YHF non rimanda mai MORSE (H6). Registra i due versi come il tap. |
 | `cwnet_tap.py` | Relay TCP trasparente: il client CWNet punta al tap, il tap inoltra al server e registra i due versi come byte grezzi. Cattura il loopback quando Wireshark/Npcap non lo intercetta. |
+| `cwnet_send.py` | Client CWNet di prova per il daemon vero, `cwnetd` (host/cwnetd): CONNECT, risposta ai PING, invio dei byte grezzi di una fixture (`--fixture first_over`, ..., `--fixture long` per la misura del jitter) o di un file, stampa di TX_INFO/RPRT/PING in chiaro. E' il "loop senza scatola" di U6/U7 — vedi [host/cwnetd/README.md](../../host/cwnetd/README.md). |
+| `cwnet_jitter.py` | Misura lo scarto (jitter) fra le righe `key`/`ptt` dell'uscita virtuale di `cwnetd` e le attese che portano scritte, e il tempo di scambio dopo la TX (B + coda). Guida `cwnetd` e `cwnet_send.py` da solo; metodo e numeri misurati: [host/cwnetd/README.md](../../host/cwnetd/README.md#misura-del-jitter-e-del-tempo-di-scambio). |
 | `pcap_to_stream.py` | Estrae i flussi TCP da un pcap/pcapng e li scrive come byte grezzi, una direzione per file (solo stdlib, gestisce Ethernet/loopback/SLL/raw). |
 | `cwnet_dump.c` | Decodifica un flusso grezzo: parser di frame **nostro** + codec del keying **di DL4YHF**. Diagnostico, non asserisce. |
 | `diff_main.c` | Confronto esaustivo del nostro `cwnet_timestamp.c` contro `CwStreamEnc.c` di DL4YHF, tutto il dominio di ingresso. |
@@ -65,7 +67,21 @@ python3 cwnet_tap.py --listen 0.0.0.0:7355 --server <ip-server>:7355 --out sess
 # oppure estrai da un pcap:
 python3 pcap_to_stream.py cattura.pcapng --port 7355 --out sess
 ./cwnet_dump sess_1_*.bin
+
+# loop senza scatola: cwnet_send.py fa da client di prova contro il daemon vero
+host/build/cwnetd --listen 127.0.0.1 --port 17355 &
+python3 cwnet_send.py --host 127.0.0.1 --port 17355 --fixture first_over --verbose
+
+# misura del jitter e del tempo di scambio (guida cwnetd e cwnet_send.py da solo)
+python3 cwnet_jitter.py --cwnetd ../../host/build/cwnetd
+python3 cwnet_jitter.py --cwnetd ../../host/build/cwnetd --handover
 ```
+
+Il daemon vero (`cwnetd`) e il suo README — avvio, flag, come si legge una
+riga di stato, e la procedura del banco con la scatola (R18) — sono in
+[host/cwnetd/](../../host/cwnetd/README.md): quel README e' il posto dove
+cercare "come faccio girare il loop con la scatola vera", questo e' dove
+cercare gli strumenti con cui costruire e leggere le catture.
 
 ## Fixture
 

--- a/tools/cwnet/cwnet_echo.py
+++ b/tools/cwnet/cwnet_echo.py
@@ -103,7 +103,7 @@ class Hub:
         if self.holder is None or self.holder not in self.clients:
             return frame(CMD_TX_INFO, b"\xff" + NOBODY)
         c = self.clients[self.holder]
-        return frame(CMD_TX_INFO, bytes([self.holder]) + c.username.encode() + b"\0")
+        return frame(CMD_TX_INFO, bytes([self.holder]) + c.callsign.encode() + b"\0")
 
     async def announce(self):
         f = self.tx_info()
@@ -130,6 +130,7 @@ class Client:
     def __init__(self, hub, index, reader, writer, cfg):
         self.hub, self.index, self.reader, self.writer, self.cfg = hub, index, reader, writer, cfg
         self.username = "?"
+        self.callsign = "?"
         self.parser = FrameParser()
         self.ping_task = None
         self.ping_id = 0
@@ -165,7 +166,9 @@ class Client:
     async def on_frame(self, code, payload):
         if code == CMD_CONNECT and len(payload) == 92:
             self.username = payload[:44].split(b"\0", 1)[0].decode("ascii", "replace")
-            self.log(f"CONNECT user={self.username!r}, permessi 0x{self.cfg.permissions:02X}")
+            call = payload[44:88].split(b"\0", 1)[0].decode("ascii", "replace")
+            self.callsign = call if call else f"NoCall #{self.index}"
+            self.log(f"CONNECT user={self.username!r} call={self.callsign!r}, permessi 0x{self.cfg.permissions:02X}")
             await self.send(frame(CMD_CONNECT, payload[:88] + le32(self.cfg.permissions)), note="CONNECT echo")
             greeting = f"Welcome {self.username}. This is the echo server: what you key comes back.".encode() + b"\0"
             await self.send(frame(CMD_PRINT, greeting), note="PRINT")

--- a/tools/cwnet/cwnet_echo.py
+++ b/tools/cwnet/cwnet_echo.py
@@ -24,7 +24,7 @@ import argparse, asyncio, sys, time
 
 from cwnet_wire import (CMD_CONNECT, CMD_DISCONNECT, CMD_MORSE, CMD_PING,
                         CMD_PRINT, CMD_RIG, CMD_TX_INFO, NAMES, FrameParser,
-                        decode7, encode7, frame, le32)
+                        decode7, frame, le32)
 
 
 def hostport(s):
@@ -37,15 +37,6 @@ def now_ms():
 
 
 NOBODY = b"-- nobody --\0"
-
-
-def hostport(s):
-    h, _, p = s.rpartition(":")
-    return h, int(p)
-
-
-def now_ms():
-    return int(time.monotonic() * 1000) & 0x7FFFFFFF
 
 
 class Hub:

--- a/tools/cwnet/cwnet_echo.py
+++ b/tools/cwnet/cwnet_echo.py
@@ -22,10 +22,9 @@ simulare una latenza.
 """
 import argparse, asyncio, sys, time
 
-CMD_CONNECT, CMD_DISCONNECT, CMD_PING, CMD_PRINT, CMD_TX_INFO, CMD_RIG, CMD_MORSE = 1, 2, 3, 4, 5, 6, 0x10
-NAMES = {1: "CONNECT", 2: "DISCONNECT", 3: "PING", 4: "PRINT", 5: "TX_INFO", 6: "RIG", 0x10: "MORSE",
-         0x14: "CI_V", 0x15: "SPECTRUM", 0x16: "FREQ_REPORT"}
-NOBODY = b"-- nobody --\0"
+from cwnet_wire import (CMD_CONNECT, CMD_DISCONNECT, CMD_MORSE, CMD_PING,
+                        CMD_PRINT, CMD_RIG, CMD_TX_INFO, NAMES, FrameParser,
+                        decode7, encode7, frame, le32)
 
 
 def hostport(s):
@@ -37,56 +36,16 @@ def now_ms():
     return int(time.monotonic() * 1000) & 0x7FFFFFFF
 
 
-def le32(v):
-    return (v & 0xFFFFFFFF).to_bytes(4, "little")
+NOBODY = b"-- nobody --\0"
 
 
-def frame(code, payload=b""):
-    """Un frame CWNet: comando con la categoria nei bit 7-6, lunghezza, payload."""
-    if not payload:
-        return bytes([code & 0x3F])
-    if len(payload) <= 255:
-        return bytes([0x40 | (code & 0x3F), len(payload)]) + payload
-    return bytes([0x80 | (code & 0x3F), len(payload) & 0xFF, len(payload) >> 8]) + payload
+def hostport(s):
+    h, _, p = s.rpartition(":")
+    return h, int(p)
 
 
-def decode7(b):
-    """Attesa in ms dai 7 bit bassi, come CwStreamEnc_7BitTimestampToMilliseconds."""
-    v = b & 0x7F
-    if v <= 0x1F:
-        return v
-    if v <= 0x3F:
-        return 32 + 4 * (v - 0x20)
-    return 157 + 16 * (v - 0x40)
-
-
-class FrameParser:
-    """Parser a flusso: restituisce (comando, payload) man mano che i frame sono completi."""
-
-    def __init__(self):
-        self.buf = bytearray()
-
-    def feed(self, data):
-        self.buf += data
-        out = []
-        while self.buf:
-            cmd = self.buf[0]
-            cat, code = cmd >> 6, cmd & 0x3F
-            if cat == 0:
-                out.append((code, b""))
-                del self.buf[:1]
-                continue
-            if cat == 3:
-                raise ValueError(f"categoria riservata nel comando 0x{cmd:02X}")
-            hdr = 2 if cat == 1 else 3
-            if len(self.buf) < hdr:
-                break
-            n = self.buf[1] if cat == 1 else self.buf[1] | (self.buf[2] << 8)
-            if len(self.buf) < hdr + n:
-                break
-            out.append((code, bytes(self.buf[hdr:hdr + n])))
-            del self.buf[:hdr + n]
-        return out
+def now_ms():
+    return int(time.monotonic() * 1000) & 0x7FFFFFFF
 
 
 class Hub:

--- a/tools/cwnet/cwnet_jitter.py
+++ b/tools/cwnet/cwnet_jitter.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Misura lo scarto fra le righe di 'key' sull'uscita virtuale di cwnetd e le
+attese codificate nel filo (U7, Success Criteria KTD3).
+
+Metodo
+------
+key_output.h scrive ogni fronte come "key <0|1> <ms>", dove <ms> e' l'istante
+*programmato* per quel fronte -- il B piu' la somma cumulata delle attese a
+7 bit decodificate dal MORSE ricevuto (cwnet_play.h). Quel numero e' "le
+attese codificate": non lo ricalcoliamo, lo leggiamo dalla riga.
+
+Quello che questo script aggiunge e' *quando* la riga arriva davvero: legge
+stdout del daemon con una pipe e, a ogni riga, prende un timestamp sul
+proprio orologio monotono (time.monotonic()). Sperimentalmente, su questo
+Mac time.monotonic() di Python e clock_gettime(CLOCK_MONOTONIC) di
+host/platform/clock.c NON condividono l'epoca fra i due processi (scarto
+misurato: circa 1.25e8 ms costante, non zero) -- diversamente da Linux, dove
+CLOCK_MONOTONIC e' la stessa epoca per ogni processo. Lo script quindi si
+calibra da solo: prende lo scarto (lettura - programmato) del primo fronte
+come riferimento e sottrae quel riferimento da tutti gli scarti successivi.
+Quello che resta e' la DERIVA rispetto al primo fronte -- ritardo end-to-end
+fra "cwnetd ha deciso che il fronte doveva succedere a t" e "un lettore
+esterno l'ha visto sull'uscita virtuale", lettura della pipe Python compresa
+-- indipendente da un'eventuale offset costante fra le due epoche.
+
+NON e' una misura con l'oscilloscopio sul tasto vero: quella e' il passo di
+banco con la scatola (R18, host/cwnetd/README.md), che la CI non fa e che
+esegue il maintainer. Questo e' uno scarto misurato su una macchina, non una
+garanzia RT.
+
+Uso
+---
+    python3 cwnet_jitter.py                         # misura di jitter (fixture 'long')
+    python3 cwnet_jitter.py --handover               # tempo di scambio (fixture 'first_over')
+    python3 cwnet_jitter.py --cwnetd ../../host/build/cwnetd --port 17400
+"""
+import argparse
+import os
+import re
+import signal
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CWNETD = os.path.join(HERE, "..", "..", "host", "build", "cwnetd")
+SEND_PY = os.path.join(HERE, "cwnet_send.py")
+
+sys.path.insert(0, HERE)
+import cwnet_send as cs  # noqa: E402 -- serve solo a decodificare la fixture 'long'
+
+
+def long_fixture_events():
+    """(stato, delay_ms) di ogni evento della fixture 'long', dagli stessi byte
+    che cwnet_send.py spedisce -- non un ricalcolo indipendente."""
+    frame_bytes = cs.FIXTURES["long"]
+    hdr = 2  # 0x50, len(<=255): frame CWNet cat1
+    n = frame_bytes[1]
+    payload = frame_bytes[hdr:hdr + n]
+    return [(bool(b & 0x80), cs.decode7(b)) for b in payload]
+
+EDGE_RE = re.compile(r"^(key|ptt) ([01]) (-?\d+)$")
+
+
+class DaemonReader:
+    """Legge stdout del daemon in un thread, con un timestamp di lettura per riga."""
+
+    def __init__(self, proc):
+        self.proc = proc
+        self.lines = []  # (wall_ms, testo_riga)
+        self.lock = threading.Lock()
+        self.ready = threading.Event()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def _run(self):
+        for raw in self.proc.stdout:
+            wall_ms = time.monotonic() * 1000.0
+            line = raw.rstrip("\n")
+            with self.lock:
+                self.lines.append((wall_ms, line))
+            if "stato ascolto" in line:
+                self.ready.set()
+
+    def snapshot(self):
+        with self.lock:
+            return list(self.lines)
+
+
+def start_daemon(cwnetd, host, port, play_floor, ptt_tail, idle_ms=None, timeout=5.0):
+    args = [cwnetd, "--listen", host, "--port", str(port),
+            "--play-floor", str(play_floor), "--ptt-tail", str(ptt_tail),
+            "--output", "virtual"]
+    if idle_ms is not None:
+        args += ["--idle", str(idle_ms)]
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             text=True, bufsize=1)
+    reader = DaemonReader(proc)
+    if not reader.ready.wait(timeout=timeout):
+        stop_daemon(proc, reader)
+        raise RuntimeError("cwnetd non ha detto 'stato ascolto' entro %.1f s" % timeout)
+    return proc, reader
+
+
+def stop_daemon(proc, reader):
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+    reader.thread.join(timeout=2)
+
+
+def run_client(host, port, fixture, hold, call="Moritz"):
+    args = [sys.executable, SEND_PY, "--host", host, "--port", str(port),
+            "--fixture", fixture, "--call", call, "--hold", str(hold), "--delay", "0.2"]
+    subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    timeout=hold + 10)
+
+
+def edges(lines, what):
+    out = []
+    for wall_ms, line in lines:
+        m = EDGE_RE.match(line)
+        if m and m.group(1) == what:
+            out.append((wall_ms, int(m.group(2)), int(m.group(3))))
+    return out
+
+
+def measure_jitter(cwnetd, host, port, play_floor, ptt_tail, verbose):
+    events = long_fixture_events()
+    span_ms = sum(d for _state, d in events[1:])  # dal primo fronte all'ultimo
+
+    # La fixture 'long' manda i suoi ~104 byte in un solo scrivi-e-basta
+    # (nessuna ripaginazione sul filo, cwnet_send.py non ritemporizza): il
+    # daemon non vede altro traffico dal client per tutta la riproduzione, e
+    # --idle (silenzio del titolare) di default e' 5000 ms -- ben sotto lo
+    # sviluppo della fixture. Va alzato per questa misura, altrimenti il
+    # titolare perde la chiave a meta' sequenza (fault "titolare muto").
+    idle_ms = int(span_ms + 5000)
+    hold = (span_ms + play_floor + ptt_tail) / 1000.0 + 3.0
+
+    proc, reader = start_daemon(cwnetd, host, port, play_floor, ptt_tail, idle_ms=idle_ms)
+    try:
+        run_client(host, port, "long", hold)
+        time.sleep(0.3)  # lascia arrivare le ultime righe prima di leggere
+    finally:
+        lines = reader.snapshot()
+        stop_daemon(proc, reader)
+
+    key_edges = edges(lines, "key")
+    if not key_edges:
+        raise RuntimeError("nessuna riga 'key' ricevuta -- vedi output del daemon")
+
+    # Scarto grezzo (lettura Python - programmato dal daemon): le due epoche
+    # monotone non coincidono fra i due processi (vedi docstring del modulo),
+    # quindi si calibra sul primo fronte e si guarda solo la deriva da li'.
+    raw = [wall_ms - m for wall_ms, _state, m in key_edges]
+    baseline = raw[0]
+    diffs = [d - baseline for d in raw]
+    mean_abs = statistics.mean(abs(d) for d in diffs)
+    max_abs = max(abs(d) for d in diffs)
+
+    if verbose:
+        for (wall_ms, state, m), d in zip(key_edges, diffs):
+            print("  key %d  programmato=%d  letto=%.1f  scarto=%.2f ms" %
+                  (state, m, wall_ms, d))
+
+    return {
+        "n": len(key_edges),
+        "expected_n": len(events),
+        "mean_abs_ms": mean_abs,
+        "max_abs_ms": max_abs,
+    }
+
+
+def measure_handover(cwnetd, host, port, play_floor, ptt_tail, verbose):
+    """Tempo di scambio dopo la TX: B + coda, confermato sul loop con
+    ref_first_over (che chiude l'over correttamente, doppio key-up finale)."""
+    proc, reader = start_daemon(cwnetd, host, port, play_floor, ptt_tail)
+    try:
+        hold = (play_floor + ptt_tail) / 1000.0 + 3.0
+        run_client(host, port, "first_over", hold)
+        time.sleep(0.3)
+    finally:
+        lines = reader.snapshot()
+        stop_daemon(proc, reader)
+
+    key_edges = edges(lines, "key")
+    ptt_edges = edges(lines, "ptt")
+    key_ups = [e for e in key_edges if e[1] == 0]
+    ptt_offs = [e for e in ptt_edges if e[1] == 0]
+    if not key_ups or not ptt_offs:
+        raise RuntimeError("over incompleto: %d key-up, %d ptt-off (vedi output del daemon)" %
+                            (len(key_ups), len(ptt_offs)))
+
+    last_key_up_m = key_ups[-1][2]
+    ptt_off_m = ptt_offs[-1][2]
+    station_interval_ms = ptt_off_m - last_key_up_m
+
+    if verbose:
+        for what, lst in (("key", key_edges), ("ptt", ptt_edges)):
+            for wall_ms, state, m in lst:
+                print("  %s %d  programmato=%d  letto=%.1f" % (what, state, m, wall_ms))
+
+    return {
+        "last_key_up_ms": last_key_up_m,
+        "ptt_off_ms": ptt_off_m,
+        "station_interval_ms": station_interval_ms,
+        "formula_ms": play_floor + ptt_tail,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cwnetd", default=DEFAULT_CWNETD, help="path dell'eseguibile cwnetd")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=17390)
+    ap.add_argument("--play-floor", type=int, default=50, help="B, ms (default 50, come cwnetd)")
+    ap.add_argument("--ptt-tail", type=int, default=100, help="coda del PTT, ms (default 100, come cwnetd)")
+    ap.add_argument("--handover", action="store_true",
+                    help="misura il tempo di scambio (B + coda) invece del jitter")
+    ap.add_argument("--verbose", action="store_true", help="stampa ogni fronte")
+    cfg = ap.parse_args()
+
+    cwnetd = os.path.abspath(cfg.cwnetd)
+    if not os.path.isfile(cwnetd):
+        print("errore: cwnetd non trovato in %s -- compilalo con "
+              "'cmake -S host -B host/build && cmake --build host/build'" % cwnetd, file=sys.stderr)
+        return 1
+
+    try:
+        if cfg.handover:
+            r = measure_handover(cwnetd, cfg.host, cfg.port, cfg.play_floor, cfg.ptt_tail, cfg.verbose)
+            print("ultimo key-up (stazione, programmato): %d ms" % r["last_key_up_ms"])
+            print("PTT giu' (stazione, programmato):       %d ms" % r["ptt_off_ms"])
+            print("intervallo stazione ultimo key-up -> PTT giu': %d ms "
+                  "(atteso: coda = %d ms)" % (r["station_interval_ms"], cfg.ptt_tail))
+            print("tempo di scambio dopo la TX (client -> PTT giu' in stazione) = "
+                  "B + coda = %d + %d = %d ms" %
+                  (cfg.play_floor, cfg.ptt_tail, r["formula_ms"]))
+        else:
+            r = measure_jitter(cwnetd, cfg.host, cfg.port, cfg.play_floor, cfg.ptt_tail,
+                               cfg.verbose)
+            print("fronti 'key' ricevuti: %d/%d attesi" % (r["n"], r["expected_n"]))
+            print("scarto medio:   %.3f ms" % r["mean_abs_ms"])
+            print("scarto massimo: %.3f ms" % r["max_abs_ms"])
+    except RuntimeError as e:
+        print("errore: %s" % e, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cwnet/cwnet_send.py
+++ b/tools/cwnet/cwnet_send.py
@@ -25,10 +25,9 @@ import socket
 import sys
 import time
 
-CMD_CONNECT, CMD_DISCONNECT, CMD_PING, CMD_PRINT, CMD_TX_INFO, CMD_RIG, CMD_MORSE = (
-    1, 2, 3, 4, 5, 6, 0x10)
-NAMES = {1: "CONNECT", 2: "DISCONNECT", 3: "PING", 4: "PRINT", 5: "TX_INFO",
-         6: "RIG", 0x10: "MORSE", 0x14: "CI_V", 0x15: "SPECTRUM", 0x16: "FREQ_REPORT"}
+from cwnet_wire import (CMD_CONNECT, CMD_DISCONNECT, CMD_MORSE, CMD_PING,
+                        CMD_PRINT, CMD_RIG, CMD_TX_INFO, NAMES, FrameParser,
+                        decode7, encode7, frame, le32)
 
 CONNECT_FIELD_LEN = 44          # username e nominativo, a lunghezza fissa
 CONNECT_PAYLOAD_LEN = 92        # 44 + 44 + 4 di permessi
@@ -63,43 +62,6 @@ FIXTURES = {
     # underrun invece di lasciare il tasto giu' (AE6).
     "key_down_only": bytes([0x50, 0x01, 0x80]),
 }
-
-
-def le32(v):
-    return (v & 0xFFFFFFFF).to_bytes(4, "little")
-
-
-def frame(code, payload=b""):
-    """Un frame CWNet: comando con la categoria nei bit 7-6, lunghezza, payload."""
-    if not payload:
-        return bytes([code & 0x3F])
-    if len(payload) <= 255:
-        return bytes([0x40 | (code & 0x3F), len(payload)]) + payload
-    return bytes([0x80 | (code & 0x3F), len(payload) & 0xFF, len(payload) >> 8]) + payload
-
-
-def decode7(b):
-    """Attesa in ms dai 7 bit bassi, come CwStreamEnc_7BitTimestampToMilliseconds."""
-    v = b & 0x7F
-    if v <= 0x1F:
-        return v
-    if v <= 0x3F:
-        return 32 + 4 * (v - 0x20)
-    return 157 + 16 * (v - 0x40)
-
-
-def encode7(ms):
-    """Inversa di decode7, stessa divisione intera troncata di
-    cwstream_encode_timestamp() (components/keyer_cwnet/src/cwnet_timestamp.c)."""
-    if ms < 0:
-        return 0
-    if ms <= 31:
-        return ms
-    if ms <= 156:
-        return 0x20 + (ms - 32) // 4
-    if ms <= 1165:
-        return 0x40 + (ms - 157) // 16
-    return 0x7F
 
 
 def build_long_sequence(reps=13, dot_ms=48):
@@ -151,35 +113,6 @@ def safe(b):
         else:
             out.append("\\x%02X" % c)
     return "".join(out)
-
-
-class FrameParser:
-    """Parser a flusso: restituisce (comando, payload) a frame completo."""
-
-    def __init__(self):
-        self.buf = bytearray()
-
-    def feed(self, data):
-        self.buf += data
-        out = []
-        while self.buf:
-            cmd = self.buf[0]
-            cat, code = cmd >> 6, cmd & 0x3F
-            if cat == 0:
-                out.append((code, b""))
-                del self.buf[:1]
-                continue
-            if cat == 3:
-                raise ValueError("categoria riservata nel comando 0x%02X" % cmd)
-            hdr = 2 if cat == 1 else 3
-            if len(self.buf) < hdr:
-                break
-            n = self.buf[1] if cat == 1 else self.buf[1] | (self.buf[2] << 8)
-            if len(self.buf) < hdr + n:
-                break
-            out.append((code, bytes(self.buf[hdr:hdr + n])))
-            del self.buf[:hdr + n]
-        return out
 
 
 class Sender:

--- a/tools/cwnet/cwnet_send.py
+++ b/tools/cwnet/cwnet_send.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Client CWNet di prova: connette, risponde ai PING, manda keying, legge.
+
+Serve il verso opposto a cwnet_echo.py. L'echo e' un server finto per provare
+la scatola; questo e' un client finto per provare il daemon vero, `cwnetd`,
+senza tirare fuori la scatola dal cassetto (U6, "loop senza scatola").
+
+Fa il minimo che un client deve fare perche' il server lo consideri uno che
+puo' trasmettere:
+
+  * CONNECT di 92 byte con username e nominativo, e attesa dell'eco
+  * RESPONSE_1 a ogni PING REQUEST del server, che e' l'iniziatore
+  * invio dei byte grezzi di una fixture della cattura del 2026-09-05, o di
+    un file, cosi' come sono: sono gia' frame CWNet completi
+  * stampa di quello che torna, con TX_INFO e RPRT in chiaro
+
+I byte non vengono ritemporizzati: il server li riproduce con le attese che
+portano dentro, ed e' proprio quella riproduzione che si sta guardando.
+
+  python3 cwnet_send.py --fixture first_over
+  python3 cwnet_send.py --host 192.168.1.10 --call IU3QEZ --file over.bin
+"""
+import argparse
+import socket
+import sys
+import time
+
+CMD_CONNECT, CMD_DISCONNECT, CMD_PING, CMD_PRINT, CMD_TX_INFO, CMD_RIG, CMD_MORSE = (
+    1, 2, 3, 4, 5, 6, 0x10)
+NAMES = {1: "CONNECT", 2: "DISCONNECT", 3: "PING", 4: "PRINT", 5: "TX_INFO",
+         6: "RIG", 0x10: "MORSE", 0x14: "CI_V", 0x15: "SPECTRUM", 0x16: "FREQ_REPORT"}
+
+CONNECT_FIELD_LEN = 44          # username e nominativo, a lunghezza fissa
+CONNECT_PAYLOAD_LEN = 92        # 44 + 44 + 4 di permessi
+
+# Byte di client_to_server della cattura del 2026-09-05, gli stessi di
+# test_host/cwnet_fixtures.h. Frame interi, non payload: si spediscono cosi'.
+FIXTURES = {
+    # ref_first_over: sessione 12, la lettera A a 25 WPM (dot 48 ms), con le
+    # due stringhe set_ptt che il riferimento intercala all'over.
+    "first_over": bytes([
+        0x50, 0x01, 0x80,
+        0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74, 0x20, 0x31, 0x0A, 0x00,
+        0x50, 0x01, 0x24,
+        0x50, 0x01, 0xA4,
+        0x50, 0x01, 0x3C,
+        0x46, 0x0B, 0x73, 0x65, 0x74, 0x5F, 0x70, 0x74, 0x74, 0x20, 0x30, 0x0A, 0x00,
+        0x50, 0x01, 0x60,
+    ]),
+    # ref_two_event_frames: due frame da due eventi ciascuno, dot circa 20 ms.
+    "two_event": bytes([
+        0x50, 0x02, 0x96, 0x12,
+        0x50, 0x02, 0x96, 0x12,
+    ]),
+    # synth_morse_frame: 'S' 'O' 'S' generato con l'encoder DL4YHF da
+    # tools/cwnet/gen_synth.c, con il key-up di fine over in coda.
+    "synth": bytes([
+        0x50, 0x11,
+        0x80, 0x41, 0xA7, 0x27, 0xC1, 0x27, 0xA7, 0x41, 0xC1, 0x27, 0xC1, 0x27,
+        0xA7, 0x27, 0xC1, 0x55, 0x00,
+    ]),
+    # Solo il primo key-down: la FIFO resta a secco e il server deve andare in
+    # underrun invece di lasciare il tasto giu' (AE6).
+    "key_down_only": bytes([0x50, 0x01, 0x80]),
+}
+
+
+def le32(v):
+    return (v & 0xFFFFFFFF).to_bytes(4, "little")
+
+
+def frame(code, payload=b""):
+    """Un frame CWNet: comando con la categoria nei bit 7-6, lunghezza, payload."""
+    if not payload:
+        return bytes([code & 0x3F])
+    if len(payload) <= 255:
+        return bytes([0x40 | (code & 0x3F), len(payload)]) + payload
+    return bytes([0x80 | (code & 0x3F), len(payload) & 0xFF, len(payload) >> 8]) + payload
+
+
+def decode7(b):
+    """Attesa in ms dai 7 bit bassi, come CwStreamEnc_7BitTimestampToMilliseconds."""
+    v = b & 0x7F
+    if v <= 0x1F:
+        return v
+    if v <= 0x3F:
+        return 32 + 4 * (v - 0x20)
+    return 157 + 16 * (v - 0x40)
+
+
+def now_ms():
+    """Millisecondi monotoni sui 31 bit del filo."""
+    return int(time.monotonic() * 1000) & 0x7FFFFFFF
+
+
+def field(text):
+    b = text.encode("ascii", "replace")[:CONNECT_FIELD_LEN - 1]
+    return b + b"\0" * (CONNECT_FIELD_LEN - len(b))
+
+
+def connect_payload(user, call, permissions):
+    return field(user) + field(call) + le32(permissions)
+
+
+def safe(b):
+    """Come il daemon: quello che arriva dal peer non finisce grezzo a schermo."""
+    out = []
+    for c in b:
+        if c == 0x5C:
+            out.append("\\\\")
+        elif 0x20 <= c < 0x7F:
+            out.append(chr(c))
+        else:
+            out.append("\\x%02X" % c)
+    return "".join(out)
+
+
+class FrameParser:
+    """Parser a flusso: restituisce (comando, payload) a frame completo."""
+
+    def __init__(self):
+        self.buf = bytearray()
+
+    def feed(self, data):
+        self.buf += data
+        out = []
+        while self.buf:
+            cmd = self.buf[0]
+            cat, code = cmd >> 6, cmd & 0x3F
+            if cat == 0:
+                out.append((code, b""))
+                del self.buf[:1]
+                continue
+            if cat == 3:
+                raise ValueError("categoria riservata nel comando 0x%02X" % cmd)
+            hdr = 2 if cat == 1 else 3
+            if len(self.buf) < hdr:
+                break
+            n = self.buf[1] if cat == 1 else self.buf[1] | (self.buf[2] << 8)
+            if len(self.buf) < hdr + n:
+                break
+            out.append((code, bytes(self.buf[hdr:hdr + n])))
+            del self.buf[:hdr + n]
+        return out
+
+
+class Sender:
+    def __init__(self, cfg, payload):
+        self.cfg = cfg
+        self.payload = payload
+        self.parser = FrameParser()
+        self.sock = None
+        self.ready = False
+        self.sent = False
+        self.t_ready = None
+        self.t_sent = None
+
+    def log(self, msg):
+        print("[%.3f] %s" % (time.monotonic(), msg), flush=True)
+
+    def run(self):
+        self.sock = socket.create_connection((self.cfg.host, self.cfg.port), timeout=5)
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.log("connesso a %s:%d" % (self.cfg.host, self.cfg.port))
+
+        payload = connect_payload(self.cfg.user, self.cfg.call, self.cfg.permissions)
+        self.sock.sendall(frame(CMD_CONNECT, payload))
+        self.log("-> CONNECT user=%r call=%r" % (self.cfg.user, self.cfg.call))
+
+        deadline = time.monotonic() + self.cfg.hold
+        self.sock.settimeout(0.1)
+        while time.monotonic() < deadline:
+            if self.ready and not self.sent and time.monotonic() >= self.t_ready + self.cfg.delay:
+                self.send_payload()
+            try:
+                data = self.sock.recv(4096)
+            except socket.timeout:
+                continue
+            if not data:
+                self.log("il server ha chiuso")
+                return 0
+            for code, pl in self.parser.feed(data):
+                self.on_frame(code, pl)
+        self.log("fine dell'attesa (--hold %g s)" % self.cfg.hold)
+        try:
+            self.sock.sendall(frame(CMD_DISCONNECT))
+        except OSError:
+            pass
+        return 0
+
+    def send_payload(self):
+        self.sent = True
+        self.t_sent = time.monotonic()
+        if self.cfg.verbose:
+            for code, pl in FrameParser().feed(self.payload):
+                if code == CMD_MORSE:
+                    ev = " ".join("%s%d" % ("D" if b & 0x80 else "u", decode7(b)) for b in pl)
+                    self.log("-> MORSE %d byte: %s" % (len(pl), ev))
+                else:
+                    self.log("-> 0x%02X %s %d byte" % (code, NAMES.get(code, "?"), len(pl)))
+        self.sock.sendall(self.payload)
+        self.log("-> %d byte di keying inviati" % len(self.payload))
+
+    def on_frame(self, code, payload):
+        if code == CMD_CONNECT:
+            perm = int.from_bytes(payload[88:92], "little") if len(payload) >= 92 else 0
+            self.log("<- CONNECT echo, permessi 0x%02X%s" %
+                     (perm, "" if perm & 0x02 else "  (senza TRANSMIT!)"))
+            if not self.ready:
+                self.ready = True
+                self.t_ready = time.monotonic()
+        elif code == CMD_PING and len(payload) >= 16:
+            kind, pid = payload[0], payload[1]
+            if kind == 0:
+                # RESPONSE_1: id e t0 come sono arrivati, t1 dal nostro orologio
+                resp = bytes([1, pid, 0, 0]) + payload[4:8] + le32(now_ms()) + bytes(4)
+                self.sock.sendall(frame(CMD_PING, resp))
+                if self.cfg.verbose:
+                    self.log("<- PING request id=%d, -> response 1" % pid)
+            elif kind == 2:
+                t0 = int.from_bytes(payload[4:8], "little")
+                t2 = int.from_bytes(payload[12:16], "little")
+                self.log("<- PING response 2 id=%d: il server misura %d ms" % (pid, t2 - t0))
+        elif code == CMD_TX_INFO and payload:
+            idx = payload[0]
+            name = safe(payload[1:].split(b"\0", 1)[0])
+            who = "nessuno" if idx == 0xFF else "client %d" % idx
+            self.log("<- TX_INFO: %s (%s)" % (who, name))
+        elif code == CMD_RIG:
+            self.log("<- RIG %r" % safe(payload.split(b"\0", 1)[0]))
+        elif code == CMD_PRINT:
+            self.log("<- PRINT %r" % safe(payload.split(b"\0", 1)[0]))
+        else:
+            self.log("<- 0x%02X %s %d byte" % (code, NAMES.get(code, "?"), len(payload)))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=7355)
+    ap.add_argument("--user", default="Moritz", help="username nel CONNECT")
+    ap.add_argument("--call", default="Moritz", help="nominativo nel CONNECT; vuoto -> NoCall #n")
+    ap.add_argument("--permissions", type=lambda s: int(s, 0), default=0,
+                    help="permessi richiesti nel CONNECT; il server li riscrive comunque a 7")
+    ap.add_argument("--fixture", choices=sorted(FIXTURES), default="first_over",
+                    help="byte di keying da mandare (default first_over)")
+    ap.add_argument("--file", default=None,
+                    help="frame CWNet grezzi da un file, al posto della fixture")
+    ap.add_argument("--delay", type=float, default=0.2,
+                    help="secondi fra l'eco del CONNECT e l'invio (default 0.2)")
+    ap.add_argument("--hold", type=float, default=3.0,
+                    help="secondi di permanenza prima di chiudere (default 3)")
+    ap.add_argument("--verbose", action="store_true", help="mostra PING e decodifica il keying")
+    cfg = ap.parse_args()
+
+    if cfg.file:
+        with open(cfg.file, "rb") as fh:
+            payload = fh.read()
+    else:
+        payload = FIXTURES[cfg.fixture]
+
+    try:
+        return Sender(cfg, payload).run()
+    except KeyboardInterrupt:
+        print("\nfine.")
+        return 0
+    except OSError as e:
+        print("errore: %s" % e, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cwnet/cwnet_send.py
+++ b/tools/cwnet/cwnet_send.py
@@ -88,6 +88,44 @@ def decode7(b):
     return 157 + 16 * (v - 0x40)
 
 
+def encode7(ms):
+    """Inversa di decode7, stessa divisione intera troncata di
+    cwstream_encode_timestamp() (components/keyer_cwnet/src/cwnet_timestamp.c)."""
+    if ms < 0:
+        return 0
+    if ms <= 31:
+        return ms
+    if ms <= 156:
+        return 0x20 + (ms - 32) // 4
+    if ms <= 1165:
+        return 0x40 + (ms - 157) // 16
+    return 0x7F
+
+
+def build_long_sequence(reps=13, dot_ms=48):
+    """~100 elementi (reps*8) per la misura del jitter (U7): la lettera 'V'
+    (...-) ripetuta, dot/spazio-intra a dot_ms, tratto/spazio-lettera a
+    3*dot_ms. Ogni evento alterna stato rispetto al precedente -- nessuna
+    coppia di key-up consecutivi, cosi' ogni byte mandato produce esattamente
+    un fronte sull'uscita virtuale e il conteggio si verifica a vista.
+
+    Ritorna il frame CWNet completo (comando + lunghezza + payload)."""
+    unit = [dot_ms, dot_ms, dot_ms, dot_ms, dot_ms, dot_ms, 3 * dot_ms, 3 * dot_ms]
+    durations = unit * reps
+    down = True
+    payload = bytearray([0x80])  # primo evento: key down, delay 0
+    for d in durations[:-1]:
+        down = not down
+        payload.append((0x80 if down else 0x00) | encode7(d))
+    return frame(CMD_MORSE, bytes(payload))
+
+
+# "long": 104 elementi, per cwnet_jitter.py (U7, Success Criteria KTD3). Non
+# nel dict letterale sopra perche' si costruisce con encode7()/frame(), non
+# ancora definite li'.
+FIXTURES["long"] = build_long_sequence()
+
+
 def now_ms():
     """Millisecondi monotoni sui 31 bit del filo."""
     return int(time.monotonic() * 1000) & 0x7FFFFFFF
@@ -244,7 +282,8 @@ def main():
     ap.add_argument("--permissions", type=lambda s: int(s, 0), default=0,
                     help="permessi richiesti nel CONNECT; il server li riscrive comunque a 7")
     ap.add_argument("--fixture", choices=sorted(FIXTURES), default="first_over",
-                    help="byte di keying da mandare (default first_over)")
+                    help="byte di keying da mandare (default first_over); "
+                         "'long' e' i 104 elementi sintetici di cwnet_jitter.py")
     ap.add_argument("--file", default=None,
                     help="frame CWNet grezzi da un file, al posto della fixture")
     ap.add_argument("--delay", type=float, default=0.2,

--- a/tools/cwnet/cwnet_wire.py
+++ b/tools/cwnet/cwnet_wire.py
@@ -1,0 +1,86 @@
+"""
+Il formato del filo CWNet, in un posto solo.
+
+Gli strumenti di questa directory parlano tutti lo stesso protocollo: l'eco
+(`cwnet_echo.py`) da un capo, il client di prova (`cwnet_send.py`) dall'altro,
+la misura (`cwnet_jitter.py`) sopra il secondo. Composizione dei frame,
+lunghezze little-endian e codec delle attese a 7 bit stanno qui perche' due
+copie della stessa idea del filo divergono, e quando divergono lo strumento
+mente sul protocollo invece di provarlo.
+
+La verita' resta `components/keyer_cwnet/` e la cattura del 2026-09-05: questo
+modulo la rispecchia, non la decide.
+"""
+
+# Codici comando, bit 5-0 del byte di comando (CwNet.h)
+CMD_CONNECT, CMD_DISCONNECT, CMD_PING, CMD_PRINT, CMD_TX_INFO, CMD_RIG, CMD_MORSE = (
+    1, 2, 3, 4, 5, 6, 0x10)
+
+NAMES = {1: "CONNECT", 2: "DISCONNECT", 3: "PING", 4: "PRINT", 5: "TX_INFO",
+         6: "RIG", 0x10: "MORSE", 0x14: "CI_V", 0x15: "SPECTRUM", 0x16: "FREQ_REPORT"}
+
+
+def le32(v):
+    return (v & 0xFFFFFFFF).to_bytes(4, "little")
+
+
+def frame(code, payload=b""):
+    """Un frame CWNet: comando con la categoria nei bit 7-6, lunghezza, payload."""
+    if not payload:
+        return bytes([code & 0x3F])
+    if len(payload) <= 255:
+        return bytes([0x40 | (code & 0x3F), len(payload)]) + payload
+    return bytes([0x80 | (code & 0x3F), len(payload) & 0xFF, len(payload) >> 8]) + payload
+
+
+def decode7(b):
+    """Attesa in ms dai 7 bit bassi, come CwStreamEnc_7BitTimestampToMilliseconds."""
+    v = b & 0x7F
+    if v <= 0x1F:
+        return v
+    if v <= 0x3F:
+        return 32 + 4 * (v - 0x20)
+    return 157 + 16 * (v - 0x40)
+
+
+def encode7(ms):
+    """Inversa di decode7, stessa divisione intera troncata di
+    cwstream_encode_timestamp() (components/keyer_cwnet/src/cwnet_timestamp.c)."""
+    if ms < 0:
+        return 0
+    if ms <= 31:
+        return ms
+    if ms <= 156:
+        return 0x20 + (ms - 32) // 4
+    if ms <= 1165:
+        return 0x40 + (ms - 157) // 16
+    return 0x7F
+
+
+class FrameParser:
+    """Parser a flusso: restituisce (comando, payload) a frame completo."""
+
+    def __init__(self):
+        self.buf = bytearray()
+
+    def feed(self, data):
+        self.buf += data
+        out = []
+        while self.buf:
+            cmd = self.buf[0]
+            cat, code = cmd >> 6, cmd & 0x3F
+            if cat == 0:
+                out.append((code, b""))
+                del self.buf[:1]
+                continue
+            if cat == 3:
+                raise ValueError("categoria riservata nel comando 0x%02X" % cmd)
+            hdr = 2 if cat == 1 else 3
+            if len(self.buf) < hdr:
+                break
+            n = self.buf[1] if cat == 1 else self.buf[1] | (self.buf[2] << 8)
+            if len(self.buf) < hdr + n:
+                break
+            out.append((code, bytes(self.buf[hdr:hdr + n])))
+            del self.buf[:hdr + n]
+        return out


### PR DESCRIPTION
## What changes

The station end of the CW link exists. A remote operator's keying now comes
out of a rig at the station with the timing he gave it: `cwnetd` listens on
the CWNet port, hands one client at a time the key, replays that client's
MORSE bytes as key edges after a buffer sized on the measured link, and
drives PTT from the keying it played rather than from the `set_ptt` strings
the client sends. Until now the station end was `cwnet_echo.py`, which keys
nothing.

The decisions worth a reviewer's attention, all taken against the reference
program read in its source and rejected where it is wrong for us:

- **PTT follows the replayed keying, not the arriving bytes.** The reference
  applies `set_ptt` on arrival, which drifts from what is actually being
  played and leaves the station transmitting when a client dies. Ours is
  acknowledged (`RPRT 0`) and dropped.
- **The key is held for the whole over.** The reference's one-second
  stopwatch makes the announcement oscillate mid-over; it is not copied.
- **A split wait is told from an end of over by the encoder's own
  convention** (`CwStreamEnc.c:135-146`), not by the raw key bit. The
  reference's receiver applies that byte immediately and keys up to 830 ms
  early. That is corrupted timing, and the reference decides the wire, not
  the product. The cost of our reading is written in `cwnet_play.h`: a wait
  of exactly the maximum encodable value plays as silence.
- **The server core and the playback engine are pure state machines**, host
  only, absent from the ESP-IDF component's SRCS. They own no socket, no
  clock and no log: time is a parameter and events come back in a result
  struct. That is the only shape in which the host suite can make them talk
  to the 2026-09-05 capture, which is what pins them.

Two changes reach already-flashed firmware. The frame parser no longer
returns a payload pointer past its own buffer when an oversized frame
arrives fragmented — ASan called that a stack-buffer-overflow — and it stays
in sync instead of erroring, because the client resynchronises after an
error by dropping one byte and would read the payload as frames. And the
ping latency gate now discards samples outside 0..2000 ms, not only negative
ones, which is what the 31-bit clock wrap produces.

A nine-reviewer pass found two ways the station could be left transmitting;
both are fixed and pinned in `ce993cd`. A key held longer than one byte can
carry ended the over with the key still down, and a full event buffer let
the daemon's key output drift out of step with the engine. The second is why
the daemon now reconciles its output against the core's own state instead of
trusting the event stream.

## Closes

[#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64) — **partly, so
the issue stays open.** Its condition has two halves. The host half is true in
the tree: the daemon accepts the box's client, plays received MORSE with a
buffer sized on measured peak latency, drives PTT with the client's tail, and
arbitrates the key, on `keyer_cwnet`'s codec compiled for host rather than a
copy (`host/CMakeLists.txt:43-50`). The suite runs the core against the DL4YHF
client capture and pins the bytes it sends: `test_cwnet_server.c:266`
(`ref_connect_echo`), `:454` (the PING layout), `test_cwnet_play.c:174`
(`ref_first_over`). The bench half — an over completed with the box in the
loop — needs the hardware and is the maintainer's; the procedure is in
`host/cwnetd/README.md` and its result goes on the issue.

Related: [#76](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/76)

## Definition of done

- Host tests: 303/303 plain, 303/303 ASan/UBSan. Was 218 before this branch.
  `host/` has its own: `ctest` 1/1, plain and sanitized, on macOS.
- Reference test: `test_cwnet_server.c::test_server_connect_echo_matches_the_capture`
  pins `ref_connect_echo`, the welcome PRINT and `ref_tx_info_nobody` against
  the 2026-09-05 capture; `test_server_announces_the_holder_to_every_client`
  pins `ref_tx_info_moritz`; `test_server_ping_request_and_response2_carry_the_reference_layout`
  pins the PING layout byte for byte; `test_cwnet_play.c::test_play_first_over_of_the_capture_plays_at_the_encoded_instants`
  pins `ref_first_over`'s edges at +50, +98, +146 and +290 with the PTT tail at
  +390, derived by hand from the encoded waits. AE2 was also reproduced live
  against the running daemon, not only in the suite.
- RT path: untouched. Nothing on Core 0 changed. `cwnet_frame.c` and
  `cwnet_ping.c` run on the box on Core 1 and both changed; the client's
  reference-pinned tests pass unaltered
  (`test_client_tx_first_over_with_ptt_matches_reference_capture_whole`), and
  the latency gate is now pinned at the client level too
  (`test_client_ping_peak_hold_gate_rejects_out_of_range_rtt`), as KTD2 asked.
- Blocking issues open on this work: none. #65 is `blocking` for the daemon's
  GUI only, which this PR does not contain.

## Not done here

- **No GUI.** [#65](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/65)
  is `blocking` and undecided. State goes to stdout as lines, so the served-page
  option stays open.
- **No physical key and PTT output.** One backend, `virtual`, printing each
  edge with its scheduled instant. A serial or GPIO backend fills the same two
  function pointers, and needs its own Decision first: the rest state of the
  transport when the daemon dies, and a key-down ceiling living outside the
  daemon's process.
- **The jitter is measured on macOS only** — mean 0.4 to 1.5 ms, worst 3.4 ms
  over 104 edges, on an M1 Max. Linux is unmeasured and tracked in
  [#76](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/76). CI builds and
  tests `host/` on Ubuntu, which is not the same as measuring it.
- **The parser defect (R14) has no tracker issue.** The plan's Definition of
  done asked for one, closed by this work; the maintainer ruled that filing and
  closing it in the same session is QRM. The fix is
  `components/keyer_cwnet/src/cwnet_frame.c:198-244`, pinned by
  `test_parse_fragmented_oversized_long_frame_is_skipped_not_error`.
- **One decision is open and deliberately not taken here.** The idle safety net
  measures silence on the wire, not silence in playback: a client that sends a
  burst covering more than the idle timeout has the key taken away mid
  transmission. The box never does this, because it sends as the operator keys;
  a client that queues — a memory keyer, a text-to-CW playback, the host client
  of #68 — would. Narrowing the net to fire only when nothing is left to play is
  one line and a test, but it changes what R6 means, and that is station policy.

## Post-Deploy Monitoring & Validation

The daemon runs in the foreground on the station PC and reports on stdout;
there is no service to watch and nothing is deployed by merging.

- **What to watch, on the daemon's own output:** `stato chiave <n> <call>` and
  `stato chiave libera` bracket every over; `stato over client N ... B <n> ms`
  says which buffer was chosen; `key`/`ptt` lines carry the instant each edge
  was scheduled for.
- **Healthy:** every `key 1` has its `key 0`, and `ptt 0` follows the last
  `key 0` by the configured tail (100 ms by default).
- **Failure signals:** `stato fault ...` (underrun, holder gone, idle, over
  ceiling), `stato eventi persi N` (the core dropped events; the output is
  reconciled but the diagnostics are incomplete), `stato stdout N righe scartate`
  (nobody is draining stdout).
- **Rollback:** stop the daemon. Nothing persists, no schema, no state on disk.
  The box is unaffected until it is reflashed; the two firmware-side changes
  ride with the next flash, not with this merge.
- **Window and owner:** the maintainer, during the bench step on #64.
