### PR TITLE
docs: measure the station daemon on Linux

### DIFF
--- a/host/cwnetd/README.md
+++ b/host/cwnetd/README.md
@@ -349,7 +349,31 @@ LAN, o una VPN su fibra — lo riporta dov'era con `--play-floor 50`, e riavrà
 pavimento non è il ritardo: se il peak-hold del titolare è più alto, B è
 quello, e il tempo di scambio sale di conseguenza.
 
-**Linux — mancante.** Questo worktree ha solo un Mac: nessun numero Linux
-in questa tabella, e nessuno stimato al suo posto. Chi ha un'immagine Linux
-a disposizione esegue `tools/cwnet/cwnet_jitter.py` li' e completa la
-tabella; nel frattempo la lacuna resta scritta qui, non nascosta.
+**Linux, x86-64 su metallo** — `sf-B450M-DS3H-V2` (AMD Ryzen 7 5700G),
+Linux 7.0.0-31-generic x86_64, 2026-09-12, gli stessi default. E' la
+macchina di stazione, avviata da un disco Ubuntu:
+
+| Misura | Valore |
+|---|---|
+| Scarto medio (jitter), 3 run da 104 fronti | fra 0.25 e 0.47 ms |
+| Scarto massimo, stesse 3 run | fra 0.62 e 1.07 ms |
+| Fronti ricevuti | 104/104 in ogni run |
+| Intervallo stazione: ultimo key-up -> PTT giu' (`--handover`) | 100 ms (= `--ptt-tail`) |
+| Tempo di scambio dopo la TX | B + coda = 100 + 100 = **200 ms** |
+
+**Misurati a macchina scarica**, senza altro carico in esecuzione. Nessuno
+ha misurato cosa succede sotto carico, e quello e' il caso che conta per una
+stazione che fa anche altro: chi ci mette sopra un browser, una cattura o un
+backup rifaccia la misura invece di fidarsi di questa riga.
+
+Con quella riserva: piu' fedele del Mac, e non di poco, perche' il massimo
+peggiore qui sta sotto il migliore di la'. Due macchine sole non fanno una
+legge, e nessuna delle due e' una misura all'oscilloscopio sul tasto vero —
+quella resta il passo di banco con la scatola.
+
+Una nota sul metodo, perche' cambia fra i due sistemi: lo script si calibra
+sul primo fronte e misura la deriva da li'. Su macOS **deve** farlo, perche'
+`time.monotonic()` di Python e `CLOCK_MONOTONIC` del daemon non condividono
+l'epoca; su Linux la condividono, quindi li' la calibrazione non serve e non
+nasconde niente. I numeri delle due tabelle restano confrontabili perche'
+misurano la stessa cosa, la deriva fronte per fronte.


### PR DESCRIPTION
## What changes

The daemon's README had a row of numbers for one machine and a paragraph
saying the other platform was unmeasured. It now has both. A Ryzen 7 5700G
booted from an Ubuntu disk — the station PC — keys 104 edges out of 104 with
a mean deviation of 0.25 to 0.47 ms and a worst case of 0.62 to 1.07, over
three runs. Turnaround after transmission is the same 200 ms.

Every Linux number is better than its Mac counterpart, the worst case here
landing under the Mac's best. That is the direction one would expect and not
much more: two machines are not a law, and neither is a scope on the real
key, which is still the bench step.

Two things are written down rather than left to the reader. The machine was
idle, and what happens under load is unmeasured — the case that matters for
a station PC that also does something else. And the measurement script
calibrates on the first edge because macOS requires it, Python's monotonic
clock and the daemon's not sharing an epoch there; on Linux they do, so the
calibration is unnecessary and conceals nothing. Both tables measure drift
edge by edge, so they compare.

## Closes

Fixes [#76](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/76). Its
condition asked for a second row of measured numbers from a real Linux
station PC named in the text, with mean and worst deviation, the edges
received, and the handover interval. All four are in
`host/cwnetd/README.md`, under "Numeri misurati", with the machine and
kernel named as the Mac's are.

## Definition of done

- Host tests: n/a, documentation only. No code changed.
- Reference test: n/a.
- RT path: untouched.
- Blocking issues open on this work: none.

## Not done here

- **Under load.** Stated as a gap in the text, not measured.
- **The bench step with the box** is the other half of
  [#64](https://github.com/iu3qez/RemoteCWKeyer-esp32/issues/64). The daemon
  now runs on that same Linux machine, which is where that step wants to
  happen, but it needs the box keying into it.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: two tables in a README.
